### PR TITLE
Set up repo scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.DS_Store
+Thumbs.db
+*.log
+.env
+.env.*
+.vscode/
+.idea/
+scratch/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Enes Yilmaz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
 # Finder
-Find who teaches your classes before everyone else
+
+Find who teaches your classes before everyone else.
+
+Ohio State's own class search will tell you a course exists. It is far less
+helpful when the question you actually have is "which of these six sections
+should I take, and who is teaching them." Finder answers that one instead:
+search a course, and get its sections grouped by **instructor**, with live seat
+status and RateMyProfessors ratings next to each name.
+
+## Why this exists
+
+[osucoursesearch.org](https://osucoursesearch.org) did roughly this job and went
+down. Its database container stopped resolving and its author moved on, so the
+site now serves a Django stack trace instead of course data.
+
+Finder is a fresh build with a different failure model. There is no server and no
+database, so there is no equivalent thing to go down.
+
+## How it works
+
+```
+Browser  ->  content.osu.edu/v2   live sections, instructors, seats
+Browser  ->  data/ratings.json    nightly RateMyProfessors snapshot
+GitHub Pages                      serves the page and the snapshot
+```
+
+Course data is read straight from OSU's public class API at request time, so it is
+never stale. That API sends `Access-Control-Allow-Origin: *`, which is what makes a
+serverless build possible.
+
+Ratings are the one thing a browser cannot fetch directly, because
+RateMyProfessors sends no CORS headers. Rather than stand up a proxy for it, a
+scheduled GitHub Action snapshots the Ohio State roster into `data/ratings.json`
+and commits it. Ratings move slowly enough that a nightly snapshot costs nothing.
+
+See [docs/osu-api.md](docs/osu-api.md) for the API details.
+
+## Running it locally
+
+No build step and no dependencies. Serve the folder over HTTP:
+
+```bash
+python -m http.server 8000
+```
+
+Then open <http://localhost:8000>. Opening `index.html` directly off the
+filesystem will not work, because `file://` pages cannot make cross-origin
+requests.
+
+To refresh ratings yourself:
+
+```bash
+node scripts/fetch-ratings.mjs
+```
+
+## Data sources
+
+| Data | Source | Freshness |
+|---|---|---|
+| Courses, sections, instructors, seats | `content.osu.edu/v2` | live |
+| Professor ratings | RateMyProfessors | nightly snapshot |
+
+Finder is not affiliated with or endorsed by The Ohio State University.
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Finder</title>
+  <meta name="description" content="Find who teaches your Ohio State classes.">
+</head>
+<body>
+  <main>
+    <h1>Finder</h1>
+    <p>Find who teaches your classes before everyone else.</p>
+    <p>The search interface is not built yet. Follow along in
+       <a href="https://github.com/EnesYilmazcode/Finder/milestone/1">milestone v1</a>.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Closes #1

Lays down the project structure so every later PR has an obvious home.

## What's here
- `.gitignore` covering Node, editor dirs, and local scratch
- MIT `LICENSE`
- `README.md` explaining what Finder does, why it exists, the serverless architecture, and how to run it locally
- Placeholder `index.html` so the repo loads in a browser before the real UI lands

## Notes for review
- The README links to `docs/osu-api.md`, which does not exist until #2 merges. Deliberate, since #2 is the next PR, but worth flagging.
- `scripts/` and `data/` are not in this PR. Git does not track empty directories and inventing placeholder files to force them in would be noise. They arrive with #6.

## Verification
Served the folder with `python -m http.server` and confirmed the page loads and renders.
