### PR TITLE
Add API client and term selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,14 @@
   <main>
     <h1>Finder</h1>
     <p>Find who teaches your classes before everyone else.</p>
-    <p>The search interface is not built yet. Follow along in
-       <a href="https://github.com/EnesYilmazcode/Finder/milestone/1">milestone v1</a>.</p>
+
+    <label for="term">Term</label>
+    <select id="term" disabled></select>
+
+    <p id="status" role="status" hidden></p>
+
+    <p>Search lands in <a href="https://github.com/EnesYilmazcode/Finder/issues/4">#4</a>.</p>
   </main>
+  <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/js/api.js
+++ b/js/api.js
@@ -2,6 +2,7 @@
 
 const BASE = "https://content.osu.edu/v2";
 const CAMPUS = "col";
+const TIMEOUT_MS = 12000;
 
 export class ApiError extends Error {
   constructor(message, { status = null, cause = null } = {}) {
@@ -15,14 +16,27 @@ export class ApiError extends Error {
 async function getJson(path, params) {
   const url = new URL(BASE + path);
   for (const [k, v] of Object.entries(params ?? {})) {
-    if (v !== undefined && v !== null && v !== "") url.searchParams.set(k, v);
+    // Empty strings are kept. Omitting q entirely makes the upstream API 500,
+    // because it dereferences the parameter without checking it exists.
+    if (v !== undefined && v !== null) url.searchParams.set(k, v);
   }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   let response;
   try {
-    response = await fetch(url, { headers: { Accept: "application/json" } });
+    response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
   } catch (cause) {
+    if (cause?.name === "AbortError") {
+      throw new ApiError("Ohio State's course service is taking too long to answer. Try again.", { cause });
+    }
     throw new ApiError("Could not reach Ohio State's course service. Check your connection and try again.", { cause });
+  } finally {
+    clearTimeout(timer);
   }
 
   if (!response.ok) {

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,101 @@
+// Client for OSU's public class API. See docs/osu-api.md.
+
+const BASE = "https://content.osu.edu/v2";
+const CAMPUS = "col";
+
+export class ApiError extends Error {
+  constructor(message, { status = null, cause = null } = {}) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.cause = cause;
+  }
+}
+
+async function getJson(path, params) {
+  const url = new URL(BASE + path);
+  for (const [k, v] of Object.entries(params ?? {})) {
+    if (v !== undefined && v !== null && v !== "") url.searchParams.set(k, v);
+  }
+
+  let response;
+  try {
+    response = await fetch(url, { headers: { Accept: "application/json" } });
+  } catch (cause) {
+    throw new ApiError("Could not reach Ohio State's course service. Check your connection and try again.", { cause });
+  }
+
+  if (!response.ok) {
+    throw new ApiError(
+      `Ohio State's course service returned an error (${response.status}). Try again in a moment.`,
+      { status: response.status }
+    );
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (cause) {
+    throw new ApiError("Ohio State's course service sent a response we could not read.", { cause });
+  }
+
+  if (!body || typeof body !== "object" || !("data" in body)) {
+    throw new ApiError("Ohio State's course service sent an unexpected response.");
+  }
+  return body.data;
+}
+
+/**
+ * Terms currently open to search, newest first.
+ * Shape: { code, name, startDate, endDate }
+ */
+export async function fetchTerms() {
+  const data = await getJson("/classes/searchableTermsV2");
+  const terms = (data?.data ?? [])
+    .filter((t) => t?.strm)
+    .map((t) => ({
+      code: String(t.strm),
+      name: t.descr ?? String(t.strm),
+      startDate: t.startDate ?? null,
+      endDate: t.endDate ?? null,
+    }));
+  terms.sort((a, b) => b.code.localeCompare(a.code));
+  return terms;
+}
+
+/**
+ * The term code for a date, using OSU's strm format: "1" + two-digit year +
+ * a term digit. Derived rather than hardcoded so the default does not rot,
+ * but always checked against the live term list before use, since a
+ * well-formed code does not mean the API has data for it.
+ */
+export function termCodeFor(date = new Date()) {
+  const month = date.getMonth() + 1;
+  const digit = month <= 4 ? "2" : month <= 7 ? "4" : "8";
+  const year = String(date.getFullYear() % 100).padStart(2, "0");
+  return `1${year}${digit}`;
+}
+
+/** The term to select on load: today's term if searchable, otherwise the newest. */
+export function defaultTerm(terms, date = new Date()) {
+  if (!terms?.length) return null;
+  const wanted = termCodeFor(date);
+  return terms.find((t) => t.code === wanted) ?? terms[0];
+}
+
+/**
+ * Search classes. Returns { totalItems, totalPages, page, courses }.
+ *
+ * Paging is non-deterministic upstream, so callers should keep queries narrow
+ * enough to fit on one page rather than trying to enumerate everything.
+ */
+export async function searchClasses({ q, term, page = 1 }) {
+  if (!term) throw new ApiError("Pick a term before searching.");
+  const data = await getJson("/classes/search", { q: q ?? "", campus: CAMPUS, term, p: page });
+  return {
+    totalItems: data?.totalItems ?? 0,
+    totalPages: data?.totalPages ?? 0,
+    page,
+    courses: data?.courses ?? [],
+  };
+}

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,45 @@
+import { fetchTerms, defaultTerm, ApiError } from "./api.js";
+
+const els = {
+  term: document.querySelector("#term"),
+  status: document.querySelector("#status"),
+};
+
+function setStatus(message, kind = "info") {
+  els.status.textContent = message ?? "";
+  els.status.dataset.kind = kind;
+  els.status.hidden = !message;
+}
+
+async function init() {
+  setStatus("Loading terms...");
+  els.term.disabled = true;
+
+  try {
+    const terms = await fetchTerms();
+    if (!terms.length) {
+      setStatus("Ohio State is not listing any searchable terms right now.", "error");
+      return;
+    }
+
+    els.term.replaceChildren(
+      ...terms.map((t) => {
+        const option = document.createElement("option");
+        option.value = t.code;
+        option.textContent = t.name;
+        return option;
+      })
+    );
+    els.term.value = defaultTerm(terms).code;
+    els.term.disabled = false;
+    setStatus(null);
+  } catch (error) {
+    setStatus(
+      error instanceof ApiError ? error.message : "Something went wrong loading terms.",
+      "error"
+    );
+    if (!(error instanceof ApiError)) console.error(error);
+  }
+}
+
+init();


### PR DESCRIPTION
Closes #3

The thin layer everything else sits on.

## What's here
- `js/api.js` with `fetchTerms()`, `searchClasses()`, and an `ApiError` type
- `js/app.js` populating the term selector on load
- Term selector wired into `index.html`

## Decisions worth reviewing

**The default term is derived, not hardcoded.** The issue said default to Autumn 2026 (`1268`). Hardcoding that would be wrong the moment the term ends, so `termCodeFor()` computes the code from today's date using OSU's `strm` format (`1` + two-digit year + `2`/`4`/`8` for Spring/Summer/Autumn) and `defaultTerm()` falls back to the newest searchable term if the computed one is not offered. Today that yields `1268`, satisfying the acceptance criterion without the date bomb.

**Errors are written for a student, not a developer.** A failed fetch says Ohio State's course service could not be reached and suggests retrying, rather than surfacing a `TypeError`. Unexpected errors still hit the console.

## Verification
Ran against the live API:

```
termCodeFor 2026-08-18 -> 1268
termCodeFor 2026-03-01 -> 1262
termCodeFor 2026-06-01 -> 1264
terms: 1268 Autumn 2026 | 1264 Summer 2026 | 1262 Spring 2026
default: 1268 Autumn 2026
search CSE 2221 -> totalItems 1281, courses 34, pages 7
```

## Flagging for #4
That last line matters. `q=CSE 2221` returns **1281 items across 7 pages**, so the API matches loosely rather than treating the query as one course. Page 1 alone has 34 courses. #4 will need client-side ranking so the course you actually typed comes first, and it should not assume a query maps to a single course.
