### PR TITLE
Build search and course results

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -1,0 +1,293 @@
+/* Finder. Scarlet is structural here, not decorative: it marks the course
+   record and nothing else, so the eye learns one meaning for it. */
+
+:root {
+  --paper: #ffffff;
+  --wash: #f0f1f4;
+  --sunk: #e7e9ee;
+  --ink: #16171a;
+  --mute: #656a72;
+  --rule: #dee0e5;
+  --scarlet: #bb0000;
+  --open: #0e7a50;
+  --wait: #a65b00;
+  --closed: #767c85;
+
+  --display: "Bricolage Grotesque", "Trebuchet MS", sans-serif;
+  --body: "IBM Plex Sans", system-ui, sans-serif;
+  --data: "IBM Plex Mono", ui-monospace, monospace;
+
+  --gap: clamp(1rem, 2.5vw, 1.75rem);
+  --radius: 3px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #131417;
+    --wash: #1a1c20;
+    --sunk: #232529;
+    --ink: #eceef2;
+    --mute: #9aa1ab;
+    --rule: #2c2f35;
+    --scarlet: #ff5c4d;
+    --open: #4cc38a;
+    --wait: #e0a44a;
+    --closed: #868d97;
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--wash);
+  color: var(--ink);
+  font-family: var(--body);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+}
+
+:focus-visible {
+  outline: 2px solid var(--scarlet);
+  outline-offset: 2px;
+}
+
+.shell {
+  max-width: 62rem;
+  margin: 0 auto;
+  padding: var(--gap);
+}
+
+/* Masthead ---------------------------------------------------------------- */
+
+.masthead {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+
+.wordmark {
+  font-family: var(--display);
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 0;
+  line-height: 1;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--mute);
+  font-size: 0.95rem;
+}
+
+/* Search ------------------------------------------------------------------ */
+
+.search {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.5rem;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 0.5rem;
+  position: sticky;
+  top: 0.5rem;
+  z-index: 10;
+}
+
+.search input,
+.search select,
+.search button {
+  font: inherit;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  padding: 0.6rem 0.75rem;
+  background: transparent;
+  color: inherit;
+}
+
+.search input {
+  min-width: 0;
+  border-color: var(--rule);
+  background: var(--paper);
+}
+
+.search input::placeholder { color: var(--mute); }
+
+.search select {
+  border-color: var(--rule);
+  background: var(--paper);
+  cursor: pointer;
+}
+
+.search button {
+  background: var(--scarlet);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  border-color: var(--scarlet);
+}
+
+.search button:hover { filter: brightness(1.08); }
+.search button:disabled { opacity: 0.5; cursor: default; }
+
+@media (prefers-color-scheme: dark) {
+  .search button { color: #16171a; }
+}
+
+/* Status ------------------------------------------------------------------ */
+
+.status {
+  margin: 1rem 0 0;
+  color: var(--mute);
+  font-size: 0.95rem;
+}
+
+.status:empty { margin: 0; }
+.status[data-kind="error"] { color: var(--scarlet); font-weight: 500; }
+
+/* Course records ---------------------------------------------------------- */
+
+.results { margin-top: 1.25rem; display: grid; gap: 0.75rem; }
+
+.course {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--scarlet);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.course-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.course-code {
+  font-family: var(--display);
+  font-weight: 800;
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
+}
+
+.course-title { font-weight: 600; }
+
+.course-meta {
+  margin-left: auto;
+  color: var(--mute);
+  font-family: var(--data);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+/* Sections ---------------------------------------------------------------- */
+
+.sections { list-style: none; margin: 0; padding: 0; }
+
+.section {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr auto;
+  gap: 0.25rem 0.9rem;
+  padding: 0.7rem 1rem;
+  border-top: 1px solid var(--rule);
+  align-items: baseline;
+}
+
+.sections > .section:first-child { border-top: 0; }
+
+.section-number {
+  font-family: var(--data);
+  font-size: 0.85rem;
+  color: var(--mute);
+}
+
+.section-when { font-size: 0.95rem; }
+
+.section-where,
+.section-who {
+  grid-column: 2;
+  color: var(--mute);
+  font-size: 0.85rem;
+}
+
+.section-who { color: var(--ink); }
+
+.chip {
+  font-family: var(--data);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.chip::before {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.chip[data-kind="open"] { color: var(--open); }
+.chip[data-kind="wait"] { color: var(--wait); }
+.chip[data-kind="closed"] { color: var(--closed); }
+.chip[data-kind="unknown"] { color: var(--mute); }
+
+.seats {
+  grid-column: 3;
+  font-family: var(--data);
+  font-size: 0.78rem;
+  color: var(--mute);
+  text-align: right;
+}
+
+.component {
+  font-family: var(--data);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--mute);
+  background: var(--sunk);
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius);
+}
+
+/* Small screens ----------------------------------------------------------- */
+
+@media (max-width: 34rem) {
+  .search { grid-template-columns: 1fr; position: static; }
+  .section { grid-template-columns: 1fr auto; }
+  .section-number { grid-column: 1; }
+  .section-when,
+  .section-where,
+  .section-who { grid-column: 1 / -1; }
+  .seats { grid-column: 1 / -1; text-align: left; }
+  .course-meta { margin-left: 0; width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/index.html
+++ b/index.html
@@ -4,20 +4,33 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Finder</title>
-  <meta name="description" content="Find who teaches your Ohio State classes.">
+  <meta name="description" content="Find who teaches your Ohio State classes before everyone else.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,700;12..96,800&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/finder.css">
 </head>
 <body>
-  <main>
-    <h1>Finder</h1>
-    <p>Find who teaches your classes before everyone else.</p>
+  <div class="shell">
+    <header class="masthead">
+      <h1 class="wordmark">Finder</h1>
+      <p class="tagline">Who teaches it, before everyone else finds out.</p>
+    </header>
 
-    <label for="term">Term</label>
-    <select id="term" disabled></select>
+    <form class="search" id="search" role="search">
+      <label class="visually-hidden" for="q">Course or professor</label>
+      <input id="q" name="q" type="search" autocomplete="off" placeholder="CSE 2221, or a professor's name">
 
-    <p id="status" role="status" hidden></p>
+      <label class="visually-hidden" for="term">Term</label>
+      <select id="term" name="term" disabled></select>
 
-    <p>Search lands in <a href="https://github.com/EnesYilmazcode/Finder/issues/4">#4</a>.</p>
-  </main>
+      <button id="go" type="submit">Search</button>
+    </form>
+
+    <p class="status" id="status" role="status" aria-live="polite"></p>
+    <div class="results" id="results"></div>
+  </div>
+
   <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/js/api.js
+++ b/js/api.js
@@ -113,3 +113,29 @@ export async function searchClasses({ q, term, page = 1 }) {
     courses: data?.courses ?? [],
   };
 }
+
+/**
+ * Search across several pages and merge.
+ *
+ * Relevance does not reliably put a match on page 1: "Smith" returns 674 items
+ * over 4 pages with zero of that professor's courses on the first. Upstream
+ * paging is also non-deterministic, so pulling more pages raises coverage
+ * rather than lowering it.
+ */
+export async function searchAllPages({ q, term, maxPages = 5 }) {
+  const first = await searchClasses({ q, term, page: 1 });
+  const pages = Math.min(first.totalPages ?? 1, maxPages);
+  if (pages <= 1) return { ...first, pagesFetched: 1 };
+
+  const rest = await Promise.all(
+    Array.from({ length: pages - 1 }, (_, i) =>
+      searchClasses({ q, term, page: i + 2 }).catch(() => ({ courses: [] }))
+    )
+  );
+
+  return {
+    ...first,
+    courses: [...first.courses, ...rest.flatMap((r) => r.courses)],
+    pagesFetched: pages,
+  };
+}

--- a/js/app.js
+++ b/js/app.js
@@ -1,45 +1,107 @@
-import { fetchTerms, defaultTerm, ApiError } from "./api.js";
+import { fetchTerms, defaultTerm, searchClasses, ApiError } from "./api.js";
+import { rankCourses } from "./rank.js";
+import { renderResults } from "./render.js";
 
 const els = {
+  form: document.querySelector("#search"),
+  query: document.querySelector("#q"),
   term: document.querySelector("#term"),
+  submit: document.querySelector("#go"),
   status: document.querySelector("#status"),
+  results: document.querySelector("#results"),
 };
+
+let terms = [];
 
 function setStatus(message, kind = "info") {
   els.status.textContent = message ?? "";
   els.status.dataset.kind = kind;
-  els.status.hidden = !message;
+}
+
+function syncUrl(q, term) {
+  const url = new URL(location.href);
+  if (q) url.searchParams.set("q", q); else url.searchParams.delete("q");
+  if (term) url.searchParams.set("term", term);
+  history.replaceState(null, "", url);
+}
+
+async function runSearch(q, term) {
+  if (!q.trim()) {
+    els.results.replaceChildren();
+    setStatus("Type a course like CSE 2221, or a professor's name.");
+    return;
+  }
+
+  els.submit.disabled = true;
+  setStatus("Searching...");
+  try {
+    const { courses } = await searchClasses({ q, term });
+    const ranked = rankCourses(courses, q);
+    renderResults(els.results, ranked);
+    if (!ranked.length) {
+      setStatus(`Nothing matched "${q}" in ${termName(term)}. Try a subject and number, like CSE 2221.`);
+    } else {
+      const sections = ranked.reduce((n, e) => n + e.sections.length, 0);
+      setStatus(`${ranked.length} course${ranked.length === 1 ? "" : "s"}, ${sections} sections in ${termName(term)}.`);
+    }
+  } catch (error) {
+    els.results.replaceChildren();
+    setStatus(error instanceof ApiError ? error.message : "Something went wrong. Try again.", "error");
+    if (!(error instanceof ApiError)) console.error(error);
+  } finally {
+    els.submit.disabled = false;
+  }
+}
+
+function termName(code) {
+  return terms.find((t) => t.code === code)?.name ?? code;
 }
 
 async function init() {
+  const params = new URLSearchParams(location.search);
   setStatus("Loading terms...");
   els.term.disabled = true;
 
   try {
-    const terms = await fetchTerms();
-    if (!terms.length) {
-      setStatus("Ohio State is not listing any searchable terms right now.", "error");
-      return;
-    }
-
-    els.term.replaceChildren(
-      ...terms.map((t) => {
-        const option = document.createElement("option");
-        option.value = t.code;
-        option.textContent = t.name;
-        return option;
-      })
-    );
-    els.term.value = defaultTerm(terms).code;
-    els.term.disabled = false;
-    setStatus(null);
+    terms = await fetchTerms();
   } catch (error) {
-    setStatus(
-      error instanceof ApiError ? error.message : "Something went wrong loading terms.",
-      "error"
-    );
-    if (!(error instanceof ApiError)) console.error(error);
+    setStatus(error instanceof ApiError ? error.message : "Could not load terms.", "error");
+    return;
   }
+
+  if (!terms.length) {
+    setStatus("Ohio State is not listing any searchable terms right now.", "error");
+    return;
+  }
+
+  els.term.replaceChildren(
+    ...terms.map((t) => {
+      const option = document.createElement("option");
+      option.value = t.code;
+      option.textContent = t.name;
+      return option;
+    })
+  );
+  const wanted = params.get("term");
+  els.term.value = terms.some((t) => t.code === wanted) ? wanted : defaultTerm(terms).code;
+  els.term.disabled = false;
+
+  els.form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const q = els.query.value;
+    syncUrl(q, els.term.value);
+    runSearch(q, els.term.value);
+  });
+
+  els.term.addEventListener("change", () => {
+    syncUrl(els.query.value, els.term.value);
+    if (els.query.value.trim()) runSearch(els.query.value, els.term.value);
+  });
+
+  const initialQuery = params.get("q") ?? "";
+  els.query.value = initialQuery;
+  if (initialQuery.trim()) runSearch(initialQuery, els.term.value);
+  else setStatus("Type a course like CSE 2221, or a professor's name.");
 }
 
 init();

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,4 @@
-import { fetchTerms, defaultTerm, searchClasses, ApiError } from "./api.js";
+import { fetchTerms, defaultTerm, searchAllPages, ApiError } from "./api.js";
 import { rankCourses } from "./rank.js";
 import { renderResults } from "./render.js";
 
@@ -12,6 +12,7 @@ const els = {
 };
 
 let terms = [];
+let latestRequest = 0;
 
 function setStatus(message, kind = "info") {
   els.status.textContent = message ?? "";
@@ -32,24 +33,31 @@ async function runSearch(q, term) {
     return;
   }
 
+  const requestId = ++latestRequest;
   els.submit.disabled = true;
   setStatus("Searching...");
   try {
-    const { courses } = await searchClasses({ q, term });
+    const { courses, totalPages, pagesFetched } = await searchAllPages({ q, term });
+    if (requestId !== latestRequest) return; // a newer search already answered
     const ranked = rankCourses(courses, q);
     renderResults(els.results, ranked);
     if (!ranked.length) {
       setStatus(`Nothing matched "${q}" in ${termName(term)}. Try a subject and number, like CSE 2221.`);
     } else {
       const sections = ranked.reduce((n, e) => n + e.sections.length, 0);
-      setStatus(`${ranked.length} course${ranked.length === 1 ? "" : "s"}, ${sections} sections in ${termName(term)}.`);
+      const truncated = totalPages > pagesFetched;
+      setStatus(
+        `Showing ${ranked.length} course${ranked.length === 1 ? "" : "s"}, ${sections} sections in ${termName(term)}` +
+          (truncated ? ". Narrow the search to see more." : ".")
+      );
     }
   } catch (error) {
+    if (requestId !== latestRequest) return;
     els.results.replaceChildren();
     setStatus(error instanceof ApiError ? error.message : "Something went wrong. Try again.", "error");
     if (!(error instanceof ApiError)) console.error(error);
   } finally {
-    els.submit.disabled = false;
+    if (requestId === latestRequest) els.submit.disabled = false;
   }
 }
 

--- a/js/format.js
+++ b/js/format.js
@@ -1,0 +1,50 @@
+// Turning API shapes into things a student reads at a glance.
+
+const DAY_KEYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
+const DAY_LABELS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+
+export function formatDays(meeting) {
+  if (!meeting) return "";
+  return DAY_KEYS.map((key, i) => (meeting[key] ? DAY_LABELS[i] : null)).filter(Boolean).join("");
+}
+
+export function formatTime(meeting) {
+  if (!meeting?.startTime) return "";
+  const start = meeting.startTime.replace(/\s?([ap])m/i, "$1").toLowerCase();
+  const end = meeting.endTime?.replace(/\s?([ap])m/i, "$1").toLowerCase();
+  return end ? `${start}–${end}` : start;
+}
+
+export function formatWhen(meeting) {
+  const days = formatDays(meeting);
+  const time = formatTime(meeting);
+  if (!days && !time) return "Time to be announced";
+  return [days, time].filter(Boolean).join(" ");
+}
+
+export function formatPlace(meeting, section) {
+  if (section?.instructionMode && /online/i.test(section.instructionMode)) return section.instructionMode;
+  const building = meeting?.buildingDescriptionShort || meeting?.facilityDescriptionShort || meeting?.facilityDescription;
+  if (!building) return "Location to be announced";
+  return building;
+}
+
+export function formatUnits(course) {
+  const min = course?.minUnits;
+  const max = course?.maxUnits;
+  if (min == null && max == null) return "";
+  if (min === max || max == null) return `${min} credit${min === 1 ? "" : "s"}`;
+  return `${min}–${max} credits`;
+}
+
+/** Instructors for a section, deduped, since they hang off each meeting. */
+export function instructorsOf(section) {
+  const seen = new Map();
+  for (const meeting of section?.meetings ?? []) {
+    for (const person of meeting?.instructors ?? []) {
+      const name = person?.displayName?.trim();
+      if (name && !seen.has(name)) seen.set(name, { name, email: person.email ?? null, role: person.role ?? null });
+    }
+  }
+  return [...seen.values()];
+}

--- a/js/rank.js
+++ b/js/rank.js
@@ -1,0 +1,86 @@
+// The API matches loosely: "CSE 2221" returns 1281 items across 7 pages, and
+// page one alone carries CSE 2231, 2321, 5022 and more. It also splits some
+// courses across duplicate records. So results get merged and reordered here
+// before anyone sees them.
+
+import { instructorsOf } from "./format.js";
+
+const SUBJECT_RE = /^[A-Z]{2,8}$/;
+const NUMBER_RE = /^\d{3,4}(\.\d+)?[A-Z]*$/;
+
+export function parseQuery(raw) {
+  const tokens = (raw ?? "").trim().toUpperCase().split(/\s+/).filter(Boolean);
+  return {
+    raw: (raw ?? "").trim(),
+    tokens,
+    subject: tokens.find((t) => SUBJECT_RE.test(t)) ?? null,
+    number: tokens.find((t) => NUMBER_RE.test(t)) ?? null,
+  };
+}
+
+/** Merge records that describe the same course, keeping every section. */
+export function mergeCourses(entries) {
+  const merged = new Map();
+  for (const entry of entries ?? []) {
+    const course = entry?.course;
+    if (!course) continue;
+    const key = `${course.subject}|${course.catalogNumber}|${course.title}`;
+    const existing = merged.get(key);
+    if (existing) {
+      const seen = new Set(existing.sections.map((s) => String(s.classNumber)));
+      for (const section of entry.sections ?? []) {
+        if (!seen.has(String(section.classNumber))) existing.sections.push(section);
+      }
+    } else {
+      merged.set(key, { course, sections: [...(entry.sections ?? [])] });
+    }
+  }
+  return [...merged.values()];
+}
+
+function scoreCourse({ course, sections }, parsed) {
+  const subject = (course.subject ?? "").toUpperCase();
+  const number = (course.catalogNumber ?? "").toUpperCase();
+  const title = (course.title ?? "").toUpperCase();
+
+  let score = 0;
+  const subjectHit = parsed.subject && subject === parsed.subject;
+  const numberHit = parsed.number && number === parsed.number;
+
+  if (subjectHit && numberHit) score += 1000;
+  else {
+    if (subjectHit) score += 120;
+    if (numberHit) score += 90;
+  }
+
+  // A bare number query should still favour the course someone meant.
+  if (!parsed.subject && numberHit) score += 60;
+
+  for (const token of parsed.tokens) {
+    if (token === subject || token === number) continue;
+    if (title.includes(token)) score += 25;
+  }
+
+  if (parsed.tokens.length) {
+    const names = sections.flatMap((s) => instructorsOf(s).map((i) => i.name.toUpperCase()));
+    for (const token of parsed.tokens) {
+      if (token.length < 3) continue;
+      if (names.some((n) => n.includes(token))) { score += 200; break; }
+    }
+  }
+
+  // Break ties toward the course people are more likely to want: more sections
+  // means a bigger, more commonly taken offering.
+  score += Math.min(sections.length, 30) / 100;
+  return score;
+}
+
+export function rankCourses(entries, rawQuery) {
+  const parsed = parseQuery(rawQuery);
+  const merged = mergeCourses(entries);
+  if (!parsed.tokens.length) return merged;
+  return merged
+    .map((entry) => ({ entry, score: scoreCourse(entry, parsed) }))
+    .sort((a, b) => b.score - a.score || a.entry.course.catalogNumber.localeCompare(b.entry.course.catalogNumber))
+    .map((x) => x.entry);
+}

--- a/js/rank.js
+++ b/js/rank.js
@@ -81,6 +81,6 @@ export function rankCourses(entries, rawQuery) {
   if (!parsed.tokens.length) return merged;
   return merged
     .map((entry) => ({ entry, score: scoreCourse(entry, parsed) }))
-    .sort((a, b) => b.score - a.score || a.entry.course.catalogNumber.localeCompare(b.entry.course.catalogNumber))
+    .sort((a, b) => b.score - a.score || String(a.entry.course.catalogNumber ?? "").localeCompare(String(b.entry.course.catalogNumber ?? "")))
     .map((x) => x.entry);
 }

--- a/js/render.js
+++ b/js/render.js
@@ -1,0 +1,71 @@
+// Everything here builds DOM nodes rather than HTML strings. Course titles and
+// instructor names come from an external API, so they never get interpolated
+// into markup.
+//
+// Seat counts are deliberately absent. The search endpoint reports one
+// enrollment figure per course and repeats it onto every section, so rendering
+// it per section would tell students a full section is open. See #13.
+
+import { formatWhen, formatPlace, formatUnits, instructorsOf } from "./format.js";
+
+const COMPONENT_ORDER = ["Lecture", "Seminar", "Studio", "Laboratory", "Recitation"];
+
+function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = text;
+  return node;
+}
+
+function sortSections(sections) {
+  return [...sections].sort((a, b) => {
+    const ai = COMPONENT_ORDER.indexOf(a.component);
+    const bi = COMPONENT_ORDER.indexOf(b.component);
+    const aRank = ai === -1 ? COMPONENT_ORDER.length : ai;
+    const bRank = bi === -1 ? COMPONENT_ORDER.length : bi;
+    if (aRank !== bRank) return aRank - bRank;
+    return String(a.classNumber).localeCompare(String(b.classNumber));
+  });
+}
+
+export function renderSection(section) {
+  const li = el("li", "section");
+  const meeting = section.meetings?.[0] ?? null;
+
+  li.append(el("span", "section-number", section.classNumber ?? ""));
+
+  const when = el("span", "section-when");
+  when.append(document.createTextNode(formatWhen(meeting) + " "));
+  if (section.component) when.append(el("span", "component", section.component));
+  li.append(when);
+
+  li.append(el("span", "section-where", formatPlace(meeting, section)));
+
+  const people = instructorsOf(section);
+  li.append(el("span", "section-who", people.length ? people.map((p) => p.name).join(", ") : "Instructor not listed"));
+
+  return li;
+}
+
+export function renderCourse({ course, sections }) {
+  const article = el("article", "course");
+
+  const head = el("header", "course-head");
+  head.append(el("span", "course-code", `${course.subject} ${course.catalogNumber}`));
+  head.append(el("span", "course-title", course.title ?? ""));
+
+  const units = formatUnits(course);
+  const count = `${sections.length} section${sections.length === 1 ? "" : "s"}`;
+  head.append(el("span", "course-meta", units ? `${units} · ${count}` : count));
+  article.append(head);
+
+  const list = el("ul", "sections");
+  for (const section of sortSections(sections)) list.append(renderSection(section));
+  article.append(list);
+
+  return article;
+}
+
+export function renderResults(container, entries) {
+  container.replaceChildren(...entries.map(renderCourse));
+}


### PR DESCRIPTION
Closes #4

Finder now does the thing it exists to do: type a course, see its sections and who teaches them.

## What's here
- `css/finder.css`, design tokens with a dark mode and a reduced-motion guard
- `js/format.js`, meeting days, times, places, credits, instructor dedupe
- `js/rank.js`, merges duplicate course records and reorders results
- `js/render.js`, builds DOM nodes, never HTML strings
- `js/app.js`, wiring, URL state so a search is shareable
- Real markup in `index.html`

## Ranking was necessary, not polish
`q=CSE 2221` returns **1281 items across 7 pages**, and page one carries CSE 2231, CSE 2321 and CSE 5022 before you find what you typed. The API also splits some courses across duplicate records, so CSE 5052 appeared twice with one section each.

After merge and rank:

```
q="CSE 2221"   raw= 31  merged= 30  top3: CSE 2221, CSE 2231, CSE 5022
q="MATH 1151"  raw= 16  merged= 16  top3: MATH 1151, MATH 1131, MATH 1172
q="Bucci"      raw=  9  merged=  9  top3: CSE 2231, CSE 5023, CSE 2221
q="2221"       raw= 36  merged= 34  top3: CSE 2221, MUSIC 2221, ANIMSCI 2221
```

## One thing removed on purpose

I built seat counts, then found the data is wrong, so I took them back out. `enrollmentTotal` is one number per course repeated onto every section:

```
class   Barrett          API
5168    32/40            32 enrolled, Open      agrees
4827    40/40  FULL      32 enrolled, Open      API says open, section is full
4831    41/40  +1 wait   32 enrolled, Open      API says open, section is over cap
```

Shipping that would send someone to a section that filled weeks ago. Full write-up and the fix are in #13.

## Verification
Ran against the live API and rendered in headless Chrome. Responsive measured at six widths:

```
 320px  scrollWidth=305  clientWidth=305  overflow=no  spills=none
 360px  scrollWidth=345  clientWidth=345  overflow=no  spills=none
 390px  scrollWidth=375  clientWidth=375  overflow=no  spills=none
 414px  scrollWidth=399  clientWidth=399  overflow=no  spills=none
 768px  scrollWidth=753  clientWidth=753  overflow=no  spills=none
1100px  scrollWidth=1085 clientWidth=1085 overflow=no  spills=none
```

Note for anyone reproducing this: Chrome's `--headless=new --window-size` is ignored for layout, `innerWidth` stays at 500 no matter what you pass, and the screenshot then gets cropped so narrow captures look broken when they are not. Measure in a sized iframe instead.
