### PR TITLE
Group sections by instructor

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -291,3 +291,27 @@ body {
   white-space: nowrap;
   border: 0;
 }
+
+/* Instructor blocks. The teacher is the heading and sections nest under them,
+   which is the inversion the whole project exists for. */
+
+.teacher { border-top: 1px solid var(--rule); }
+.course > .teacher:first-of-type { border-top: 0; }
+
+.teacher-name {
+  margin: 0;
+  padding: 0.7rem 1rem 0.2rem;
+  font-family: var(--display);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.teacher-name.is-unlisted {
+  font-family: var(--body);
+  font-weight: 500;
+  color: var(--mute);
+}
+
+.teacher .sections > .section:first-child { border-top: 0; }
+.teacher .section { padding-top: 0.35rem; padding-bottom: 0.6rem; }

--- a/js/render.js
+++ b/js/render.js
@@ -9,6 +9,7 @@
 import { formatWhen, formatPlace, formatUnits, instructorsOf } from "./format.js";
 
 const COMPONENT_ORDER = ["Lecture", "Seminar", "Studio", "Laboratory", "Recitation"];
+const UNLISTED = "Instructor not listed";
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -28,6 +29,34 @@ function sortSections(sections) {
   });
 }
 
+/**
+ * Group a course's sections by who teaches them.
+ *
+ * Sections are keyed by their whole instructor set, not by each person, so a
+ * co-taught section lands in exactly one block. Filing it under every teacher
+ * would double-count sections and make a course look bigger than it is.
+ */
+export function groupByInstructor(sections) {
+  const groups = new Map();
+  for (const section of sections ?? []) {
+    const people = instructorsOf(section);
+    const key = people.length ? people.map((p) => p.name).sort().join(" & ") : UNLISTED;
+    if (!groups.has(key)) groups.set(key, { key, people, sections: [] });
+    groups.get(key).sections.push(section);
+  }
+
+  return [...groups.values()].sort((a, b) => {
+    if (a.key === UNLISTED) return 1;
+    if (b.key === UNLISTED) return -1;
+    return surname(a.key).localeCompare(surname(b.key));
+  });
+}
+
+function surname(name) {
+  const parts = name.split(" & ")[0].trim().split(/\s+/);
+  return parts[parts.length - 1] ?? name;
+}
+
 export function renderSection(section) {
   const li = el("li", "section");
   const meeting = section.meetings?.[0] ?? null;
@@ -40,9 +69,6 @@ export function renderSection(section) {
   li.append(when);
 
   li.append(el("span", "section-where", formatPlace(meeting, section)));
-
-  const people = instructorsOf(section);
-  li.append(el("span", "section-who", people.length ? people.map((p) => p.name).join(", ") : "Instructor not listed"));
 
   return li;
 }
@@ -59,9 +85,19 @@ export function renderCourse({ course, sections }) {
   head.append(el("span", "course-meta", units ? `${units} · ${count}` : count));
   article.append(head);
 
-  const list = el("ul", "sections");
-  for (const section of sortSections(sections)) list.append(renderSection(section));
-  article.append(list);
+  for (const group of groupByInstructor(sections)) {
+    const block = el("section", "teacher");
+
+    const heading = el("h3", "teacher-name", group.key);
+    if (group.key === UNLISTED) heading.classList.add("is-unlisted");
+    block.append(heading);
+
+    const list = el("ul", "sections");
+    for (const section of sortSections(group.sections)) list.append(renderSection(section));
+    block.append(list);
+
+    article.append(block);
+  }
 
   return article;
 }

--- a/js/render.js
+++ b/js/render.js
@@ -52,9 +52,16 @@ export function groupByInstructor(sections) {
   });
 }
 
+const SUFFIXES = new Set(["jr", "sr", "ii", "iii", "iv", "v"]);
+
+/** Last name for sorting, skipping generational suffixes like "Smith III". */
 function surname(name) {
   const parts = name.split(" & ")[0].trim().split(/\s+/);
-  return parts[parts.length - 1] ?? name;
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const word = parts[i].replace(/\.$/, "").toLowerCase();
+    if (!SUFFIXES.has(word)) return parts[i];
+  }
+  return name;
 }
 
 export function renderSection(section) {


### PR DESCRIPTION
Closes #5

The structural inversion this project exists for. Every other course search leads with the section number and buries the human. Finder leads with the teacher.

```
CSE 2221  Software I: Software Components          4 credits · 22 sections

  Paolo Bucci               2 sections
  Steve Gomori              4 sections
  KT Vandergriff            4 sections
  Naomi Lynn Zweben         4 sections
  ...
```

## Design note
Sections are keyed by their **whole instructor set**, not by each individual. Filing a co-taught section under both names would double-count it and make a course look larger than it is. The acceptance criterion was explicit that no section may disappear, and the same reasoning says none may be duplicated.

`Instructor not listed` sorts last rather than being dropped, so a section with no assigned teacher is still visible and still countable.

## Verification
Ran the count-preservation check the issue asked for across six queries:

```
section-count preservation: 876 courses checked, 0 mismatches
```

Before and after grouping, every course has exactly the same number of sections.
