### PR TITLE
Filter search results instead of only ranking them

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -315,3 +315,22 @@ body {
 
 .teacher .sections > .section:first-child { border-top: 0; }
 .teacher .section { padding-top: 0.35rem; padding-bottom: 0.6rem; }
+
+/* Related courses stay reachable without competing with the answer. */
+
+.related {
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+
+.related > summary {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  color: var(--mute);
+  font-size: 0.9rem;
+}
+
+.related > summary:hover { color: var(--ink); }
+.related[open] > summary { border-bottom: 1px solid var(--rule); }
+.related > .course { border: 0; border-radius: 0; border-top: 1px solid var(--rule); }

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 import { fetchTerms, defaultTerm, searchAllPages, ApiError } from "./api.js";
-import { rankCourses } from "./rank.js";
+import { filterCourses } from "./rank.js";
 import { renderResults } from "./render.js";
 
 const els = {
@@ -37,19 +37,16 @@ async function runSearch(q, term) {
   els.submit.disabled = true;
   setStatus("Searching...");
   try {
-    const { courses, totalPages, pagesFetched } = await searchAllPages({ q, term });
+    const { courses } = await searchAllPages({ q, term });
     if (requestId !== latestRequest) return; // a newer search already answered
-    const ranked = rankCourses(courses, q);
-    renderResults(els.results, ranked);
-    if (!ranked.length) {
+    const { primary, related } = filterCourses(courses, q);
+    renderResults(els.results, { primary, related });
+    if (!primary.length) {
       setStatus(`Nothing matched "${q}" in ${termName(term)}. Try a subject and number, like CSE 2221.`);
     } else {
-      const sections = ranked.reduce((n, e) => n + e.sections.length, 0);
-      const truncated = totalPages > pagesFetched;
-      setStatus(
-        `Showing ${ranked.length} course${ranked.length === 1 ? "" : "s"}, ${sections} sections in ${termName(term)}` +
-          (truncated ? ". Narrow the search to see more." : ".")
-      );
+      const sections = primary.reduce((n, e) => n + e.sections.length, 0);
+      const noun = primary.length === 1 ? "course" : "courses";
+      setStatus(`${primary.length} ${noun}, ${sections} sections in ${termName(term)}.`);
     }
   } catch (error) {
     if (requestId !== latestRequest) return;

--- a/js/rank.js
+++ b/js/rank.js
@@ -75,6 +75,71 @@ function scoreCourse({ course, sections }, parsed) {
   return score;
 }
 
+const NON_TEACHING_COMPONENTS = new Set([
+  "Independent Study",
+  "Research",
+  "Thesis Research",
+  "Dissertation",
+]);
+
+/**
+ * Independent study, research and thesis courses carry dozens of one-student
+ * sections with no meeting pattern. CSE 4193 alone has 66. They are real, but
+ * nobody searching a subject wants them, so they stay out of generic results
+ * and remain reachable by name.
+ */
+export function isIndividualStudy({ course, sections }) {
+  if (!sections?.length) return false;
+  const scheduled = sections.some((s) =>
+    (s.meetings ?? []).some((m) => m.monday || m.tuesday || m.wednesday || m.thursday || m.friday || m.saturday || m.sunday)
+  );
+  if (scheduled) return false;
+  const components = new Set(sections.map((s) => s.component).filter(Boolean));
+  if ([...components].every((c) => NON_TEACHING_COMPONENTS.has(c))) return true;
+  return /individual studies|research|thesis|dissertation/i.test(course.title ?? "");
+}
+
+/**
+ * Split results into what was asked for and what merely matched.
+ *
+ * Ranking alone left 103 courses on screen for "CSE 2321". Ordering the noise
+ * correctly is not the same as removing it.
+ */
+export function filterCourses(entries, rawQuery) {
+  const parsed = parseQuery(rawQuery);
+  const ranked = rankCourses(entries, rawQuery);
+  if (!ranked.length) return { primary: [], related: [], reason: "none" };
+
+  const wantsStudy = /individual|research|thesis|dissertation/i.test(parsed.raw);
+  const setAside = wantsStudy ? [] : ranked.filter(isIndividualStudy);
+  const pool = wantsStudy ? ranked : ranked.filter((e) => !isIndividualStudy(e));
+  // Nothing is ever discarded outright. Demoted results move to `related` so a
+  // student who really did want CSE 4193 can still reach it.
+  if (!pool.length) return { primary: ranked.slice(0, 25), related: ranked.slice(25), reason: "ranked" };
+
+  // An exact subject plus number is unambiguous. Answer the question asked.
+  if (parsed.subject && parsed.number) {
+    const exact = pool.filter(
+      (e) =>
+        (e.course.subject ?? "").toUpperCase() === parsed.subject &&
+        (e.course.catalogNumber ?? "").toUpperCase() === parsed.number
+    );
+    if (exact.length) {
+      const rest = [...pool.filter((e) => !exact.includes(e)), ...setAside];
+      return { primary: exact, related: rest, reason: "exact" };
+    }
+  }
+
+  // Otherwise keep what scores near the top and drop the long tail.
+  const scored = pool.map((entry) => ({ entry, score: scoreCourse(entry, parsed) }));
+  const best = Math.max(...scored.map((s) => s.score));
+  const floor = best > 200 ? best * 0.25 : 0;
+  const kept = scored.filter((s) => s.score >= floor).map((s) => s.entry);
+  const primary = kept.slice(0, 25);
+  const related = [...kept.slice(25), ...pool.filter((e) => !kept.includes(e)), ...setAside];
+  return { primary, related, reason: "ranked" };
+}
+
 export function rankCourses(entries, rawQuery) {
   const parsed = parseQuery(rawQuery);
   const merged = mergeCourses(entries);

--- a/js/render.js
+++ b/js/render.js
@@ -114,9 +114,18 @@ export function renderResults(container, { primary, related }) {
 
   if (related?.length) {
     const details = el("details", "related");
-    const summary = el("summary", null, `Show ${related.length} related course${related.length === 1 ? "" : "s"}`);
-    details.append(summary);
-    for (const entry of related) details.append(renderCourse(entry));
+    details.append(el("summary", null, `Show ${related.length} related course${related.length === 1 ? "" : "s"}`));
+
+    // <details> hides its content, it does not defer building it. Rendering
+    // these up front costs thousands of nodes to display none of them, so they
+    // are built on first open instead.
+    let built = false;
+    details.addEventListener("toggle", () => {
+      if (built || !details.open) return;
+      built = true;
+      details.append(...related.map(renderCourse));
+    });
+
     nodes.push(details);
   }
 

--- a/js/render.js
+++ b/js/render.js
@@ -109,6 +109,16 @@ export function renderCourse({ course, sections }) {
   return article;
 }
 
-export function renderResults(container, entries) {
-  container.replaceChildren(...entries.map(renderCourse));
+export function renderResults(container, { primary, related }) {
+  const nodes = primary.map(renderCourse);
+
+  if (related?.length) {
+    const details = el("details", "related");
+    const summary = el("summary", null, `Show ${related.length} related course${related.length === 1 ? "" : "s"}`);
+    details.append(summary);
+    for (const entry of related) details.append(renderCourse(entry));
+    nodes.push(details);
+  }
+
+  container.replaceChildren(...nodes);
 }


### PR DESCRIPTION
Closes #16

Reported from real use: searching `CSE 2321` returns 103 courses and 1000 sections. Ranking put CSE 2321 first, then left CSE 4193, 4998, 4998H, 4999, 6193, 6998 and 8998 underneath it, most of them independent study listings with 40 to 70 sections that all read "Time to be announced".

Ordering noise correctly is not the same as removing it. This PR removes it.

## Effect

```
query        before                    after
CSE 2321     103 courses / 928 sec  ->   1 course /  11 sections
CSE 2221     101 courses / 916 sec  ->   1 course /  22 sections
MATH 1151    166 courses / 981 sec  ->   1 course /  74 sections
Bucci          9 courses /  17 sec  ->   4 courses / 12 sections
CSE          102 courses / 1000 sec ->  25 courses / 244 sections
```

## How
- **Exact subject and number answers with that course alone.** `CSE 2321` is unambiguous, so it gets a direct answer instead of a ranked list.
- **Independent study, research and thesis courses are demoted** out of generic results. Detected by having no meeting pattern on any section plus a non-teaching component, not by title alone.
- **Relevance floor** cuts the long tail for open-ended queries, capped at 25 courses.

## Nothing is thrown away
Everything demoted moves into a `Show N related courses` disclosure. Related courses matter: CSE 2221 and CSE 5022 are the same class for different students, and someone really might want CSE 4193.

Verified that no course can be lost:

```
q=CSE 2321   ranked=103  primary= 1 related=102  total=103  lost=0
q=CSE 2221   ranked=101  primary= 1 related=100  total=101  lost=0
q=Bucci      ranked=  9  primary= 4 related=  5  total=  9  lost=0
q=Smith      ranked=252  primary=25 related=227  total=252  lost=0
q=CSE        ranked=102  primary=25 related= 77  total=102  lost=0
q=MATH 1151  ranked=166  primary= 1 related=165  total=166  lost=0
```

`primary + related` always equals the full ranked set. I got this wrong on the first pass, where demoted courses vanished entirely, and the check above is what caught it.

## Note
This also delivers the compare-professors case without new UI. A single-course result is now every instructor teaching it, side by side, which is what the layout was already built for and what the noise was burying.
