### PR TITLE
Responsive and accessibility pass

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -6,12 +6,13 @@
   --wash: #f0f1f4;
   --sunk: #e7e9ee;
   --ink: #16171a;
-  --mute: #656a72;
+  --mute: #5f646c;
   --rule: #dee0e5;
+  --field: #8a9099;
   --scarlet: #bb0000;
   --open: #0e7a50;
   --wait: #a65b00;
-  --closed: #767c85;
+  --closed: #686d76;
 
   --display: "Bricolage Grotesque", "Trebuchet MS", sans-serif;
   --body: "IBM Plex Sans", system-ui, sans-serif;
@@ -29,6 +30,7 @@
     --ink: #eceef2;
     --mute: #9aa1ab;
     --rule: #2c2f35;
+    --field: #6b7079;
     --scarlet: #ff5c4d;
     --open: #4cc38a;
     --wait: #e0a44a;
@@ -51,6 +53,12 @@ body {
 :focus-visible {
   outline: 2px solid var(--scarlet);
   outline-offset: 2px;
+}
+
+.search button:focus-visible { outline-color: var(--ink); }
+
+@media (forced-colors: active) {
+  :focus-visible { outline: 2px solid Highlight; }
 }
 
 .shell {
@@ -103,6 +111,7 @@ body {
 .search select,
 .search button {
   font: inherit;
+  min-height: 2.75rem;
   border-radius: var(--radius);
   border: 1px solid transparent;
   padding: 0.6rem 0.75rem;
@@ -112,14 +121,14 @@ body {
 
 .search input {
   min-width: 0;
-  border-color: var(--rule);
+  border-color: var(--field);
   background: var(--paper);
 }
 
 .search input::placeholder { color: var(--mute); }
 
 .search select {
-  border-color: var(--rule);
+  border-color: var(--field);
   background: var(--paper);
   cursor: pointer;
 }
@@ -133,7 +142,12 @@ body {
 }
 
 .search button:hover { filter: brightness(1.08); }
-.search button:disabled { opacity: 0.5; cursor: default; }
+.search button[aria-disabled="true"] {
+  background: var(--mute);
+  border-color: var(--mute);
+  cursor: default;
+}
+.search button[aria-disabled="true"]:hover { filter: none; }
 
 @media (prefers-color-scheme: dark) {
   .search button { color: #16171a; }
@@ -145,6 +159,7 @@ body {
   margin: 1rem 0 0;
   color: var(--mute);
   font-size: 0.95rem;
+  overflow-wrap: break-word;
 }
 
 .status:empty { margin: 0; }
@@ -170,6 +185,12 @@ body {
   padding: 0.9rem 1rem;
   border-bottom: 1px solid var(--rule);
 }
+
+.course-title,
+.teacher-name,
+.section-when,
+.section-where,
+.section-who { overflow-wrap: break-word; }
 
 .course-code {
   font-family: var(--display);
@@ -273,11 +294,20 @@ body {
   .section-where,
   .section-who { grid-column: 1 / -1; }
   .seats { grid-column: 1 / -1; text-align: left; }
-  .course-meta { margin-left: 0; width: 100%; }
+  .course-meta { margin-left: 0; width: 100%; white-space: normal; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * { animation: none !important; transition: none !important; }
+  html { scroll-behavior: auto !important; }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 .visually-hidden {
@@ -288,6 +318,7 @@ body {
   margin: -1px;
   overflow: hidden;
   clip: rect(0 0 0 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/index.html
+++ b/index.html
@@ -17,18 +17,26 @@
       <p class="tagline">Who teaches it, before everyone else finds out.</p>
     </header>
 
-    <form class="search" id="search" role="search">
-      <label class="visually-hidden" for="q">Course or professor</label>
-      <input id="q" name="q" type="search" autocomplete="off" placeholder="CSE 2221, or a professor's name">
+    <main>
+      <form class="search" id="search" role="search" aria-label="Course search">
+        <label class="visually-hidden" for="q">Course or professor</label>
+        <input id="q" name="q" type="search" autocomplete="off" autocapitalize="none"
+               autocorrect="off" spellcheck="false" enterkeyhint="search"
+               aria-controls="results" aria-describedby="status"
+               placeholder="CSE 2221, or a professor's name">
 
-      <label class="visually-hidden" for="term">Term</label>
-      <select id="term" name="term" disabled></select>
+        <label class="visually-hidden" for="term">Term</label>
+        <select id="term" name="term" disabled></select>
 
-      <button id="go" type="submit">Search</button>
-    </form>
+        <button id="go" type="submit">Search</button>
+      </form>
 
-    <p class="status" id="status" role="status" aria-live="polite"></p>
-    <div class="results" id="results"></div>
+      <!-- Stays in the DOM at all times, empty or not. A live region that is
+           added or unhidden at announce time is usually not announced. -->
+      <p class="status" id="status" role="status" aria-live="polite" aria-atomic="true"></p>
+
+      <div class="results" id="results" role="region" aria-label="Search results" tabindex="-1"></div>
+    </main>
   </div>
 
   <script type="module" src="js/app.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -14,9 +14,18 @@ const els = {
 let terms = [];
 let latestRequest = 0;
 
+// The status element is never removed or hidden, only its text changes. A live
+// region that was hidden when content arrived usually goes unannounced.
 function setStatus(message, kind = "info") {
   els.status.textContent = message ?? "";
   els.status.dataset.kind = kind;
+}
+
+// aria-disabled, not the disabled property: searching by pressing Enter leaves
+// focus on the button, and disabling it would throw that focus back to the body.
+function setBusy(busy) {
+  els.submit.setAttribute("aria-disabled", String(busy));
+  els.results.setAttribute("aria-busy", String(busy));
 }
 
 function syncUrl(q, term) {
@@ -34,7 +43,7 @@ async function runSearch(q, term) {
   }
 
   const requestId = ++latestRequest;
-  els.submit.disabled = true;
+  setBusy(true);
   setStatus("Searching...");
   try {
     const { courses } = await searchAllPages({ q, term });
@@ -54,7 +63,7 @@ async function runSearch(q, term) {
     setStatus(error instanceof ApiError ? error.message : "Something went wrong. Try again.", "error");
     if (!(error instanceof ApiError)) console.error(error);
   } finally {
-    if (requestId === latestRequest) els.submit.disabled = false;
+    if (requestId === latestRequest) setBusy(false);
   }
 }
 
@@ -64,6 +73,7 @@ function termName(code) {
 
 async function init() {
   const params = new URLSearchParams(location.search);
+  setBusy(false);
   setStatus("Loading terms...");
   els.term.disabled = true;
 
@@ -93,6 +103,7 @@ async function init() {
 
   els.form.addEventListener("submit", (event) => {
     event.preventDefault();
+    if (els.submit.getAttribute("aria-disabled") === "true") return;
     const q = els.query.value;
     syncUrl(q, els.term.value);
     runSearch(q, els.term.value);


### PR DESCRIPTION
Closes #9

A correctness pass over the phone and assistive-tech paths. No palette
rework, no type changes, no layout concept changes, no renamed classes.

## How this was measured

Chrome ignores `--window-size` for layout in `--headless=new`, `innerWidth`
stays pinned at 500 and the screenshot gets cropped, so narrow captures look
broken when the page is fine. Everything below was measured inside iframes of
a fixed CSS pixel width, reading
`iframe.contentDocument.documentElement.scrollWidth` and `clientWidth` and
listing any element whose `getBoundingClientRect().right` runs past
`clientWidth`. Query used was `?q=CSE 2221&term=1268`, with the "Show N
related courses" disclosure forced open so its contents were measured too.
`clientWidth` sits 15px under the iframe width because the desktop scrollbar
takes that room, so the real test is narrower than the label.

## Overflow, before and after

Baseline is `4b892ee` on main, after is this branch.

| width | before scrollWidth / clientWidth | overflow | after scrollWidth / clientWidth | overflow | offending elements |
|---|---|---|---|---|---|
| 320 | 305 / 305 | 0px | 305 / 305 | 0px | none |
| 360 | 345 / 345 | 0px | 345 / 345 | 0px | none |
| 390 | 375 / 375 | 0px | 375 / 375 | 0px | none |
| 414 | 399 / 399 | 0px | 399 / 399 | 0px | none |
| 768 | 753 / 753 | 0px | 753 / 753 | 0px | none |
| 1100 | 1085 / 1085 | 0px | 1085 / 1085 | 0px | none |

Main was already clean here, so this is a hold-the-line result rather than a
fix. To keep it true against real API data, long unbroken strings in course
titles, instructor names, room codes and the status line now wrap. Stress
test at 360: a 99 character unbroken token dropped into the title, the
instructor heading, the room line and the status line left scrollWidth at
345 against a clientWidth of 345.

Control sizes at 360, all at or above the 44px touch target:

| control | before | after |
|---|---|---|
| search input | 295x45 | 295x45 |
| term select | 295x43 | 295x44 |
| Search button | 295x45 | 295x45 |
| related courses summary | 311x47 | 311x46 |

## Keyboard

Every interactive element, in DOM order, focused and inspected in both
schemes. All four are reachable, all four match `:focus-visible`, all four
paint a ring.

| element | reachable | ring, light | ring, dark | size |
|---|---|---|---|---|
| `input#q` | yes | 2px solid `#bb0000`, offset 2px | 2px solid `#ff5c4d`, offset 2px | 295x45 |
| `select#term` | yes | 2px solid `#bb0000`, offset 2px | 2px solid `#ff5c4d`, offset 2px | 295x44 |
| `button#go` | yes | 2px solid `#16171a`, offset 2px | 2px solid `#eceef2`, offset 2px | 295x45 |
| `summary` (Show N related courses) | yes | 2px solid `#bb0000`, offset 2px | 2px solid `#ff5c4d`, offset 2px | 311x46 |

Nothing else inside `#results` takes focus, so there is no tab trap in a
thousand-section result.

The real keyboard bug was the busy state. Searching by pressing Enter leaves
focus on the Search button, and the old code set `submit.disabled = true`,
which drops focus to the body. Measured on main: focus the button, set
`.disabled`, `document.activeElement` becomes `BODY`. It now uses
`aria-disabled` and the submit handler ignores repeat submits while a request
is in flight. Measured on this branch, sampled synchronously at submit:

```
before submit: activeElement=#go
busy:          activeElement=#go  aria-disabled=true  disabledProp=false
               results aria-busy=true  status="Searching..."
after settle:  activeElement=#go  aria-disabled=false results aria-busy=false
```

The ring on the Search button was scarlet on a scarlet button. It is ink now,
so the ring and the thing it marks are not the same colour. A
`forced-colors: active` block keeps a ring in Windows high contrast, where
author outline colours are dropped.

## Screen readers

- `main` now wraps the form, status and results, `role="search"` is labelled,
  and results is a labelled region carrying `aria-busy` while a search runs.
- The status paragraph is a permanent live region. It is never hidden, never
  replaced, never removed, only its text changes. A live region that was
  hidden at the moment content landed in it usually goes unannounced. Verified
  in the DOM after an empty-query submit: `inDOM=true hidden=false
  role=status aria-live=polite aria-atomic=true display=block`.
- `aria-atomic="true"` so the whole count is read rather than a diffed
  fragment, and `aria-describedby` ties the field to that count.
- Mobile keyboard hints on the field: `enterkeyhint="search"`,
  `autocapitalize="none"`, `autocorrect="off"`, `spellcheck="false"`.

## Reduced motion

Verified with `--force-prefers-reduced-motion`. A test element given
`animation: spin 3s linear infinite` and `transition: opacity 2s` computes to
`animation-duration: 1e-05s`, `animation-iteration-count: 1`,
`transition-duration: 1e-05s`. The block now zeroes durations and covers
`::before` and `::after` and `scroll-behavior` instead of setting
`animation: none`, so anything that ever waits on an `animationend` event
still gets one.

## Contrast

Ratios computed from the tokens in `css/finder.css` against the backgrounds
those elements actually resolve to, read out of `getComputedStyle` in both
schemes. AA is 4.5:1 for body text and 3:1 for UI boundaries.

**Light**

| element | needs | before | after |
|---|---|---|---|
| Body text on the page | 4.5:1 | 15.87:1 pass | 15.87:1 pass |
| Body text on a course card | 4.5:1 | 17.92:1 pass | 17.92:1 pass |
| Status line | 4.5:1 | 4.82:1 pass | 5.27:1 pass |
| Status line, error state | 4.5:1 | 5.97:1 pass | 5.97:1 pass |
| Placeholder text | 4.5:1 | 5.44:1 pass | 5.96:1 pass |
| Course meta, room, section number | 4.5:1 | 5.44:1 pass | 5.96:1 pass |
| Related courses summary | 4.5:1 | 5.44:1 pass | 5.96:1 pass |
| Component pill on the sunk fill | 4.5:1 | 4.48:1 **fail** | 4.90:1 pass |
| Instructor heading | 4.5:1 | 17.92:1 pass | 17.92:1 pass |
| Status chip, open | 4.5:1 | 5.36:1 pass | 5.36:1 pass |
| Status chip, waitlist | 4.5:1 | 5.10:1 pass | 5.10:1 pass |
| Status chip, closed | 4.5:1 | 4.21:1 **fail** | 5.20:1 pass |
| Search button label | 4.5:1 | 6.75:1 pass | 6.75:1 pass |
| Search button label while busy | 4.5:1 | 5.44:1 pass | 5.96:1 pass |
| Input and select border | 3.0:1 | 1.32:1 **fail** | 3.22:1 pass |
| Focus ring on input, select, summary | 3.0:1 | 6.75:1 pass | 6.75:1 pass |
| Focus ring on the Search button | 3.0:1 | 6.75:1 pass | 17.92:1 pass |
| Card left accent | 3.0:1 | 6.75:1 pass | 6.75:1 pass |

**Dark**

| element | needs | before | after |
|---|---|---|---|
| Body text on the page | 4.5:1 | 14.69:1 pass | 14.69:1 pass |
| Body text on a course card | 4.5:1 | 15.86:1 pass | 15.86:1 pass |
| Status line | 4.5:1 | 6.55:1 pass | 6.55:1 pass |
| Status line, error state | 4.5:1 | 5.60:1 pass | 5.60:1 pass |
| Placeholder text | 4.5:1 | 7.07:1 pass | 7.07:1 pass |
| Course meta, room, section number | 4.5:1 | 7.07:1 pass | 7.07:1 pass |
| Related courses summary | 4.5:1 | 7.07:1 pass | 7.07:1 pass |
| Component pill on the sunk fill | 4.5:1 | 5.89:1 pass | 5.89:1 pass |
| Instructor heading | 4.5:1 | 15.86:1 pass | 15.86:1 pass |
| Status chip, open | 4.5:1 | 8.32:1 pass | 8.32:1 pass |
| Status chip, waitlist | 4.5:1 | 8.40:1 pass | 8.40:1 pass |
| Status chip, closed | 4.5:1 | 5.50:1 pass | 5.50:1 pass |
| Search button label | 4.5:1 | 5.88:1 pass | 5.88:1 pass |
| Search button label while busy | 4.5:1 | 6.88:1 pass | 6.88:1 pass |
| Input and select border | 3.0:1 | 1.37:1 **fail** | 3.70:1 pass |
| Focus ring on input, select, summary | 3.0:1 | 6.04:1 pass | 6.04:1 pass |
| Focus ring on the Search button | 3.0:1 | 6.04:1 pass | 15.86:1 pass |
| Card left accent | 3.0:1 | 6.04:1 pass | 6.04:1 pass |

Four failures, three of them in light. Fixes:

- `--mute` light `#656a72` to `#5f646c`, a 9 percent luminance drop that
  takes the component pill from 4.48:1 to 4.90:1 on the sunk fill and lifts
  every other muted line with it.
- `--closed` light `#767c85` to `#686d76`, 4.21:1 to 5.20:1.
- New `--field` token for input and select borders, `#8a9099` light and
  `#6b7079` dark. Those borders are the only thing that says where the field
  is, and `--rule` at 1.32:1 and 1.37:1 is a divider weight, not a control
  boundary. `--rule` itself is unchanged and still draws the card dividers,
  which are decoration rather than UI components.

The Search button focus ring is measured against the 2px gap of card
background it sits in, which is what it is adjacent to. The ring does not
touch the scarlet fill.

Everything passes after.

## Not changed

- Card and divider borders stay at `--rule`. They are decorative separators,
  not UI component boundaries, so 1.4.11 does not apply to them and darkening
  them would be a visual redesign.
- No ring colour clears 3:1 against both white paper and the scarlet fill in
  light mode without going to near black, so the button uses the layered
  arrangement instead: scarlet fill, then a 2px gap of paper at 6.75:1
  against the fill, then a 2px ink ring at 17.92:1 against that gap.
