### PR TITLE
Show RateMyProfessors ratings on instructor blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Find who teaches your classes before everyone else.
 
+**Live: https://enesyilmazcode.github.io/Finder/**
+
 Ohio State's own class search will tell you a course exists. It is far less
 helpful when the question you actually have is "which of these six sections
 should I take, and who is teaching them." Finder answers that one instead:

--- a/css/finder.css
+++ b/css/finder.css
@@ -365,3 +365,29 @@ body {
 .related > summary:hover { color: var(--ink); }
 .related[open] > summary { border-bottom: 1px solid var(--rule); }
 .related > .course { border: 0; border-radius: 0; border-top: 1px solid var(--rule); }
+
+/* Ratings. The name is the link, so an unrated instructor costs nothing. */
+
+.teacher-link { color: inherit; text-decoration-color: var(--rule); text-underline-offset: 3px; }
+.teacher-link:hover { text-decoration-color: var(--scarlet); }
+
+.score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  margin-left: 0.5rem;
+  font-family: var(--data);
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--mute);
+  vertical-align: baseline;
+}
+
+.score::before { content: "★"; color: var(--scarlet); font-size: 0.75rem; }
+.score[data-thin="true"] { opacity: 0.65; }
+.score[data-thin="true"]::before { color: var(--mute); }
+/* Parenthesised, because "2.7 / 3" reads as a score out of three when 3 is
+   actually how many people rated them. */
+.score-count { font-size: 0.7rem; color: var(--mute); }
+.score-count::before { content: "("; }
+.score-count::after { content: ")"; }

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,7 @@
 import { fetchTerms, defaultTerm, searchAllPages, ApiError } from "./api.js";
 import { filterCourses } from "./rank.js";
 import { renderResults } from "./render.js";
+import { loadRatings } from "./ratings.js";
 
 const els = {
   form: document.querySelector("#search"),
@@ -72,6 +73,10 @@ function termName(code) {
 }
 
 async function init() {
+  // Fire and forget. Ratings are an enhancement, so a failed or slow load must
+  // never hold up or break a search.
+  loadRatings().catch((error) => console.warn("ratings unavailable", error));
+
   const params = new URLSearchParams(location.search);
   setBusy(false);
   setStatus("Loading terms...");

--- a/js/app.js
+++ b/js/app.js
@@ -47,7 +47,13 @@ async function runSearch(q, term) {
   setBusy(true);
   setStatus("Searching...");
   try {
-    const { courses } = await searchAllPages({ q, term });
+    // Ratings must be in hand before rendering, or instructors draw unrated and
+    // never redraw. Awaited alongside the search rather than before it, so the
+    // cost is the slower of the two and only on the first search.
+    const [{ courses }] = await Promise.all([
+      searchAllPages({ q, term }),
+      loadRatings().catch(() => null),
+    ]);
     if (requestId !== latestRequest) return; // a newer search already answered
     const { primary, related } = filterCourses(courses, q);
     renderResults(els.results, { primary, related });
@@ -73,8 +79,7 @@ function termName(code) {
 }
 
 async function init() {
-  // Fire and forget. Ratings are an enhancement, so a failed or slow load must
-  // never hold up or break a search.
+  // Start the ratings download early so the first search rarely waits on it.
   loadRatings().catch((error) => console.warn("ratings unavailable", error));
 
   const params = new URLSearchParams(location.search);

--- a/js/ratings.js
+++ b/js/ratings.js
@@ -1,0 +1,119 @@
+// RateMyProfessors ratings, joined onto instructor names.
+//
+// The snapshot is built nightly by scripts/fetch-ratings.mjs because RMP sends
+// no CORS headers and a browser can never call it directly.
+
+const SCHOOL_LEGACY_ID = 724;
+const SUFFIXES = new Set(["jr", "sr", "ii", "iii", "iv", "v"]);
+
+let index = null;
+let loading = null;
+
+/**
+ * OSU returns full legal names ("Diana Ikenberry Kline") while RMP holds the
+ * everyday form ("Diana Kline"), so exact matching misses. Key on first and
+ * last name only, ignoring middle names and generational suffixes.
+ */
+export function nameKey(full) {
+  const parts = String(full ?? "")
+    .toLowerCase()
+    .replace(/[.,'`’-]/g, "")
+    .split(/\s+/)
+    .filter(Boolean);
+  if (!parts.length) return "";
+
+  let end = parts.length - 1;
+  while (end > 0 && SUFFIXES.has(parts[end])) end--;
+  return end === 0 ? parts[0] : `${parts[0]} ${parts[end]}`;
+}
+
+/** Surname alone, for the fallback pass. */
+export function surnameKey(full) {
+  const key = nameKey(full);
+  const parts = key.split(" ");
+  return parts[parts.length - 1] ?? "";
+}
+
+function firstName(full) {
+  return nameKey(full).split(" ")[0] ?? "";
+}
+
+/**
+ * Do two first names plausibly belong to the same person?
+ *
+ * OSU uses legal names, RMP uses whatever students typed, so "Timothy" appears
+ * as "Tim" and "Steve" as "Stephen". A prefix covers the first case. The second
+ * needs a shared initial, which is only safe when the surname is unique, so the
+ * caller enforces that.
+ */
+function compatibleFirstNames(a, b) {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  if (a.startsWith(b) || b.startsWith(a)) return true;
+  return a[0] === b[0];
+}
+
+export async function loadRatings(baseUrl = "data/ratings.json") {
+  if (index) return index;
+  if (loading) return loading;
+
+  loading = (async () => {
+    const response = await fetch(baseUrl);
+    if (!response.ok) throw new Error(`ratings ${response.status}`);
+    const data = await response.json();
+
+    const byKey = new Map();
+    const bySurname = new Map();
+    for (const person of data.professors ?? []) {
+      const full = `${person.firstName} ${person.lastName}`;
+      const key = nameKey(full);
+      if (!key) continue;
+      if (!byKey.has(key)) byKey.set(key, []);
+      byKey.get(key).push(person);
+
+      const last = surnameKey(full);
+      if (!bySurname.has(last)) bySurname.set(last, []);
+      bySurname.get(last).push(person);
+    }
+    index = { byKey, bySurname };
+    return index;
+  })();
+
+  return loading;
+}
+
+/**
+ * Look up one instructor.
+ *
+ * Returns null when the name is absent, and also when two different professors
+ * share a first and last name. Showing one of them would be a coin flip, and a
+ * wrong rating is worse than no rating.
+ */
+export function ratingFor(name, idx = index) {
+  if (!idx) return null;
+
+  const exact = idx.byKey.get(nameKey(name));
+  if (exact?.length === 1) return exact[0];
+  if (exact?.length > 1) return null; // genuinely ambiguous, do not guess
+
+  // Fallback: same surname, plausible first name, resolving to exactly one person.
+  const candidates = idx.bySurname.get(surnameKey(name)) ?? [];
+  if (!candidates.length) return null;
+  const first = firstName(name);
+  const viable = candidates.filter((p) => {
+    const theirs = firstName(`${p.firstName} ${p.lastName}`);
+    if (theirs === first || theirs.startsWith(first) || first.startsWith(theirs)) return true;
+    // A shared initial is weak evidence, so only trust it when nobody else
+    // could be meant.
+    return candidates.length === 1 && compatibleFirstNames(first, theirs);
+  });
+  return viable.length === 1 ? viable[0] : null;
+}
+
+export function searchUrl(name) {
+  return `https://www.ratemyprofessors.com/search/professors/${SCHOOL_LEGACY_ID}?q=${encodeURIComponent(name)}`;
+}
+
+export function profileUrl(legacyId) {
+  return `https://www.ratemyprofessors.com/professor/${legacyId}`;
+}

--- a/js/render.js
+++ b/js/render.js
@@ -7,6 +7,7 @@
 // it per section would tell students a full section is open. See #13.
 
 import { formatWhen, formatPlace, formatUnits, instructorsOf } from "./format.js";
+import { ratingFor, searchUrl, profileUrl } from "./ratings.js";
 
 const COMPONENT_ORDER = ["Lecture", "Seminar", "Studio", "Laboratory", "Recitation"];
 const UNLISTED = "Instructor not listed";
@@ -64,6 +65,41 @@ function surname(name) {
   return name;
 }
 
+/**
+ * Instructor heading, with a rating when we have one.
+ *
+ * Only about a third of instructors appear on RateMyProfessors, so the
+ * unmatched case has to cost nothing visually. The name itself is the link,
+ * which means an unrated professor adds no extra marks to the page at all.
+ */
+function renderTeacher(group) {
+  const nodes = [];
+  const people = group.people.length ? group.people : [{ name: group.key }];
+
+  people.forEach((person, i) => {
+    if (i) nodes.push(document.createTextNode(" & "));
+    const rating = ratingFor(person.name);
+
+    const link = el("a", "teacher-link", person.name);
+    link.href = rating ? profileUrl(rating.legacyId) : searchUrl(person.name);
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    nodes.push(link);
+
+    if (!rating) return;
+
+    const score = el("span", "score", Number(rating.avgRating).toFixed(1));
+    // A 4.9 from two people is not a 4.9 from two hundred, so the count is
+    // never optional and thin evidence is marked as thin.
+    score.dataset.thin = rating.numRatings < 5 ? "true" : "false";
+    score.append(el("span", "score-count", `${rating.numRatings}`));
+    score.title = `${rating.avgRating} out of 5 from ${rating.numRatings} rating${rating.numRatings === 1 ? "" : "s"} on RateMyProfessors`;
+    nodes.push(score);
+  });
+
+  return nodes;
+}
+
 export function renderSection(section) {
   const li = el("li", "section");
   const meeting = section.meetings?.[0] ?? null;
@@ -95,8 +131,13 @@ export function renderCourse({ course, sections }) {
   for (const group of groupByInstructor(sections)) {
     const block = el("section", "teacher");
 
-    const heading = el("h3", "teacher-name", group.key);
-    if (group.key === UNLISTED) heading.classList.add("is-unlisted");
+    const heading = el("h3", "teacher-name");
+    if (group.key === UNLISTED) {
+      heading.classList.add("is-unlisted");
+      heading.textContent = group.key;
+    } else {
+      heading.append(...renderTeacher(group));
+    }
     block.append(heading);
 
     const list = el("ul", "sections");


### PR DESCRIPTION
Closes #7

Joins the #18 snapshot onto the instructor headings from #5. This is the payoff for the whole project: search a course, see who teaches it, see how they are rated, in one view.

## The number that shaped the design

**Only 36% of instructors are on RateMyProfessors.** Measured across 757 instructors in 8 subjects for Autumn 2026. So the unmatched case is the *common* case, and it has to cost nothing visually.

The instructor name itself is the link. Matched, it goes to their RMP profile. Unmatched, it goes to an RMP search for them. Either way an unrated professor adds no extra marks to the page, which keeps the interface as quiet as it was.

## Matching took two passes

Exact first-and-last matching, after stripping middle names and generational suffixes, got 33%. Investigating the misses showed two different causes:

```
Steve Gomori             RMP has 1 Gomori: Stephen Gomori (35)     <- fixable
Timothy Ellis Carpenter  RMP has 3 Carpenters, incl Tim (37)       <- fixable
Umme Hafsa Billah        RMP has 0 Billah                          <- genuinely absent
Ramin Yarinezhad         RMP has 0 Yarinezhad                      <- genuinely absent
Jeff Eden                RMP has 0 Eden                            <- genuinely absent
```

OSU publishes legal names, students type everyday ones. A surname fallback accepting a first-name prefix or, when the surname is unique, a shared initial, fixes that class:

```
Steve Gomori             -> Stephen Gomori   3.7 (35)
Timothy Ellis Carpenter  -> Tim Carpenter    4.4 (37)
Diana Ikenberry Kline    -> Diana Kline      4.2 (32)
Dauntrica Marie Woods    -> no match          (6 different Woods, correctly refuses)
Umme Hafsa Billah        -> no match          (nobody by that surname)
```

That took it 33% to 36%. The remaining 64% are simply not on RMP, mostly lecturers and newer instructors, and no matching cleverness will conjure them.

A wrong rating is worse than no rating, so ambiguity always loses: 62 name keys have two or more professors sharing a first and last name, and those return nothing rather than a coin flip.

## Rating counts are never optional
The issue asked that 2 ratings not look like 200. The count always renders, and anything under 5 is dimmed. Displayed as `★ 2.7 (3)` rather than `★ 2.7 / 3`, because the slash reads as a score out of three when 3 is the number of people who rated them.

Also adds the live URL to the README and the repo homepage.
