### PR TITLE
Show real seat counts from the Barrett snapshot

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -391,3 +391,21 @@ body {
 .score-count { font-size: 0.7rem; color: var(--mute); }
 .score-count::before { content: "("; }
 .score-count::after { content: ")"; }
+
+/* Seat counts. Full is the state worth spotting while scanning ten sections. */
+
+.seats {
+  grid-column: 3;
+  font-family: var(--data);
+  font-size: 0.78rem;
+  color: var(--mute);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.seats[data-state="full"] { color: var(--scarlet); font-weight: 500; }
+.waitlist { margin-left: 0.25rem; opacity: 0.85; }
+
+@media (max-width: 34rem) {
+  .seats { grid-column: 1 / -1; text-align: left; }
+}

--- a/css/finder.css
+++ b/css/finder.css
@@ -241,38 +241,6 @@ body {
 
 .section-who { color: var(--ink); }
 
-.chip {
-  font-family: var(--data);
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  white-space: nowrap;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.chip::before {
-  content: "";
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: currentColor;
-}
-
-.chip[data-kind="open"] { color: var(--open); }
-.chip[data-kind="wait"] { color: var(--wait); }
-.chip[data-kind="closed"] { color: var(--closed); }
-.chip[data-kind="unknown"] { color: var(--mute); }
-
-.seats {
-  grid-column: 3;
-  font-family: var(--data);
-  font-size: 0.78rem;
-  color: var(--mute);
-  text-align: right;
-}
-
 .component {
   font-family: var(--data);
   font-size: 0.72rem;

--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,7 @@ import { fetchTerms, defaultTerm, searchAllPages, ApiError } from "./api.js";
 import { filterCourses } from "./rank.js";
 import { renderResults } from "./render.js";
 import { loadRatings } from "./ratings.js";
+import { loadSeats, seatsTerm, seatsUpdated } from "./seats.js";
 
 const els = {
   form: document.querySelector("#search"),
@@ -53,16 +54,20 @@ async function runSearch(q, term) {
     const [{ courses }] = await Promise.all([
       searchAllPages({ q, term }),
       loadRatings().catch(() => null),
+      loadSeats().catch(() => null),
     ]);
     if (requestId !== latestRequest) return; // a newer search already answered
     const { primary, related } = filterCourses(courses, q);
-    renderResults(els.results, { primary, related });
+    renderResults(els.results, { primary, related }, term);
     if (!primary.length) {
       setStatus(`Nothing matched "${q}" in ${termName(term)}. Try a subject and number, like CSE 2221.`);
     } else {
       const sections = primary.reduce((n, e) => n + e.sections.length, 0);
       const noun = primary.length === 1 ? "course" : "courses";
-      setStatus(`${primary.length} ${noun}, ${sections} sections in ${termName(term)}.`);
+      // Barrett refreshes once a day, so the numbers are dated, and during a
+      // registration window that distinction matters.
+      const dated = seatsTerm() === term && seatsUpdated() ? ` Seats as of ${formatDate(seatsUpdated())}.` : "";
+      setStatus(`${primary.length} ${noun}, ${sections} sections in ${termName(term)}.${dated}`);
     }
   } catch (error) {
     if (requestId !== latestRequest) return;
@@ -74,6 +79,13 @@ async function runSearch(q, term) {
   }
 }
 
+function formatDate(iso) {
+  const date = new Date(`${iso}T12:00:00`);
+  return Number.isNaN(date.getTime())
+    ? iso
+    : date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
 function termName(code) {
   return terms.find((t) => t.code === code)?.name ?? code;
 }
@@ -81,6 +93,7 @@ function termName(code) {
 async function init() {
   // Start the ratings download early so the first search rarely waits on it.
   loadRatings().catch((error) => console.warn("ratings unavailable", error));
+  loadSeats().catch((error) => console.warn("seats unavailable", error));
 
   const params = new URLSearchParams(location.search);
   setBusy(false);

--- a/js/render.js
+++ b/js/render.js
@@ -8,6 +8,7 @@
 
 import { formatWhen, formatPlace, formatUnits, instructorsOf } from "./format.js";
 import { ratingFor, searchUrl, profileUrl } from "./ratings.js";
+import { seatsFor } from "./seats.js";
 
 const COMPONENT_ORDER = ["Lecture", "Seminar", "Studio", "Laboratory", "Recitation"];
 const UNLISTED = "Instructor not listed";
@@ -100,7 +101,7 @@ function renderTeacher(group) {
   return nodes;
 }
 
-export function renderSection(section) {
+export function renderSection(section, term) {
   const li = el("li", "section");
   const meeting = section.meetings?.[0] ?? null;
 
@@ -113,10 +114,23 @@ export function renderSection(section) {
 
   li.append(el("span", "section-where", formatPlace(meeting, section)));
 
+  // Absent means unknown, never zero. A section with no snapshot row simply
+  // shows nothing rather than implying it is empty.
+  const seats = seatsFor(section.classNumber, term);
+  if (seats) {
+    const node = el("span", "seats", `${seats.enrolled}/${seats.limit}`);
+    node.dataset.state = seats.full ? "full" : "open";
+    if (seats.waitlist > 0) node.append(el("span", "waitlist", `+${seats.waitlist}`));
+    node.title = seats.full
+      ? `Full. ${seats.enrolled} enrolled of ${seats.limit}${seats.waitlist ? `, ${seats.waitlist} waiting` : ""}.`
+      : `${seats.enrolled} enrolled of ${seats.limit}.`;
+    li.append(node);
+  }
+
   return li;
 }
 
-export function renderCourse({ course, sections }) {
+export function renderCourse({ course, sections }, term) {
   const article = el("article", "course");
 
   const head = el("header", "course-head");
@@ -141,7 +155,7 @@ export function renderCourse({ course, sections }) {
     block.append(heading);
 
     const list = el("ul", "sections");
-    for (const section of sortSections(group.sections)) list.append(renderSection(section));
+    for (const section of sortSections(group.sections)) list.append(renderSection(section, term));
     block.append(list);
 
     article.append(block);
@@ -150,8 +164,8 @@ export function renderCourse({ course, sections }) {
   return article;
 }
 
-export function renderResults(container, { primary, related }) {
-  const nodes = primary.map(renderCourse);
+export function renderResults(container, { primary, related }, term) {
+  const nodes = primary.map((entry) => renderCourse(entry, term));
 
   if (related?.length) {
     const details = el("details", "related");
@@ -164,7 +178,7 @@ export function renderResults(container, { primary, related }) {
     details.addEventListener("toggle", () => {
       if (built || !details.open) return;
       built = true;
-      details.append(...related.map(renderCourse));
+      details.append(...related.map((entry) => renderCourse(entry, term)));
     });
 
     nodes.push(details);

--- a/js/seats.js
+++ b/js/seats.js
@@ -1,0 +1,57 @@
+// Per-section seat counts from Barrett's schedule, snapshotted daily by
+// scripts/fetch-seats.mjs.
+//
+// OSU's own API cannot supply these: it reports one enrollment figure per
+// course and repeats it onto every section, so it calls a 41/40 section "Open".
+// See docs/osu-api.md.
+
+let snapshot = null;
+let loading = null;
+
+export async function loadSeats(url = "data/seats.json") {
+  if (snapshot) return snapshot;
+  if (loading) return loading;
+
+  loading = (async () => {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`seats ${response.status}`);
+    snapshot = await response.json();
+    return snapshot;
+  })();
+
+  return loading;
+}
+
+/** The term this snapshot covers, or null if nothing is loaded. */
+export function seatsTerm() {
+  return snapshot?.term ?? null;
+}
+
+/** The date Barrett last refreshed, for labelling the numbers as day-old. */
+export function seatsUpdated() {
+  return snapshot?.sourceUpdated ?? null;
+}
+
+/**
+ * Seats for one section, or null when unknown.
+ *
+ * The term guard is the important part. The snapshot holds a single term while
+ * the UI offers three, and showing Autumn seats against a Spring section would
+ * be confidently wrong, which is worse than showing nothing. A class number
+ * that is simply absent is also unknown, never zero.
+ */
+export function seatsFor(classNumber, term) {
+  if (!snapshot || !term || String(snapshot.term) !== String(term)) return null;
+  const row = snapshot.sections?.[String(classNumber)];
+  if (!Array.isArray(row) || row.length < 2) return null;
+
+  const [enrolled, limit, waitlist = 0] = row;
+  if (typeof enrolled !== "number" || typeof limit !== "number") return null;
+
+  return {
+    enrolled,
+    limit,
+    waitlist,
+    full: limit > 0 && enrolled >= limit,
+  };
+}


### PR DESCRIPTION
Closes #21

Wires #19's snapshot onto section rows. This closes the loop opened back in #13, where seat counts were pulled out of the UI because OSU's API reports them wrong.

## The result that justifies the whole detour

CSE 2221, Autumn 2026, rendered from real data:

```
sections   : 22
with seats : 22
FULL       : 18
waitlisted :  6
status     : 1 course, 22 sections in Autumn 2026. Seats as of Aug 18.
```

**18 of the 22 sections are full.** OSU's own API calls all 22 of them "Open" with "32 enrolled". Anyone planning around that would pick a section that filled weeks ago.

## Term guard

The requirement most likely to be skipped and most likely to produce confident lies. The snapshot holds one term (`1268`) while the selector offers three, so `seatsFor()` refuses unless `snapshot.term` matches the selected term. Verified by switching:

```
Autumn 2026 (1268)   22 sections   22 with seats   "Seats as of Aug 18."
Spring 2026 (1262)   26 sections    0 with seats   no date claim
```

Spring shows no seats rather than Autumn's seats, and the status line drops the freshness claim too, since claiming a date for data you are not showing is its own small lie.

## Other requirements
- **Missing means unknown.** A class number absent from the snapshot renders nothing. Never `0/0`, never an empty bar.
- **Freshness is stated.** Barrett refreshes once daily around 06:50 Eastern, so the status line says `Seats as of Aug 18` rather than implying live seats.
- **Full is scannable.** Full sections render in scarlet with the waitlist appended, so scanning ten sections for the one you can still get into does not require reading every number.
