### PR TITLE
Add three layout wireframes for the full-width revamp

### DIFF
--- a/wireframes/README.md
+++ b/wireframes/README.md
@@ -1,0 +1,17 @@
+# Layout wireframes
+
+Three answers to the same complaint: the current single-column layout wastes the
+left and right thirds of a desktop screen, and everything is crammed into a
+narrow vertical strip.
+
+Open them directly:
+
+- [A. Three pane](a-three-pane.html) — filters, results, detail
+- [B. Compare board](b-compare.html) — one row per instructor
+- [C. Schedule grid](c-schedule.html) — sections plotted on a week
+
+All three share the same left rail: subject and course-number dropdowns that
+autocomplete, so you do not need to know that Foundations II is CSE 2331.
+
+Static mockups with sample data from CSE 2331, Autumn 2026. Nothing here is
+wired to the live API.

--- a/wireframes/a-three-pane.html
+++ b/wireframes/a-three-pane.html
@@ -1,0 +1,115 @@
+<!doctype html><meta charset=utf-8><link rel=stylesheet href=shared.css>
+<style>
+.app{grid-template-columns:264px 1fr 372px;grid-template-rows:auto 1fr}
+.card{border:1px solid var(--rule);border-left:3px solid var(--scarlet);border-radius:3px;background:var(--panel);margin-bottom:12px}
+.chead{display:flex;align-items:baseline;gap:9px;padding:11px 13px;border-bottom:1px solid var(--rule)}
+.tblk{border-top:1px solid var(--rule)}
+.tblk:first-of-type{border-top:0}
+.tname{font-family:var(--display);font-weight:700;font-size:14px;padding:9px 13px 3px;margin:0;display:flex;align-items:center;gap:7px}
+.sec{display:grid;grid-template-columns:54px 1fr 92px;gap:2px 12px;padding:6px 13px 8px;align-items:baseline;font-size:13px}
+.sec.sel{background:#20242b;box-shadow:inset 3px 0 0 var(--scarlet)}
+.sec .n{font-family:var(--data);font-size:11.5px;color:var(--dim)}
+.sec .rm{grid-column:2;color:var(--mute);font-size:11.5px}
+.sec .s{grid-column:3;text-align:right;font-family:var(--data);font-size:11.5px;color:var(--mute)}
+.dgrp{margin-bottom:16px}
+.drow{display:flex;justify-content:space-between;font-size:12.5px;padding:5px 0;border-bottom:1px solid var(--rule)}
+.drow span:first-child{color:var(--mute)}
+.big{font-family:var(--display);font-weight:800;font-size:34px;letter-spacing:-.03em;line-height:1}
+</style>
+<div class=app>
+  <div class=topbar>
+    <p class=wordmark>Finder</p>
+    <div style="flex:1"></div>
+    <div class=ctl style="width:210px"><span class=mono>CSE 2331</span><span class=car>▾</span></div>
+    <div class=ctl style="width:150px"><span>Autumn 2026</span><span class=car>▾</span></div>
+    <span class=count>8 sections · seats Aug 18</span>
+  </div>
+
+  <aside class=rail>
+    <p class=eyebrow>Course</p>
+    <div class=field><label class=label>Subject</label><div class=ctl mono><span class=mono>CSE</span><span class=car>▾</span></div></div>
+    <div class=field><label class=label>Number</label><div class=ctl><span class=mono>2331</span><span class=car>▾</span></div>
+      <div style="border:1px solid var(--rule2);border-top:0;border-radius:0 0 3px 3px;background:var(--panel2)">
+        <div style="padding:5px 9px;font-size:12px;background:#22262d"><span class=mono>2331</span> <span style="color:var(--mute)">Foundations II</span></div>
+        <div style="padding:5px 9px;font-size:12px"><span class=mono>2321</span> <span style="color:var(--mute)">Foundations I</span></div>
+        <div style="padding:5px 9px;font-size:12px"><span class=mono>2421</span> <span style="color:var(--mute)">Systems I</span></div>
+      </div>
+    </div>
+    <div class=sep></div>
+    <p class=eyebrow>Filters</p>
+    <div class=field><label class=label>Days</label>
+      <div class=chiprow><span class="chip on">Mo</span><span class=chip>Tu</span><span class="chip on">We</span><span class=chip>Th</span><span class="chip on">Fr</span></div>
+    </div>
+    <div class=field><label class=label>Earliest start</label><div class=ctl><span class=mono>10:00a</span><span class=car>▾</span></div></div>
+    <div class=field><label class=label>Latest end</label><div class=ctl><span class=mono>4:00p</span><span class=car>▾</span></div></div>
+    <div class=field><label class=label>Minimum rating</label>
+      <div class=chiprow><span class=chip>any</span><span class=chip>3.0+</span><span class="chip on">3.5+</span><span class=chip>4.0+</span></div>
+    </div>
+    <div class=field style="margin-top:12px">
+      <div class=chk><span class="box on"></span>Hide full sections</div>
+      <div class=chk><span class=box></span>Hide online</div>
+      <div class=chk><span class="box on"></span>Rated instructors only</div>
+    </div>
+    <div class=sep></div>
+    <p class=eyebrow>Matching</p>
+    <p style="font-size:12px;color:var(--mute);margin:0">3 of 8 sections<br><span class=count>5 hidden by filters</span></p>
+  </aside>
+
+  <main class=main>
+    <div class=card>
+      <div class=chead><span class="mono" style="font-family:var(--display);font-weight:800;font-size:16px">CSE 2331</span>
+        <span style="font-weight:600">Foundations II: Data Structures and Algorithms</span>
+        <span style="margin-left:auto" class=count>3 credits · 8 sections</span></div>
+
+      <div class=tblk><h3 class=tname>Nickalaus Painter <span class="mono" style="font-size:11px;color:var(--mute)"><span class=star>★</span> 4.8 (68)</span></h3>
+        <div class="sec sel"><span class=n>5353</span><span>MoWeFr 4:10p–5:05p <span class=pill>lecture</span></span><span class="s full">50/50 +2</span><span class=rm>JR 239</span></div>
+        <div class=sec><span class=n>5377</span><span>MoWeFr 3:00p–3:55p <span class=pill>lecture</span></span><span class="s full">50/50 +3</span><span class=rm>JR 239</span></div>
+      </div>
+      <div class=tblk><h3 class=tname>Nabhan Salih <span class="mono" style="font-size:11px;color:var(--mute)"><span class=star>★</span> 2.7 (9)</span></h3>
+        <div class=sec><span class=n>10158</span><span>MoWeFr 10:20a–11:15a <span class=pill>lecture</span></span><span class="s">36/40 +1</span><span class=rm>KN 190</span></div>
+        <div class=sec><span class=n>9767</span><span>MoWeFr 1:50p–2:45p <span class=pill>lecture</span></span><span class="s ok">25/40</span><span class=rm>BE 188</span></div>
+      </div>
+      <div class=tblk><h3 class=tname style="color:var(--dim)">Ali Alilooee <span class="mono" style="font-size:11px;color:var(--dim)">no ratings</span></h3>
+        <div class=sec><span class=n>9269</span><span>MoWeFr 11:30a–12:25p <span class=pill>lecture</span></span><span class="s ok">30/40</span><span class=rm>KN 190</span></div>
+      </div>
+    </div>
+    <div style="border:1px dashed var(--rule2);border-radius:3px;padding:10px 13px;color:var(--dim);font-size:12.5px">
+      5 sections hidden by your filters. <span style="color:var(--scarlet)">Show them</span>
+    </div>
+  </main>
+
+  <aside class=detail>
+    <p class=eyebrow>Section 5353</p>
+    <h2 class=h2>Nickalaus Painter</h2>
+    <p class=sub>CSE 2331 · Lecture · 3 credits</p>
+    <div style="display:flex;gap:18px;align-items:flex-end;margin-bottom:16px">
+      <div><div class="big star">4.8</div><div class=count>68 ratings</div></div>
+      <div><div class=big>2.9</div><div class=count>difficulty</div></div>
+      <div><div class=big>91%</div><div class=count>take again</div></div>
+    </div>
+    <div class=dgrp>
+      <p class=eyebrow>Seats</p>
+      <div class=bar><i class=f style="width:100%"></i></div>
+      <div class=drow><span>Enrolled</span><span class="mono full">50 / 50</span></div>
+      <div class=drow><span>Waitlist</span><span class="mono full">2 waiting</span></div>
+      <div class=drow><span>As of</span><span class=mono>Aug 18, 6:50a</span></div>
+    </div>
+    <div class=dgrp>
+      <p class=eyebrow>Meets</p>
+      <div class=drow><span>Days</span><span class=mono>Mo We Fr</span></div>
+      <div class=drow><span>Time</span><span class=mono>4:10p – 5:05p</span></div>
+      <div class=drow><span>Room</span><span class=mono>Journalism 239</span></div>
+      <div class=drow><span>Mode</span><span>In person</span></div>
+    </div>
+    <div class=dgrp>
+      <p class=eyebrow>Also teaches</p>
+      <div class=drow><span>CSE 2331 · 5377</span><span class="mono full">50/50</span></div>
+      <div class=drow><span>CSE 5331 · 5359</span><span class="mono ok">18/25</span></div>
+      <div class=drow><span>CSE 6331 · 5363</span><span class="mono ok">9/30</span></div>
+    </div>
+    <div class=dgrp>
+      <p class=eyebrow>Description</p>
+      <p style="font-size:12.5px;color:var(--mute);margin:0">Basic data structures and algorithms. Sorting, searching, graphs, greedy and dynamic programming, complexity analysis. Prereq: 2321.</p>
+    </div>
+  </aside>
+</div>

--- a/wireframes/b-compare.html
+++ b/wireframes/b-compare.html
@@ -1,0 +1,90 @@
+<!doctype html><meta charset=utf-8><link rel=stylesheet href=shared.css>
+<style>
+.app{grid-template-columns:264px 1fr;grid-template-rows:auto 1fr}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th{font-family:var(--data);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);
+   text-align:left;padding:0 12px 8px;font-weight:400;border-bottom:1px solid var(--rule)}
+th.r,td.r{text-align:right}
+td{padding:11px 12px;border-bottom:1px solid var(--rule);vertical-align:top}
+td:last-child,th:last-child{padding-right:20px}
+tr.head td{background:var(--panel);border-bottom:1px solid var(--rule2)}
+.nm{font-family:var(--display);font-weight:700;font-size:14.5px;white-space:nowrap}
+.rate{font-family:var(--data);font-size:19px;font-weight:500}
+.sub2{font-size:11px;color:var(--dim);font-family:var(--data)}
+.slot{display:flex;gap:6px;align-items:baseline;padding:2px 0;font-size:12.5px}
+.slot .n{font-family:var(--data);font-size:11px;color:var(--dim);width:44px;flex:none}
+.meter{width:66px;height:5px;background:var(--rule2);border-radius:3px;overflow:hidden;display:inline-block;vertical-align:middle}
+.meter i{display:block;height:100%;background:var(--good)}
+.meter i.f{background:var(--scarlet)}
+.best{box-shadow:inset 3px 0 0 var(--good)}
+.tag{font-family:var(--data);font-size:9px;letter-spacing:.08em;text-transform:uppercase;color:var(--good);border:1px solid var(--good);border-radius:2px;padding:1px 4px}
+</style>
+<div class=app>
+  <div class=topbar>
+    <p class=wordmark>Finder</p>
+    <div style="flex:1"></div>
+    <div class=ctl style="width:210px"><span class=mono>CSE 2331</span><span class=car>▾</span></div>
+    <div class=ctl style="width:150px"><span>Autumn 2026</span><span class=car>▾</span></div>
+    <span class=count>comparing 4 instructors</span>
+  </div>
+
+  <aside class=rail>
+    <p class=eyebrow>Course</p>
+    <div class=field><label class=label>Subject</label><div class="ctl mono"><span>CSE</span><span class=car>▾</span></div></div>
+    <div class=field><label class=label>Number</label><div class=ctl><span class=mono>2331</span><span class=car>▾</span></div></div>
+    <div class=sep></div>
+    <p class=eyebrow>Rank instructors by</p>
+    <div class=field>
+      <div class=chk><span class="box on"></span>Rating</div>
+      <div class=chk><span class=box></span>Easiest</div>
+      <div class=chk><span class=box></span>Most seats left</div>
+      <div class=chk><span class=box></span>Earliest class</div>
+    </div>
+    <div class=sep></div>
+    <p class=eyebrow>Only show</p>
+    <div class=field>
+      <div class=chk><span class="box on"></span>Sections with seats</div>
+      <div class=chk><span class=box></span>No 8am</div>
+      <div class=chk><span class=box></span>No Friday</div>
+    </div>
+    <div class=sep></div>
+    <p class=eyebrow>Weigh confidence</p>
+    <p style="font-size:12px;color:var(--mute);margin:0 0 8px">Ignore instructors with fewer than</p>
+    <div class=chiprow><span class=chip>1</span><span class="chip on">10</span><span class=chip>25</span><span class=chip>50</span></div>
+    <p class=count style="margin-top:8px">ratings</p>
+  </aside>
+
+  <main class=main style="padding:0">
+    <div style="padding:14px 12px 6px">
+      <h2 class=h2 style="font-size:19px">CSE 2331 · Foundations II: Data Structures and Algorithms</h2>
+      <p class=sub style="margin-bottom:0">4 instructors, 8 sections, Autumn 2026. Seats as of Aug 18.</p>
+    </div>
+    <table>
+      <tr><th style="width:210px">Instructor</th><th class=r style="width:74px">Rating</th><th class=r style="width:74px">Difficulty</th>
+          <th class=r style="width:82px">Take again</th><th>Sections</th><th class=r style="width:170px">Seats</th></tr>
+
+      <tr class=best><td><div class=nm>Nickalaus Painter</div><div class=sub2>68 ratings <span class=tag style="margin-left:4px">best rated</span></div></td>
+        <td class=r><span class="rate star">4.8</span></td><td class=r><span class=rate>2.9</span></td><td class=r><span class=rate>91%</span></td>
+        <td><div class=slot><span class=n>5353</span><span>MoWeFr 4:10p</span></div><div class=slot><span class=n>5377</span><span>MoWeFr 3:00p</span></div></td>
+        <td class=r><div><span class=meter><i class=f style="width:100%"></i></span> <span class="mono full">50/50 +2</span></div>
+                    <div style="margin-top:5px"><span class=meter><i class=f style="width:100%"></i></span> <span class="mono full">50/50 +3</span></div></td></tr>
+
+      <tr><td><div class=nm>Ali Alilooee</div><div class=sub2>no ratings yet</div></td>
+        <td class=r><span class=rate style="color:var(--dim)">—</span></td><td class=r><span class=rate style="color:var(--dim)">—</span></td><td class=r><span class=rate style="color:var(--dim)">—</span></td>
+        <td><div class=slot><span class=n>5354</span><span>TuTh 2:20p</span></div><div class=slot><span class=n>8837</span><span>MoWeFr 12:40p</span></div><div class=slot><span class=n>9269</span><span>MoWeFr 11:30a</span></div></td>
+        <td class=r><div><span class=meter><i style="width:90%"></i></span> <span class=mono>38/42 +1</span></div>
+                    <div style="margin-top:5px"><span class=meter><i class=f style="width:100%"></i></span> <span class="mono full">45/45</span></div>
+                    <div style="margin-top:5px"><span class=meter><i style="width:75%"></i></span> <span class="mono ok">30/40</span></div></td></tr>
+
+      <tr><td><div class=nm>Nabhan Salih</div><div class=sub2>9 ratings · thin evidence</div></td>
+        <td class=r><span class=rate style="opacity:.6">2.7</span></td><td class=r><span class=rate style="opacity:.6">4.1</span></td><td class=r><span class=rate style="opacity:.6">33%</span></td>
+        <td><div class=slot><span class=n>10158</span><span>MoWeFr 10:20a</span></div><div class=slot><span class=n>10269</span><span>MoWeFr 9:10a</span></div><div class=slot><span class=n>9767</span><span>MoWeFr 1:50p</span></div></td>
+        <td class=r><div><span class=meter><i style="width:90%"></i></span> <span class=mono>36/40 +1</span></div>
+                    <div style="margin-top:5px"><span class=meter><i style="width:48%"></i></span> <span class="mono ok">19/40</span></div>
+                    <div style="margin-top:5px"><span class=meter><i style="width:63%"></i></span> <span class="mono ok">25/40</span></div></td></tr>
+    </table>
+    <div style="padding:12px;color:var(--dim);font-size:12.5px">
+      1 instructor hidden: fewer than 10 ratings. <span style="color:var(--scarlet)">Include them</span>
+    </div>
+  </main>
+</div>

--- a/wireframes/c-schedule.html
+++ b/wireframes/c-schedule.html
@@ -1,0 +1,124 @@
+<!doctype html><meta charset=utf-8><link rel=stylesheet href=shared.css>
+<style>
+.app{grid-template-columns:264px 1fr 320px;grid-template-rows:auto 1fr}
+.grid{display:grid;grid-template-columns:46px repeat(5,1fr);gap:0;position:relative}
+.hh{font-family:var(--data);font-size:10px;color:var(--dim);text-align:center;padding:6px 0;border-bottom:1px solid var(--rule2)}
+.hr{font-family:var(--data);font-size:9.5px;color:var(--dim);text-align:right;padding-right:6px;transform:translateY(-5px)}
+.col{border-left:1px solid var(--rule);position:relative}
+.row{border-bottom:1px solid #1e2127;height:44px}
+.ev{position:absolute;left:3px;right:3px;border-radius:3px;padding:4px 6px;font-size:11px;overflow:hidden;
+    border-left:3px solid var(--good);background:#1c2a24}
+.ev.mid{border-left-color:var(--warn);background:#2a2519}
+.ev.bad{border-left-color:var(--scarlet);background:#2a1c1a}
+.ev.mine{border-left-color:#4a4f58;background:#191c21;opacity:.55}
+.ev.sel{outline:1.5px solid var(--ink)}
+.ev b{display:block;font-family:var(--display);font-size:11.5px;font-weight:700}
+.ev span{color:var(--mute);font-family:var(--data);font-size:9.5px}
+.lg{display:flex;gap:12px;align-items:center;font-size:11px;color:var(--mute);padding:6px 0 8px}
+.dot{width:8px;height:8px;border-radius:2px;display:inline-block;margin-right:4px}
+.drow{display:flex;justify-content:space-between;font-size:12.5px;padding:5px 0;border-bottom:1px solid var(--rule)}
+.drow span:first-child{color:var(--mute)}
+.big{font-family:var(--display);font-weight:800;font-size:30px;letter-spacing:-.03em;line-height:1}
+</style>
+<div class=app>
+  <div class=topbar>
+    <p class=wordmark>Finder</p>
+    <div style="flex:1"></div>
+    <div class=ctl style="width:210px"><span class=mono>CSE 2331</span><span class=car>&#9662;</span></div>
+    <div class=ctl style="width:150px"><span>Autumn 2026</span><span class=car>&#9662;</span></div>
+    <span class=count>8 sections plotted</span>
+  </div>
+
+  <aside class=rail>
+    <p class=eyebrow>Course</p>
+    <div class=field><label class=label>Subject</label><div class="ctl mono"><span>CSE</span><span class=car>&#9662;</span></div></div>
+    <div class=field><label class=label>Number</label><div class=ctl><span class=mono>2331</span><span class=car>&#9662;</span></div></div>
+    <div class=sep></div>
+    <p class=eyebrow>My schedule</p>
+    <p style="font-size:12px;color:var(--mute);margin:0 0 9px">Added so far, drawn behind results.</p>
+    <div style="border:1px solid var(--rule2);border-radius:3px;padding:7px 9px;margin-bottom:6px;font-size:12.5px">
+      <div style="font-weight:600">MATH 2568</div><div class=count>TuTh 9:35a &middot; 5461</div></div>
+    <div style="border:1px solid var(--rule2);border-radius:3px;padding:7px 9px;margin-bottom:6px;font-size:12.5px">
+      <div style="font-weight:600">ENGR 1182</div><div class=count>MoWe 1:50p &middot; 8812</div></div>
+    <div style="border:1px dashed var(--rule2);border-radius:3px;padding:7px 9px;color:var(--dim);font-size:12.5px">+ add a course</div>
+    <div class=sep></div>
+    <p class=eyebrow>Hide</p>
+    <div class=chk><span class="box on"></span>Conflicts with my schedule</div>
+    <div class=chk><span class="box on"></span>Full sections</div>
+    <div class=chk><span class=box></span>Before 10am</div>
+    <div class=sep></div>
+    <p class=eyebrow>Colour by</p>
+    <div class=chiprow><span class="chip on">Rating</span><span class=chip>Seats</span><span class=chip>Difficulty</span></div>
+  </aside>
+
+  <main class=main>
+    <div class=lg>
+      <span><span class=dot style="background:var(--good)"></span>4.0+</span>
+      <span><span class=dot style="background:var(--warn)"></span>3.0&ndash;3.9</span>
+      <span><span class=dot style="background:var(--scarlet)"></span>under 3.0 or full</span>
+      <span style="margin-left:auto" class=count>2 sections hidden: conflict with MATH 2568</span>
+    </div>
+    <div class=grid>
+      <div>
+        <div class=hh></div>
+        <div class=row><div class=hr>9a</div></div><div class=row><div class=hr>10a</div></div>
+        <div class=row><div class=hr>11a</div></div><div class=row><div class=hr>12p</div></div>
+        <div class=row><div class=hr>1p</div></div><div class=row><div class=hr>2p</div></div>
+        <div class=row><div class=hr>3p</div></div><div class=row><div class=hr>4p</div></div>
+      </div>
+      <div class=col><div class=hh>MON</div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class="ev bad" style="top:74px;height:40px"><b>Salih</b><span>10:20a &middot; 36/40 &middot; 2.7</span></div>
+        <div class="ev mine" style="top:250px;height:40px"><b>ENGR 1182</b><span>your schedule</span></div>
+        <div class="ev bad" style="top:338px;height:40px"><b>Painter</b><span>3:00p &middot; FULL 50/50 +3</span></div>
+      </div>
+      <div class=col><div class=hh>TUE</div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class="ev mine" style="top:30px;height:40px"><b>MATH 2568</b><span>your schedule</span></div>
+        <div class="ev mid" style="top:294px;height:52px"><b>Alilooee</b><span>2:20p &middot; 38/42 +1</span></div>
+      </div>
+      <div class=col><div class=hh>WED</div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class="ev bad" style="top:74px;height:40px"><b>Salih</b><span>10:20a &middot; 36/40</span></div>
+        <div class="ev mid sel" style="top:118px;height:40px"><b>Alilooee</b><span>11:30a &middot; 30/40 &middot; open</span></div>
+        <div class="ev mine" style="top:250px;height:40px"><b>ENGR 1182</b><span>your schedule</span></div>
+      </div>
+      <div class=col><div class=hh>THU</div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class="ev mine" style="top:30px;height:40px"><b>MATH 2568</b><span>your schedule</span></div>
+        <div class="ev mid" style="top:294px;height:52px"><b>Alilooee</b><span>2:20p &middot; 38/42 +1</span></div>
+      </div>
+      <div class=col><div class=hh>FRI</div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class=row></div><div class=row></div><div class=row></div><div class=row></div>
+        <div class="ev bad" style="top:74px;height:40px"><b>Salih</b><span>10:20a &middot; 36/40</span></div>
+        <div class="ev mid sel" style="top:118px;height:40px"><b>Alilooee</b><span>11:30a &middot; 30/40</span></div>
+        <div class="ev bad" style="top:338px;height:40px"><b>Painter</b><span>3:00p &middot; FULL</span></div>
+      </div>
+    </div>
+  </main>
+
+  <aside class=detail>
+    <p class=eyebrow>Section 9269</p>
+    <h2 class=h2>Ali Alilooee</h2>
+    <p class=sub>MoWeFr 11:30a&ndash;12:25p &middot; KN 190</p>
+    <div style="display:flex;gap:20px;align-items:flex-end;margin-bottom:14px">
+      <div><div class=big style="color:var(--dim)">&mdash;</div><div class=count>no ratings</div></div>
+      <div><div class="big ok">10</div><div class=count>seats left</div></div>
+    </div>
+    <div class=bar style="margin-bottom:14px"><i style="width:75%"></i></div>
+    <div class=drow><span>Enrolled</span><span class=mono>30 / 40</span></div>
+    <div class=drow><span>Waitlist</span><span class=mono>none</span></div>
+    <div class=drow><span>Conflicts</span><span class=ok>none</span></div>
+    <div class=drow><span>Mode</span><span>In person</span></div>
+    <div style="margin-top:16px;border:1px solid var(--good);color:var(--good);border-radius:3px;padding:9px;text-align:center;font-size:13px;font-weight:600">Add to my schedule</div>
+    <div style="margin-top:18px">
+      <p class=eyebrow>Why this one</p>
+      <p style="font-size:12.5px;color:var(--mute);margin:0">Only CSE 2331 section that has seats left and does not collide with MATH 2568 or ENGR 1182.</p>
+    </div>
+  </aside>
+</div>

--- a/wireframes/shared.css
+++ b/wireframes/shared.css
@@ -1,0 +1,41 @@
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,700;12..96,800&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap');
+*{box-sizing:border-box}
+:root{
+  --void:#0e0f12; --panel:#16181c; --panel2:#1b1e23; --rule:#282c33; --rule2:#343943;
+  --ink:#eceef2; --mute:#949bA6; --dim:#6b727d;
+  --scarlet:#ff5c4d; --good:#4cc38a; --warn:#e0a44a;
+  --display:"Bricolage Grotesque",sans-serif; --body:"IBM Plex Sans",system-ui,sans-serif; --data:"IBM Plex Mono",monospace;
+}
+body{margin:0;background:var(--void);color:var(--ink);font:14px/1.45 var(--body);height:100vh;overflow:hidden}
+.app{display:grid;height:100vh}
+.wordmark{font-family:var(--display);font-weight:800;font-size:20px;letter-spacing:-.03em;margin:0}
+.eyebrow{font-family:var(--data);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);margin:0 0 8px}
+.rail{background:var(--panel);border-right:1px solid var(--rule);padding:16px;overflow-y:auto}
+.topbar{grid-column:1/-1;display:flex;align-items:center;gap:14px;padding:10px 16px;background:var(--panel);border-bottom:1px solid var(--rule)}
+.field{margin-bottom:14px}
+.label{display:block;font-size:11px;color:var(--mute);margin-bottom:5px}
+.ctl{width:100%;background:var(--panel2);border:1px solid var(--rule2);border-radius:3px;color:var(--ink);
+     font:13px var(--body);padding:7px 9px;display:flex;justify-content:space-between;align-items:center}
+.ctl .car{color:var(--dim);font-size:10px}
+.ctl.mono{font-family:var(--data)}
+.chiprow{display:flex;flex-wrap:wrap;gap:5px}
+.chip{border:1px solid var(--rule2);border-radius:2px;padding:3px 7px;font-size:11px;color:var(--mute);font-family:var(--data)}
+.chip.on{background:var(--scarlet);border-color:var(--scarlet);color:#16181c;font-weight:600}
+.chk{display:flex;align-items:center;gap:7px;font-size:12.5px;color:var(--mute);margin-bottom:6px}
+.box{width:13px;height:13px;border:1px solid var(--rule2);border-radius:2px;flex:none}
+.box.on{background:var(--scarlet);border-color:var(--scarlet);position:relative}
+.box.on::after{content:"";position:absolute;left:4px;top:1px;width:3px;height:7px;border:solid #16181c;border-width:0 2px 2px 0;transform:rotate(45deg)}
+.sep{height:1px;background:var(--rule);margin:16px -16px}
+.count{font-family:var(--data);font-size:10px;color:var(--dim)}
+.main{overflow-y:auto;padding:16px}
+.detail{background:var(--panel);border-left:1px solid var(--rule);padding:16px;overflow-y:auto}
+.h2{font-family:var(--display);font-weight:700;font-size:17px;letter-spacing:-.02em;margin:0 0 2px}
+.sub{color:var(--mute);font-size:12.5px;margin:0 0 14px}
+.star{color:var(--scarlet)}
+.mono{font-family:var(--data)}
+.full{color:var(--scarlet);font-weight:500}
+.ok{color:var(--good)}
+.pill{font-family:var(--data);font-size:9.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--mute);background:var(--panel2);padding:2px 5px;border-radius:2px}
+.bar{height:4px;background:var(--rule2);border-radius:2px;overflow:hidden}
+.bar i{display:block;height:100%;background:var(--good)}
+.bar i.f{background:var(--scarlet)}


### PR DESCRIPTION
Mockups only, no app code touched. Merging so they are viewable on the live site.

The complaint: the current layout leaves the left and right thirds of a desktop screen empty and stacks everything into a narrow vertical strip.

Three different answers rather than three skins on the same one:

- **[A. Three pane](https://enesyilmazcode.github.io/Finder/wireframes/a-three-pane.html)** — filters, results, section detail
- **[B. Compare board](https://enesyilmazcode.github.io/Finder/wireframes/b-compare.html)** — one row per instructor, every metric a column
- **[C. Schedule grid](https://enesyilmazcode.github.io/Finder/wireframes/c-schedule.html)** — sections plotted on a week with your existing courses behind them

All three replace the free-text search with subject and number dropdowns that autocomplete, so you can find a course without knowing its number.
