### PR TITLE
Build the three-pane app shell

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -61,25 +61,35 @@ body {
   :focus-visible { outline: 2px solid Highlight; }
 }
 
-.shell {
-  max-width: 62rem;
-  margin: 0 auto;
-  padding: var(--gap);
+/* Three-pane shell --------------------------------------------------------
+
+   Desktop is a real three-column application: filters, results, detail.
+   Below the breakpoint it becomes one column, because three panes squeezed
+   into a phone is worse than one pane at a time, and registration happens
+   on a phone. */
+
+.app {
+  display: grid;
+  grid-template-columns: 17rem minmax(0, 1fr) 23rem;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100vh;
+  height: 100dvh;
 }
 
-/* Masthead ---------------------------------------------------------------- */
-
-.masthead {
+.topbar {
+  grid-column: 1 / -1;
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.75rem;
+  padding: 0.6rem var(--gap);
+  background: var(--paper);
+  border-bottom: 1px solid var(--rule);
   flex-wrap: wrap;
-  margin-bottom: 1.25rem;
 }
 
 .wordmark {
   font-family: var(--display);
-  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  font-size: 1.4rem;
   font-weight: 800;
   letter-spacing: -0.03em;
   margin: 0;
@@ -89,22 +99,46 @@ body {
 .tagline {
   margin: 0;
   color: var(--mute);
-  font-size: 0.95rem;
+  font-size: 0.85rem;
 }
+
+.rail {
+  overflow-y: auto;
+  padding: var(--gap);
+  background: var(--paper);
+  border-right: 1px solid var(--rule);
+}
+
+.rail-empty { margin: 0; color: var(--mute); font-size: 0.85rem; }
+
+.centre {
+  overflow-y: auto;
+  padding: var(--gap);
+  min-width: 0;
+}
+
+.detail {
+  overflow-y: auto;
+  padding: var(--gap);
+  background: var(--paper);
+  border-left: 1px solid var(--rule);
+}
+
+.detail-idle { margin: 0; color: var(--mute); font-size: 0.9rem; }
+
+/* The rail toggle and the detail back button exist only in the collapsed
+   layout, so they are hidden by default rather than created conditionally. */
+.rail-toggle,
+.detail-back { display: none; }
 
 /* Search ------------------------------------------------------------------ */
 
 .search {
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   gap: 0.5rem;
-  background: var(--paper);
-  border: 1px solid var(--rule);
-  border-radius: var(--radius);
-  padding: 0.5rem;
-  position: sticky;
-  top: 0.5rem;
-  z-index: 10;
+  margin-left: auto;
+  min-width: min(28rem, 100%);
 }
 
 .search input,
@@ -122,7 +156,7 @@ body {
 .search input {
   min-width: 0;
   border-color: var(--field);
-  background: var(--paper);
+  background: var(--wash);
 }
 
 .search input::placeholder { color: var(--mute); }
@@ -156,7 +190,7 @@ body {
 /* Status ------------------------------------------------------------------ */
 
 .status {
-  margin: 1rem 0 0;
+  margin: 0 0 0.9rem;
   color: var(--mute);
   font-size: 0.95rem;
   overflow-wrap: break-word;
@@ -167,7 +201,7 @@ body {
 
 /* Course records ---------------------------------------------------------- */
 
-.results { margin-top: 1.25rem; display: grid; gap: 0.75rem; }
+.results { display: grid; gap: 0.75rem; }
 
 .course {
   background: var(--paper);
@@ -254,9 +288,77 @@ body {
 
 /* Small screens ----------------------------------------------------------- */
 
+/* Collapsed layout --------------------------------------------------------
+
+   One column. The rail becomes a sheet the top bar opens, and the detail pane
+   becomes a full view pushed over the results with a way back. */
+
+@media (max-width: 64rem) {
+  .app {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .rail {
+    display: none;
+    grid-column: 1;
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .app[data-rail="open"] .rail { display: block; }
+
+  .rail-toggle {
+    display: inline-block;
+    order: 3;
+    font: inherit;
+    font-size: 0.85rem;
+    padding: 0.45rem 0.7rem;
+    border: 1px solid var(--field);
+    border-radius: var(--radius);
+    background: var(--wash);
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .rail-toggle[aria-expanded="true"] {
+    background: var(--scarlet);
+    border-color: var(--scarlet);
+    color: var(--paper);
+  }
+
+  .centre { grid-column: 1; }
+
+  .detail {
+    display: none;
+    grid-column: 1;
+    border-left: 0;
+  }
+
+  /* Detail replaces the results rather than sitting beside them. */
+  .app[data-view="detail"] .detail { display: block; }
+  .app[data-view="detail"] .centre { display: none; }
+
+  .app[data-view="detail"] .detail-back {
+    display: inline-block;
+    font: inherit;
+    font-size: 0.85rem;
+    margin-bottom: 0.9rem;
+    padding: 0.45rem 0.7rem;
+    border: 1px solid var(--field);
+    border-radius: var(--radius);
+    background: var(--wash);
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .tagline { display: none; }
+  .search { margin-left: 0; width: 100%; min-width: 0; }
+}
+
 @media (max-width: 34rem) {
-  .search { grid-template-columns: 1fr; position: static; }
-  .section { grid-template-columns: 1fr auto; }
+  .search { grid-template-columns: minmax(0, 1fr); }
+  .section { grid-template-columns: minmax(0, 1fr) auto; }
   .section-number { grid-column: 1; }
   .section-when,
   .section-where,
@@ -376,4 +478,28 @@ body {
 
 @media (max-width: 34rem) {
   .seats { grid-column: 1 / -1; text-align: left; }
+}
+
+/* Selection --------------------------------------------------------------- */
+
+.section { cursor: pointer; }
+.section:hover { background: var(--wash); }
+
+.section.is-selected {
+  background: var(--wash);
+  box-shadow: inset 3px 0 0 var(--scarlet);
+}
+
+.detail .h2 {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.6rem;
+}
+
+.detail-line {
+  margin: 0 0 0.4rem;
+  font-size: 0.9rem;
+  color: var(--mute);
 }

--- a/css/finder.css
+++ b/css/finder.css
@@ -503,3 +503,8 @@ body {
   font-size: 0.9rem;
   color: var(--mute);
 }
+
+.section:focus-visible {
+  outline: 2px solid var(--scarlet);
+  outline-offset: -2px;
+}

--- a/index.html
+++ b/index.html
@@ -11,13 +11,15 @@
   <link rel="stylesheet" href="css/finder.css">
 </head>
 <body>
-  <div class="shell">
-    <header class="masthead">
+  <div class="app">
+
+    <header class="topbar">
       <h1 class="wordmark">Finder</h1>
       <p class="tagline">Who teaches it, before everyone else finds out.</p>
-    </header>
 
-    <main>
+      <button class="rail-toggle" id="rail-toggle" type="button"
+              aria-expanded="false" aria-controls="rail">Filters</button>
+
       <form class="search" id="search" role="search" aria-label="Course search">
         <label class="visually-hidden" for="q">Course or professor</label>
         <input id="q" name="q" type="search" autocomplete="off" autocapitalize="none"
@@ -30,13 +32,27 @@
 
         <button id="go" type="submit">Search</button>
       </form>
+    </header>
 
+    <aside class="rail" id="rail" aria-label="Filters">
+      <p class="rail-empty">Filters arrive with <a href="https://github.com/EnesYilmazcode/Finder/issues/27">#27</a>.</p>
+    </aside>
+
+    <main class="centre" id="centre">
       <!-- Stays in the DOM at all times, empty or not. A live region that is
            added or unhidden at announce time is usually not announced. -->
       <p class="status" id="status" role="status" aria-live="polite" aria-atomic="true"></p>
 
       <div class="results" id="results" role="region" aria-label="Search results" tabindex="-1"></div>
     </main>
+
+    <aside class="detail" id="detail" aria-label="Section detail" tabindex="-1">
+      <button class="detail-back" id="detail-back" type="button" hidden>Back to results</button>
+      <div id="detail-body">
+        <p class="detail-idle">Pick a section to see the instructor, seats and room.</p>
+      </div>
+    </aside>
+
   </div>
 
   <script type="module" src="js/app.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -5,7 +5,13 @@ import { loadRatings } from "./ratings.js";
 import { loadSeats, seatsTerm, seatsUpdated } from "./seats.js";
 
 const els = {
+  app: document.querySelector(".app"),
   form: document.querySelector("#search"),
+  rail: document.querySelector("#rail"),
+  railToggle: document.querySelector("#rail-toggle"),
+  detail: document.querySelector("#detail"),
+  detailBody: document.querySelector("#detail-body"),
+  detailBack: document.querySelector("#detail-back"),
   query: document.querySelector("#q"),
   term: document.querySelector("#term"),
   submit: document.querySelector("#go"),
@@ -15,6 +21,38 @@ const els = {
 
 let terms = [];
 let latestRequest = 0;
+
+/**
+ * True while the layout is collapsed to one column. Matches the CSS breakpoint,
+ * which is the only place the number should really live, so it is read from a
+ * media query rather than duplicated as a magic width.
+ */
+const collapsed = window.matchMedia("(max-width: 64rem)");
+
+function openRail(open) {
+  els.app.dataset.rail = open ? "open" : "closed";
+  els.railToggle.setAttribute("aria-expanded", String(open));
+}
+
+/**
+ * Show a section in the detail pane.
+ *
+ * On desktop the pane is always visible, so this only swaps content. Collapsed,
+ * it takes over the screen and focus moves with it, otherwise a keyboard user
+ * is left on a control that is no longer on screen.
+ */
+export function showDetail(node) {
+  els.detailBody.replaceChildren(node);
+  if (collapsed.matches) {
+    els.app.dataset.view = "detail";
+    els.detail.focus();
+  }
+}
+
+function closeDetail() {
+  els.app.dataset.view = "results";
+  els.results.focus();
+}
 
 // The status element is never removed or hidden, only its text changes. A live
 // region that was hidden when content arrived usually goes unannounced.
@@ -79,6 +117,28 @@ async function runSearch(q, term) {
   }
 }
 
+/**
+ * Minimal stand-in so the third pane is demonstrable. The real content, with
+ * ratings, difficulty, other sections and the description, lands in #28.
+ */
+function buildDetailPlaceholder(row) {
+  const wrap = document.createElement("div");
+  const heading = document.createElement("h2");
+  heading.className = "h2";
+  heading.textContent = row.querySelector(".section-who")?.textContent ?? "Section";
+  wrap.append(heading);
+
+  for (const selector of [".section-number", ".section-when", ".section-where", ".seats"]) {
+    const found = row.querySelector(selector);
+    if (!found) continue;
+    const line = document.createElement("p");
+    line.className = "detail-line";
+    line.textContent = found.textContent.trim();
+    wrap.append(line);
+  }
+  return wrap;
+}
+
 function formatDate(iso) {
   const date = new Date(`${iso}T12:00:00`);
   return Number.isNaN(date.getTime())
@@ -123,6 +183,29 @@ async function init() {
   const wanted = params.get("term");
   els.term.value = terms.some((t) => t.code === wanted) ? wanted : defaultTerm(terms).code;
   els.term.disabled = false;
+
+  els.railToggle.addEventListener("click", () => {
+    openRail(els.app.dataset.rail !== "open");
+  });
+
+  els.detailBack.addEventListener("click", closeDetail);
+
+  // Returning to a wide layout must not leave the results hidden behind a
+  // detail view that no longer takes over the screen.
+  collapsed.addEventListener("change", (event) => {
+    if (!event.matches) els.app.dataset.view = "results";
+  });
+
+  // Selecting a section is delegated, so results can re-render freely.
+  els.results.addEventListener("click", (event) => {
+    const row = event.target.closest(".section");
+    if (!row || event.target.closest("a")) return;
+    for (const other of els.results.querySelectorAll(".section.is-selected")) {
+      other.classList.remove("is-selected");
+    }
+    row.classList.add("is-selected");
+    showDetail(buildDetailPlaceholder(row));
+  });
 
   els.form.addEventListener("submit", (event) => {
     event.preventDefault();

--- a/js/app.js
+++ b/js/app.js
@@ -41,12 +41,23 @@ function openRail(open) {
  * it takes over the screen and focus moves with it, otherwise a keyboard user
  * is left on a control that is no longer on screen.
  */
-export function showDetail(node) {
+function showDetail(node) {
   els.detailBody.replaceChildren(node);
   if (collapsed.matches) {
     els.app.dataset.view = "detail";
     els.detail.focus();
   }
+}
+
+function selectSection(row) {
+  for (const other of els.results.querySelectorAll(".section.is-selected")) {
+    other.classList.remove("is-selected");
+    other.removeAttribute("aria-current");
+  }
+  row.classList.add("is-selected");
+  // Selection is state, not just colour, so it is exposed rather than implied.
+  row.setAttribute("aria-current", "true");
+  showDetail(buildDetailPlaceholder(row));
 }
 
 function closeDetail() {
@@ -199,12 +210,15 @@ async function init() {
   // Selecting a section is delegated, so results can re-render freely.
   els.results.addEventListener("click", (event) => {
     const row = event.target.closest(".section");
+    if (row && !event.target.closest("a")) selectSection(row);
+  });
+
+  els.results.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    const row = event.target.closest(".section");
     if (!row || event.target.closest("a")) return;
-    for (const other of els.results.querySelectorAll(".section.is-selected")) {
-      other.classList.remove("is-selected");
-    }
-    row.classList.add("is-selected");
-    showDetail(buildDetailPlaceholder(row));
+    event.preventDefault(); // Space would otherwise scroll the results pane
+    selectSection(row);
   });
 
   els.form.addEventListener("submit", (event) => {

--- a/js/render.js
+++ b/js/render.js
@@ -103,6 +103,10 @@ function renderTeacher(group) {
 
 export function renderSection(section, term) {
   const li = el("li", "section");
+  // Selecting a section is the primary action in the three-pane layout, so the
+  // row has to be a real control rather than a div with a click handler.
+  li.tabIndex = 0;
+  li.setAttribute("role", "button");
   const meeting = section.meetings?.[0] ?? null;
 
   li.append(el("span", "section-number", section.classNumber ?? ""));


### PR DESCRIPTION
Closes #25

Wireframe A's layout, wired to the live app.

## Responsive behaviour, measured

Collapse is a layout change, not a squeeze. Measured in sized iframes at eight widths:

```
  320px cols=1 rail=sheet detail=hidden filtersBtn=yes  overflow=no  spills=0
  360px cols=1 rail=sheet detail=hidden filtersBtn=yes  overflow=no  spills=0
  390px cols=1 rail=sheet detail=hidden filtersBtn=yes  overflow=no  spills=0
  414px cols=1 rail=sheet detail=hidden filtersBtn=yes  overflow=no  spills=0
  768px cols=1 rail=sheet detail=hidden filtersBtn=yes  overflow=no  spills=0
 1024px cols=1 rail=sheet detail=hidden filtersBtn=yes  overflow=no  spills=0
 1100px cols=3 rail=shown detail=shown  filtersBtn=no   overflow=no  spills=0
 1600px cols=3 rail=shown detail=shown  filtersBtn=no   overflow=no  spills=0
```

Zero overflow and zero spilling elements at every width, so #20's guarantee still holds.

## Interaction, measured

```
desktop after click: Section 5377 MoWeFr 3:00p-3:55p Lecture JR 239 50/50 +3
  selected rows   : 1
  results visible : true

mobile view attr  : detail
  results hidden  : true      detail shown : true      back btn shown : true
  focus moved to  : detail
  after back      : view=results  focus=results
  rail after toggle: open  aria-expanded=true
```

Focus management is the part worth reviewing. Collapsed, opening a detail hides the results entirely, so leaving focus on a section row inside a hidden pane would strand a keyboard user. Focus moves to the detail pane and returns to results on the way back.

Widening the window while a detail is open also resets the view, otherwise the results stay hidden behind a pane that is no longer covering anything.

## Scope
Detail content is a deliberate placeholder showing the row's own text. The real pane, with ratings, difficulty, other sections and the description, is #28. The rail is empty and says so, pointing at #27.
