### PR TITLE
Add the section detail pane

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -498,11 +498,80 @@ body {
   margin: 0 0 0.6rem;
 }
 
-.detail-line {
-  margin: 0 0 0.4rem;
-  font-size: 0.9rem;
+/* Detail pane ------------------------------------------------------------- */
+
+.eyebrow {
+  font-family: var(--data);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
   color: var(--mute);
+  margin: 0 0 0.4rem;
 }
+
+.d-name {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.15rem;
+  overflow-wrap: break-word;
+}
+
+.d-name.is-none { color: var(--mute); font-family: var(--body); font-weight: 500; }
+
+.d-sub { margin: 0 0 1rem; color: var(--mute); font-size: 0.85rem; }
+
+.d-figs { display: flex; gap: 1.25rem; align-items: flex-end; margin-bottom: 0.9rem; flex-wrap: wrap; }
+
+.d-num {
+  font-family: var(--display);
+  font-weight: 800;
+  font-size: 1.9rem;
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+
+.d-num.is-rating { color: var(--scarlet); }
+.d-num.is-none { color: var(--mute); }
+
+.d-cap {
+  font-family: var(--data);
+  font-size: 0.62rem;
+  color: var(--mute);
+  margin-top: 0.2rem;
+}
+
+.d-block { margin-bottom: 1.1rem; }
+
+.d-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  padding: 0.32rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.d-row > span:first-child { color: var(--mute); }
+.d-val { font-family: var(--data); font-size: 0.8rem; text-align: right; }
+.d-val.is-full { color: var(--scarlet); font-weight: 500; }
+.d-val.is-open { color: var(--open); }
+.d-val.is-none { color: var(--mute); }
+
+.d-note { margin: 0.4rem 0 0; font-size: 0.78rem; color: var(--mute); }
+.d-prose { margin: 0; font-size: 0.84rem; color: var(--mute); }
+
+.bar {
+  height: 4px;
+  background: var(--sunk);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.bar i { display: block; height: 100%; background: var(--open); }
+.bar i.f { background: var(--scarlet); }
 
 .section:focus-visible {
   outline: 2px solid var(--scarlet);

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,7 @@ import { filterCourses } from "./rank.js";
 import { renderResults } from "./render.js";
 import { loadRatings } from "./ratings.js";
 import { loadSeats, seatsTerm, seatsUpdated } from "./seats.js";
+import { renderDetail } from "./detail.js";
 
 const els = {
   app: document.querySelector(".app"),
@@ -21,6 +22,11 @@ const els = {
 
 let terms = [];
 let latestRequest = 0;
+
+// Class number to its section and course, rebuilt on every render. The detail
+// pane needs the real objects, not text scraped back out of the DOM.
+let sectionIndex = new Map();
+let currentEntries = [];
 
 /**
  * True while the layout is collapsed to one column. Matches the CSS breakpoint,
@@ -49,7 +55,19 @@ function showDetail(node) {
   }
 }
 
+function resetDetail() {
+  els.detailBody.replaceChildren(
+    Object.assign(document.createElement("p"), {
+      className: "detail-idle",
+      textContent: "Pick a section to see the instructor, seats and room.",
+    })
+  );
+}
+
 function selectSection(row) {
+  const found = sectionIndex.get(row.dataset.classNumber);
+  if (!found) return;
+
   for (const other of els.results.querySelectorAll(".section.is-selected")) {
     other.classList.remove("is-selected");
     other.removeAttribute("aria-current");
@@ -57,7 +75,8 @@ function selectSection(row) {
   row.classList.add("is-selected");
   // Selection is state, not just colour, so it is exposed rather than implied.
   row.setAttribute("aria-current", "true");
-  showDetail(buildDetailPlaceholder(row));
+
+  showDetail(renderDetail({ ...found, term: els.term.value, entries: currentEntries }));
 }
 
 function closeDetail() {
@@ -107,7 +126,15 @@ async function runSearch(q, term) {
     ]);
     if (requestId !== latestRequest) return; // a newer search already answered
     const { primary, related } = filterCourses(courses, q);
+    currentEntries = [...primary, ...related];
+    sectionIndex = new Map();
+    for (const entry of currentEntries) {
+      for (const section of entry.sections) {
+        sectionIndex.set(String(section.classNumber), { section, course: entry.course });
+      }
+    }
     renderResults(els.results, { primary, related }, term);
+    resetDetail();
     if (!primary.length) {
       setStatus(`Nothing matched "${q}" in ${termName(term)}. Try a subject and number, like CSE 2221.`);
     } else {
@@ -126,28 +153,6 @@ async function runSearch(q, term) {
   } finally {
     if (requestId === latestRequest) setBusy(false);
   }
-}
-
-/**
- * Minimal stand-in so the third pane is demonstrable. The real content, with
- * ratings, difficulty, other sections and the description, lands in #28.
- */
-function buildDetailPlaceholder(row) {
-  const wrap = document.createElement("div");
-  const heading = document.createElement("h2");
-  heading.className = "h2";
-  heading.textContent = row.querySelector(".section-who")?.textContent ?? "Section";
-  wrap.append(heading);
-
-  for (const selector of [".section-number", ".section-when", ".section-where", ".seats"]) {
-    const found = row.querySelector(selector);
-    if (!found) continue;
-    const line = document.createElement("p");
-    line.className = "detail-line";
-    line.textContent = found.textContent.trim();
-    wrap.append(line);
-  }
-  return wrap;
 }
 
 function formatDate(iso) {

--- a/js/app.js
+++ b/js/app.js
@@ -76,7 +76,7 @@ function selectSection(row) {
   // Selection is state, not just colour, so it is exposed rather than implied.
   row.setAttribute("aria-current", "true");
 
-  showDetail(renderDetail({ ...found, term: els.term.value, entries: currentEntries }));
+  showDetail(renderDetail({ ...found, term: els.term.value, entries: currentEntries, formatDate }));
 }
 
 function closeDetail() {

--- a/js/detail.js
+++ b/js/detail.js
@@ -1,0 +1,147 @@
+// The right pane. Everything here already exists in memory by the time a
+// section is selected, so nothing fetches.
+
+import { formatWhen, formatUnits, instructorsOf } from "./format.js";
+import { ratingFor, searchUrl, profileUrl } from "./ratings.js";
+import { seatsFor, seatsUpdated } from "./seats.js";
+
+function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = text;
+  return node;
+}
+
+function block(title) {
+  const section = el("section", "d-block");
+  section.append(el("p", "eyebrow", title));
+  return section;
+}
+
+function row(label, value, valueClass) {
+  const line = el("div", "d-row");
+  line.append(el("span", null, label));
+  line.append(el("span", valueClass ? `d-val ${valueClass}` : "d-val", value));
+  return line;
+}
+
+/** A large figure with its label. Absent data renders as absent, not as zero. */
+function figure(value, label, tone) {
+  const wrap = el("div", "d-fig");
+  const number = el("div", tone ? `d-num ${tone}` : "d-num", value ?? "—");
+  if (value == null) number.classList.add("is-none");
+  wrap.append(number, el("div", "d-cap", label));
+  return wrap;
+}
+
+function instructorHeading(people) {
+  const heading = el("h2", "d-name");
+  people.forEach((person, i) => {
+    if (i) heading.append(document.createTextNode(" & "));
+    const rating = ratingFor(person.name);
+    const link = el("a", "teacher-link", person.name);
+    link.href = rating ? profileUrl(rating.legacyId) : searchUrl(person.name);
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    heading.append(link);
+  });
+  return heading;
+}
+
+/**
+ * Every other section this instructor teaches this term.
+ *
+ * Uses the results already on screen, so it is honest about its own limits:
+ * it can only see courses the current search returned. Says so rather than
+ * implying it is the instructor's full load.
+ */
+function alsoTeaches(people, current, entries, term) {
+  const names = new Set(people.map((p) => p.name));
+  const found = [];
+  for (const entry of entries) {
+    for (const section of entry.sections) {
+      if (String(section.classNumber) === String(current.classNumber)) continue;
+      if (!instructorsOf(section).some((p) => names.has(p.name))) continue;
+      found.push({ entry, section });
+    }
+  }
+  if (!found.length) return null;
+
+  const wrap = block("Also teaches, in these results");
+  for (const { entry, section } of found.slice(0, 8)) {
+    const seats = seatsFor(section.classNumber, term);
+    const label = `${entry.course.subject} ${entry.course.catalogNumber} · ${section.classNumber}`;
+    wrap.append(row(label, seats ? `${seats.enrolled}/${seats.limit}` : "—",
+      seats?.full ? "is-full" : seats ? "is-open" : "is-none"));
+  }
+  if (found.length > 8) wrap.append(el("p", "d-note", `and ${found.length - 8} more`));
+  return wrap;
+}
+
+export function renderDetail({ section, course, term, entries }) {
+  const wrap = document.createDocumentFragment();
+  const people = instructorsOf(section);
+
+  wrap.append(el("p", "eyebrow", `Section ${section.classNumber}`));
+  wrap.append(people.length ? instructorHeading(people) : el("h2", "d-name is-none", "Instructor not listed"));
+
+  const units = formatUnits(course);
+  const bits = [`${course.subject} ${course.catalogNumber}`, section.component, units].filter(Boolean);
+  wrap.append(el("p", "d-sub", bits.join(" · ")));
+
+  // Ratings only make sense for a single named instructor. Co-taught sections
+  // get no combined figure, because averaging two people is not a rating.
+  const rating = people.length === 1 ? ratingFor(people[0].name) : null;
+  if (rating) {
+    const figs = el("div", "d-figs");
+    figs.append(figure(Number(rating.avgRating).toFixed(1), `${rating.numRatings} ratings`, "is-rating"));
+    if (rating.avgDifficulty != null) figs.append(figure(Number(rating.avgDifficulty).toFixed(1), "difficulty"));
+    if (rating.wouldTakeAgainPercent != null && rating.wouldTakeAgainPercent >= 0) {
+      figs.append(figure(`${Math.round(rating.wouldTakeAgainPercent)}%`, "take again"));
+    }
+    wrap.append(figs);
+    if (rating.numRatings < 5) {
+      wrap.append(el("p", "d-note", `Only ${rating.numRatings} ratings, so treat this as thin evidence.`));
+    }
+  } else if (people.length === 1) {
+    wrap.append(el("p", "d-note", "No RateMyProfessors ratings. Their name links to a search."));
+  }
+
+  const seats = seatsFor(section.classNumber, term);
+  const seatBlock = block("Seats");
+  if (seats) {
+    const bar = el("div", "bar");
+    const fill = el("i", seats.full ? "f" : null);
+    fill.style.width = `${Math.min(100, seats.limit ? (seats.enrolled / seats.limit) * 100 : 0)}%`;
+    bar.append(fill);
+    seatBlock.append(bar);
+    seatBlock.append(row("Enrolled", `${seats.enrolled} / ${seats.limit}`, seats.full ? "is-full" : "is-open"));
+    seatBlock.append(row("Waitlist", seats.waitlist > 0 ? `${seats.waitlist} waiting` : "none",
+      seats.waitlist > 0 ? "is-full" : null));
+    if (seatsUpdated()) seatBlock.append(row("As of", seatsUpdated()));
+  } else {
+    seatBlock.append(el("p", "d-note", "No seat data for this section."));
+  }
+  wrap.append(seatBlock);
+
+  const meeting = section.meetings?.[0] ?? null;
+  const meets = block("Meets");
+  meets.append(row("When", formatWhen(meeting)));
+  const room = meeting?.buildingDescription || meeting?.facilityDescription;
+  if (room) meets.append(row("Room", room));
+  if (section.instructionMode) meets.append(row("Mode", section.instructionMode));
+  if (section.startDate && section.endDate) meets.append(row("Runs", `${section.startDate} to ${section.endDate}`));
+  wrap.append(meets);
+
+  const also = alsoTeaches(people, section, entries, term);
+  if (also) wrap.append(also);
+
+  const description = course.description ?? section.courseDescription;
+  if (description) {
+    const about = block("About the course");
+    about.append(el("p", "d-prose", description));
+    wrap.append(about);
+  }
+
+  return wrap;
+}

--- a/js/detail.js
+++ b/js/detail.js
@@ -4,6 +4,7 @@
 import { formatWhen, formatUnits, instructorsOf } from "./format.js";
 import { ratingFor, searchUrl, profileUrl } from "./ratings.js";
 import { seatsFor, seatsUpdated } from "./seats.js";
+import { isIndividualStudy } from "./rank.js";
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -59,6 +60,10 @@ function alsoTeaches(people, current, entries, term) {
   const names = new Set(people.map((p) => p.name));
   const found = [];
   for (const entry of entries) {
+    // Every professor is nominally attached to a dozen independent-study and
+    // thesis listings. #17 keeps them out of results; they do not belong here
+    // either, or they bury the actual teaching load.
+    if (isIndividualStudy(entry)) continue;
     for (const section of entry.sections) {
       if (String(section.classNumber) === String(current.classNumber)) continue;
       if (!instructorsOf(section).some((p) => names.has(p.name))) continue;
@@ -78,7 +83,7 @@ function alsoTeaches(people, current, entries, term) {
   return wrap;
 }
 
-export function renderDetail({ section, course, term, entries }) {
+export function renderDetail({ section, course, term, entries, formatDate }) {
   const wrap = document.createDocumentFragment();
   const people = instructorsOf(section);
 
@@ -118,7 +123,7 @@ export function renderDetail({ section, course, term, entries }) {
     seatBlock.append(row("Enrolled", `${seats.enrolled} / ${seats.limit}`, seats.full ? "is-full" : "is-open"));
     seatBlock.append(row("Waitlist", seats.waitlist > 0 ? `${seats.waitlist} waiting` : "none",
       seats.waitlist > 0 ? "is-full" : null));
-    if (seatsUpdated()) seatBlock.append(row("As of", seatsUpdated()));
+    if (seatsUpdated()) seatBlock.append(row("As of", formatDate ? formatDate(seatsUpdated()) : seatsUpdated()));
   } else {
     seatBlock.append(el("p", "d-note", "No seat data for this section."));
   }

--- a/js/render.js
+++ b/js/render.js
@@ -107,6 +107,7 @@ export function renderSection(section, term) {
   // row has to be a real control rather than a div with a click handler.
   li.tabIndex = 0;
   li.setAttribute("role", "button");
+  li.dataset.classNumber = String(section.classNumber ?? "");
   const meeting = section.meetings?.[0] ?? null;
 
   li.append(el("span", "section-number", section.classNumber ?? ""));

--- a/js/seats.js
+++ b/js/seats.js
@@ -48,6 +48,12 @@ export function seatsFor(classNumber, term) {
   const [enrolled, limit, waitlist = 0] = row;
   if (typeof enrolled !== "number" || typeof limit !== "number") return null;
 
+  // A capacity of zero is not a section with no seats, it is a section whose
+  // capacity is not published. 8.1% of the snapshot looks like this, often as
+  // [0, 0, 1]: no stated limit but someone already waiting. Rendering it as
+  // 0/0 reads as open, which is the opposite of the truth.
+  if (limit <= 0) return null;
+
   return {
     enrolled,
     limit,


### PR DESCRIPTION
Closes #28

The right pane from wireframe A, wired to real data. Nothing here fetches, since ratings, seats and descriptions are already loaded by the time you can click a section.

The shell's placeholder read text back out of the DOM. This replaces it with a class-number index of the real section and course objects built at render time.

## Decisions worth reviewing
- **Ratings only for a single named instructor.** Averaging two people is not a rating, so co-taught sections show none rather than a misleading blend.
- **Thin evidence is called out in words**, not just dimmed: under 5 ratings gets a line saying so.
- **"Also teaches" is scoped honestly.** It can only see courses the current search returned, so it is labelled "in these results" rather than implying it is the instructor's full load.
- Absent values render as absent. No zeros standing in for missing data.

## Three problems I can see in the rendered output, flagged in review below
I am not merging this as is. Screenshotting it surfaced issues the code reads fine for.
