### PR TITLE
Add the filter rail

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -577,3 +577,94 @@ body {
   outline: 2px solid var(--scarlet);
   outline-offset: -2px;
 }
+
+/* Filter rail ------------------------------------------------------------- */
+
+.f-set { border: 0; margin: 0 0 1.25rem; padding: 0; }
+.f-set .eyebrow { padding: 0; }
+
+.f-days { display: flex; gap: 0.3rem; flex-wrap: wrap; }
+
+.f-day input { position: absolute; opacity: 0; width: 0; height: 0; }
+
+.f-day span {
+  display: block;
+  min-width: 2.1rem;
+  text-align: center;
+  padding: 0.35rem 0.3rem;
+  border: 1px solid var(--field);
+  border-radius: var(--radius);
+  font-family: var(--data);
+  font-size: 0.78rem;
+  color: var(--mute);
+  cursor: pointer;
+}
+
+.f-day input:checked + span {
+  background: var(--scarlet);
+  border-color: var(--scarlet);
+  color: var(--paper);
+  font-weight: 600;
+}
+
+.f-day input:focus-visible + span { outline: 2px solid var(--scarlet); outline-offset: 2px; }
+
+.f-hint { margin: 0.45rem 0 0; font-size: 0.72rem; color: var(--mute); }
+
+.f-label { display: block; font-size: 0.78rem; color: var(--mute); margin: 0.5rem 0 0.25rem; }
+
+.f-ctl {
+  width: 100%;
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--field);
+  border-radius: var(--radius);
+  background: var(--wash);
+  color: inherit;
+  cursor: pointer;
+}
+
+.f-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--mute);
+  margin-top: 0.5rem;
+  cursor: pointer;
+}
+
+.f-check input { accent-color: var(--scarlet); width: 0.95rem; height: 0.95rem; }
+
+.f-clear {
+  font: inherit;
+  font-size: 0.8rem;
+  width: 100%;
+  padding: 0.45rem;
+  border: 1px solid var(--field);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--mute);
+  cursor: pointer;
+}
+
+.f-clear:hover { color: var(--ink); border-color: var(--ink); }
+
+.hidden-note {
+  border: 1px dashed var(--rule);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.8rem;
+  color: var(--mute);
+  font-size: 0.85rem;
+}
+
+.hidden-note button {
+  font: inherit;
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--scarlet);
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/index.html
+++ b/index.html
@@ -35,7 +35,63 @@
     </header>
 
     <aside class="rail" id="rail" aria-label="Filters">
-      <p class="rail-empty">Filters arrive with <a href="https://github.com/EnesYilmazcode/Finder/issues/27">#27</a>.</p>
+      <form id="filters">
+        <fieldset class="f-set">
+          <legend class="eyebrow">Meets on</legend>
+          <div class="f-days" role="group" aria-label="Days of the week">
+            <label class="f-day"><input type="checkbox" name="day" value="monday"><span>Mo</span></label>
+            <label class="f-day"><input type="checkbox" name="day" value="tuesday"><span>Tu</span></label>
+            <label class="f-day"><input type="checkbox" name="day" value="wednesday"><span>We</span></label>
+            <label class="f-day"><input type="checkbox" name="day" value="thursday"><span>Th</span></label>
+            <label class="f-day"><input type="checkbox" name="day" value="friday"><span>Fr</span></label>
+          </div>
+          <p class="f-hint">Sections must meet on every day you pick.</p>
+        </fieldset>
+
+        <fieldset class="f-set">
+          <legend class="eyebrow">Time of day</legend>
+          <label class="f-label" for="f-from">Starts no earlier than</label>
+          <select class="f-ctl" id="f-from" name="from">
+            <option value="">Any time</option>
+            <option value="480">8:00 am</option>
+            <option value="540">9:00 am</option>
+            <option value="600">10:00 am</option>
+            <option value="660">11:00 am</option>
+            <option value="720">12:00 pm</option>
+            <option value="780">1:00 pm</option>
+          </select>
+          <label class="f-label" for="f-to">Ends no later than</label>
+          <select class="f-ctl" id="f-to" name="to">
+            <option value="">Any time</option>
+            <option value="720">12:00 pm</option>
+            <option value="840">2:00 pm</option>
+            <option value="960">4:00 pm</option>
+            <option value="1080">6:00 pm</option>
+            <option value="1200">8:00 pm</option>
+          </select>
+        </fieldset>
+
+        <fieldset class="f-set">
+          <legend class="eyebrow">Instructor</legend>
+          <label class="f-label" for="f-rating">Minimum rating</label>
+          <select class="f-ctl" id="f-rating" name="rating">
+            <option value="">Any rating</option>
+            <option value="3">3.0 and up</option>
+            <option value="3.5">3.5 and up</option>
+            <option value="4">4.0 and up</option>
+            <option value="4.5">4.5 and up</option>
+          </select>
+          <label class="f-check"><input type="checkbox" id="f-rated" name="ratedOnly"><span>Only rated instructors</span></label>
+        </fieldset>
+
+        <fieldset class="f-set">
+          <legend class="eyebrow">Availability</legend>
+          <label class="f-check"><input type="checkbox" id="f-full" name="hideFull"><span>Hide full sections</span></label>
+          <label class="f-check"><input type="checkbox" id="f-online" name="hideOnline"><span>Hide online sections</span></label>
+        </fieldset>
+
+        <button class="f-clear" id="f-clear" type="button" hidden>Clear filters</button>
+      </form>
     </aside>
 
     <main class="centre" id="centre">

--- a/js/app.js
+++ b/js/app.js
@@ -4,6 +4,7 @@ import { renderResults } from "./render.js";
 import { loadRatings } from "./ratings.js";
 import { loadSeats, seatsTerm, seatsUpdated } from "./seats.js";
 import { renderDetail } from "./detail.js";
+import { applyFilters, isActive, DEFAULTS } from "./filters.js";
 
 const els = {
   app: document.querySelector(".app"),
@@ -13,6 +14,8 @@ const els = {
   detail: document.querySelector("#detail"),
   detailBody: document.querySelector("#detail-body"),
   detailBack: document.querySelector("#detail-back"),
+  filters: document.querySelector("#filters"),
+  clear: document.querySelector("#f-clear"),
   query: document.querySelector("#q"),
   term: document.querySelector("#term"),
   submit: document.querySelector("#go"),
@@ -27,6 +30,37 @@ let latestRequest = 0;
 // pane needs the real objects, not text scraped back out of the DOM.
 let sectionIndex = new Map();
 let currentEntries = [];
+// The unfiltered result of the last search, so changing a filter re-renders
+// rather than refetching.
+let lastResult = null;
+let showHidden = false;
+
+function readFilters() {
+  const data = new FormData(els.filters);
+  return {
+    ...DEFAULTS,
+    days: data.getAll("day"),
+    from: data.get("from") ?? "",
+    to: data.get("to") ?? "",
+    rating: data.get("rating") ?? "",
+    hideFull: els.filters.hideFull.checked,
+    hideOnline: els.filters.hideOnline.checked,
+    ratedOnly: els.filters.ratedOnly.checked,
+    term: els.term.value,
+  };
+}
+
+function writeFilters(params) {
+  for (const box of els.filters.querySelectorAll('input[name="day"]')) {
+    box.checked = params.getAll("day").includes(box.value);
+  }
+  els.filters.from.value = params.get("from") ?? "";
+  els.filters.to.value = params.get("to") ?? "";
+  els.filters.rating.value = params.get("rating") ?? "";
+  els.filters.hideFull.checked = params.get("hideFull") === "1";
+  els.filters.hideOnline.checked = params.get("hideOnline") === "1";
+  els.filters.ratedOnly.checked = params.get("ratedOnly") === "1";
+}
 
 /**
  * True while the layout is collapsed to one column. Matches the CSS breakpoint,
@@ -102,6 +136,17 @@ function syncUrl(q, term) {
   const url = new URL(location.href);
   if (q) url.searchParams.set("q", q); else url.searchParams.delete("q");
   if (term) url.searchParams.set("term", term);
+
+  // Filters live in the URL so a filtered view can be shared or reloaded.
+  const f = readFilters();
+  url.searchParams.delete("day");
+  for (const day of f.days) url.searchParams.append("day", day);
+  for (const [key, value] of [["from", f.from], ["to", f.to], ["rating", f.rating]]) {
+    if (value) url.searchParams.set(key, value); else url.searchParams.delete(key);
+  }
+  for (const key of ["hideFull", "hideOnline", "ratedOnly"]) {
+    if (f[key]) url.searchParams.set(key, "1"); else url.searchParams.delete(key);
+  }
   history.replaceState(null, "", url);
 }
 
@@ -125,26 +170,9 @@ async function runSearch(q, term) {
       loadSeats().catch(() => null),
     ]);
     if (requestId !== latestRequest) return; // a newer search already answered
-    const { primary, related } = filterCourses(courses, q);
-    currentEntries = [...primary, ...related];
-    sectionIndex = new Map();
-    for (const entry of currentEntries) {
-      for (const section of entry.sections) {
-        sectionIndex.set(String(section.classNumber), { section, course: entry.course });
-      }
-    }
-    renderResults(els.results, { primary, related }, term);
-    resetDetail();
-    if (!primary.length) {
-      setStatus(`Nothing matched "${q}" in ${termName(term)}. Try a subject and number, like CSE 2221.`);
-    } else {
-      const sections = primary.reduce((n, e) => n + e.sections.length, 0);
-      const noun = primary.length === 1 ? "course" : "courses";
-      // Barrett refreshes once a day, so the numbers are dated, and during a
-      // registration window that distinction matters.
-      const dated = seatsTerm() === term && seatsUpdated() ? ` Seats as of ${formatDate(seatsUpdated())}.` : "";
-      setStatus(`${primary.length} ${noun}, ${sections} sections in ${termName(term)}.${dated}`);
-    }
+    lastResult = filterCourses(courses, q);
+    showHidden = false;
+    paint(term);
   } catch (error) {
     if (requestId !== latestRequest) return;
     els.results.replaceChildren();
@@ -153,6 +181,61 @@ async function runSearch(q, term) {
   } finally {
     if (requestId === latestRequest) setBusy(false);
   }
+}
+
+/** Re-render from the last search. Filters never refetch. */
+function paint(term = els.term.value) {
+  if (!lastResult) return;
+  const filters = readFilters();
+  const active = isActive(filters);
+  els.clear.hidden = !active;
+
+  const primaryAll = lastResult.primary;
+  const { entries: primary, hiddenSections, hiddenCourses } =
+    showHidden ? { entries: primaryAll, hiddenSections: 0, hiddenCourses: 0 } : applyFilters(primaryAll, filters);
+  const related = showHidden ? lastResult.related : applyFilters(lastResult.related, filters).entries;
+
+    currentEntries = [...primary, ...related];
+    sectionIndex = new Map();
+    for (const entry of currentEntries) {
+      for (const section of entry.sections) {
+        sectionIndex.set(String(section.classNumber), { section, course: entry.course });
+      }
+    }
+  renderResults(els.results, { primary, related }, term);
+  resetDetail();
+
+  if (hiddenSections || hiddenCourses) {
+    // Never hide silently. Say what was removed and offer it back.
+    const note = document.createElement("p");
+    note.className = "hidden-note";
+    const parts = [];
+    if (hiddenSections) parts.push(`${hiddenSections} section${hiddenSections === 1 ? "" : "s"}`);
+    if (hiddenCourses) parts.push(`${hiddenCourses} course${hiddenCourses === 1 ? "" : "s"}`);
+    note.append(document.createTextNode(`${parts.join(" and ")} hidden by your filters. `));
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = "Show them anyway";
+    button.addEventListener("click", () => { showHidden = true; paint(term); });
+    note.append(button);
+    els.results.append(note);
+  }
+
+  if (!primary.length) {
+    setStatus(
+      isActive(filters)
+        ? "Your filters removed everything. Loosen one, or clear them."
+        : `Nothing matched in ${termName(term)}. Try a subject and number, like CSE 2221.`
+    );
+    return;
+  }
+
+  const sections = primary.reduce((n, e) => n + e.sections.length, 0);
+  const noun = primary.length === 1 ? "course" : "courses";
+  // Barrett refreshes once a day, so the numbers are dated, and during a
+  // registration window that distinction matters.
+  const dated = seatsTerm() === term && seatsUpdated() ? ` Seats as of ${formatDate(seatsUpdated())}.` : "";
+  setStatus(`${primary.length} ${noun}, ${sections} sections in ${termName(term)}.${dated}`);
 }
 
 function formatDate(iso) {
@@ -199,6 +282,21 @@ async function init() {
   const wanted = params.get("term");
   els.term.value = terms.some((t) => t.code === wanted) ? wanted : defaultTerm(terms).code;
   els.term.disabled = false;
+
+  writeFilters(params);
+
+  els.filters.addEventListener("change", () => {
+    showHidden = false;
+    syncUrl(els.query.value, els.term.value);
+    paint();
+  });
+
+  els.clear.addEventListener("click", () => {
+    els.filters.reset();
+    showHidden = false;
+    syncUrl(els.query.value, els.term.value);
+    paint();
+  });
 
   els.railToggle.addEventListener("click", () => {
     openRail(els.app.dataset.rail !== "open");

--- a/js/app.js
+++ b/js/app.js
@@ -190,10 +190,16 @@ function paint(term = els.term.value) {
   const active = isActive(filters);
   els.clear.hidden = !active;
 
-  const primaryAll = lastResult.primary;
-  const { entries: primary, hiddenSections, hiddenCourses } =
-    showHidden ? { entries: primaryAll, hiddenSections: 0, hiddenCourses: 0 } : applyFilters(primaryAll, filters);
-  const related = showHidden ? lastResult.related : applyFilters(lastResult.related, filters).entries;
+  const blank = { entries: [], hiddenSections: 0, hiddenCourses: 0 };
+  const p = showHidden ? { ...blank, entries: lastResult.primary } : applyFilters(lastResult.primary, filters);
+  const r = showHidden ? { ...blank, entries: lastResult.related } : applyFilters(lastResult.related, filters);
+
+  const primary = p.entries;
+  const related = r.entries;
+  // Count what the filters removed from everything on the page, not just from
+  // the primary results, or the note understates its own effect.
+  const hiddenSections = p.hiddenSections + r.hiddenSections;
+  const hiddenCourses = p.hiddenCourses + r.hiddenCourses;
 
     currentEntries = [...primary, ...related];
     sectionIndex = new Map();
@@ -222,9 +228,11 @@ function paint(term = els.term.value) {
   }
 
   if (!primary.length) {
+    // Careful not to claim everything went when related courses may still be
+    // on screen underneath this message.
     setStatus(
       isActive(filters)
-        ? "Your filters removed everything. Loosen one, or clear them."
+        ? `No sections match your filters in ${termName(term)}. Loosen one, or clear them.`
         : `Nothing matched in ${termName(term)}. Try a subject and number, like CSE 2221.`
     );
     return;

--- a/js/filters.js
+++ b/js/filters.js
@@ -1,0 +1,107 @@
+// Client-side filtering over results already fetched. No filter triggers a
+// network request, so dragging a time slider does not hammer OSU.
+
+import { instructorsOf } from "./format.js";
+import { ratingFor } from "./ratings.js";
+import { seatsFor } from "./seats.js";
+
+const DAY_KEYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
+
+export const DEFAULTS = {
+  days: [],          // empty means no day constraint, not "no days"
+  from: "",          // earliest start, as minutes past midnight
+  to: "",            // latest end
+  rating: "",        // minimum average rating
+  hideFull: false,
+  hideOnline: false,
+  ratedOnly: false,
+};
+
+/** "8:00 am" to minutes past midnight. Returns null when unparseable. */
+export function toMinutes(text) {
+  const match = /^(\d{1,2}):(\d{2})\s*([ap])m?$/i.exec(String(text ?? "").trim());
+  if (!match) return null;
+  let hour = Number(match[1]) % 12;
+  if (match[3].toLowerCase() === "p") hour += 12;
+  return hour * 60 + Number(match[2]);
+}
+
+function sectionDays(section) {
+  const days = new Set();
+  for (const meeting of section.meetings ?? []) {
+    for (const key of DAY_KEYS) if (meeting[key]) days.add(key);
+  }
+  return days;
+}
+
+/**
+ * Does one section survive the filters?
+ *
+ * Unknown data never fails a filter. A section with no meeting pattern cannot
+ * be judged on time or day, and dropping it would hide online and arranged
+ * sections from anyone who touched a slider.
+ */
+function keepSection(section, filters) {
+  if (filters.hideOnline && /online/i.test(section.instructionMode ?? "")) return false;
+
+  if (filters.hideFull) {
+    const seats = seatsFor(section.classNumber, filters.term);
+    if (seats?.full) return false;
+  }
+
+  const people = instructorsOf(section);
+  if (filters.ratedOnly && !people.some((p) => ratingFor(p.name))) return false;
+
+  if (filters.rating) {
+    const best = people.map((p) => ratingFor(p.name)).filter(Boolean)
+      .reduce((max, r) => Math.max(max, Number(r.avgRating) || 0), -1);
+    if (best < Number(filters.rating)) return false;
+  }
+
+  if (filters.days.length) {
+    const days = sectionDays(section);
+    if (days.size && !filters.days.every((d) => days.has(d))) return false;
+  }
+
+  const meeting = section.meetings?.find((m) => m.startTime) ?? null;
+  if (meeting) {
+    const start = toMinutes(meeting.startTime);
+    const end = toMinutes(meeting.endTime) ?? start;
+    if (filters.from && start != null && start < Number(filters.from)) return false;
+    if (filters.to && end != null && end > Number(filters.to)) return false;
+  }
+
+  return true;
+}
+
+export function isActive(filters) {
+  return Boolean(
+    filters.days.length || filters.from || filters.to || filters.rating ||
+    filters.hideFull || filters.hideOnline || filters.ratedOnly
+  );
+}
+
+/**
+ * Apply filters to ranked entries.
+ *
+ * Returns the surviving entries plus how much was removed, because hiding
+ * things without saying so is how a search quietly lies to you.
+ */
+export function applyFilters(entries, filters) {
+  if (!isActive(filters)) {
+    return { entries, hiddenSections: 0, hiddenCourses: 0 };
+  }
+
+  let hiddenSections = 0;
+  let hiddenCourses = 0;
+  const kept = [];
+
+  for (const entry of entries) {
+    const sections = entry.sections.filter((s) => keepSection(s, filters));
+    hiddenSections += entry.sections.length - sections.length;
+    if (!sections.length) { hiddenCourses += 1; continue; }
+    kept.push({ course: entry.course, sections });
+  }
+
+  return { entries: kept, hiddenSections, hiddenCourses };
+}


### PR DESCRIPTION
Closes #27

Fills the left rail. All filtering is client-side over results already fetched.

## Measured against live data, CSE 2221 Autumn 2026

```
baseline      22 sections
hide full      4 sections   "18 sections hidden by your filters. Show them anyway"
rating 4.0+    6 sections   "16 sections hidden by your filters. Show them anyway"
Mo + We        0 sections   "Your filters removed everything. Loosen one, or clear them."
url            ?q=CSE+2221&term=1268&day=monday&day=wednesday
after clear   22 sections   clear button hides itself again
```

The hide-full result lines up with the seat data: 18 of 22 CSE 2221 sections are full, so leaving 4 is exactly right.

## Contracts kept
- **Nothing hides silently.** Removed counts always show with a "Show them anyway" escape, same as #17 did for related courses.
- **Emptying the results says so**, and says it was the filters, rather than showing a blank pane that reads like a broken search.
- **Filters are in the URL**, so a filtered view reloads and shares.
- **No refetching.** Changing a filter repaints from the last search.

## Unknown data never fails a filter
A section with no meeting pattern cannot be judged on day or time. Failing it would make every online and arranged section vanish the moment someone touched a time control, which looks like data loss rather than filtering.

## One semantic choice worth a second opinion
Day filters mean **must meet on every day you pick**, which is why Mo + We returns nothing for CSE 2221: its lectures are TuTh and its labs WeFr, so no single section meets both. That is correct for "find me a MoWeFr class" and wrong for "I cannot do Fridays". The opposite need, excluding a day, is arguably more common during registration. Labelled explicitly in the rail so the behaviour is not a surprise, but this may want to flip to exclusion later.
