### PR TITLE
Add the calendar view toggle

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -668,3 +668,113 @@ body {
   cursor: pointer;
   text-decoration: underline;
 }
+
+/* Calendar ---------------------------------------------------------------- */
+
+.view-bar { display: flex; margin-bottom: 0.8rem; }
+
+.view-toggle { display: inline-flex; border: 1px solid var(--field); border-radius: var(--radius); overflow: hidden; }
+
+.view-toggle button {
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.32rem 0.8rem;
+  border: 0;
+  background: transparent;
+  color: var(--mute);
+  cursor: pointer;
+}
+
+.view-toggle button + button { border-left: 1px solid var(--field); }
+.view-toggle button.is-on { background: var(--scarlet); color: var(--paper); font-weight: 600; }
+
+.cal {
+  display: grid;
+  grid-template-columns: 3rem repeat(var(--cal-days), minmax(0, 1fr));
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--paper);
+  overflow: hidden;
+}
+
+.cal-head {
+  font-family: var(--data);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--mute);
+  text-align: center;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.cal-col { border-left: 1px solid var(--rule); min-width: 0; }
+.cal-body { position: relative; }
+.cal-line { border-bottom: 1px solid var(--sunk); }
+
+.cal-gutter { min-width: 0; }
+
+.cal-hour {
+  position: relative;
+  border-bottom: 1px solid transparent;
+}
+
+.cal-hour span {
+  position: absolute;
+  top: -0.42rem;
+  right: 0.35rem;
+  font-family: var(--data);
+  font-size: 0.62rem;
+  color: var(--mute);
+}
+
+.cal-slot {
+  position: absolute;
+  left: 2px;
+  right: 2px;
+  border-radius: var(--radius);
+  border-left: 3px solid var(--open);
+  background: var(--wash);
+  padding: 0.2rem 0.3rem;
+  overflow: hidden;
+}
+
+.cal-slot.is-full { border-left-color: var(--scarlet); }
+.cal-slot.is-part { border-left-color: var(--wait); }
+
+.cal-time, .cal-count {
+  margin: 0;
+  font-family: var(--data);
+  font-size: 0.6rem;
+  color: var(--mute);
+}
+
+.cal-count { color: var(--scarlet); font-weight: 500; }
+
+.cal-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  width: 100%;
+  font: inherit;
+  font-size: 0.72rem;
+  text-align: left;
+  background: none;
+  border: 0;
+  padding: 0.08rem 0;
+  color: inherit;
+  cursor: pointer;
+}
+
+.cal-item:hover .cal-who { text-decoration: underline; }
+.cal-item.is-selected { outline: 2px solid var(--scarlet); outline-offset: -1px; border-radius: 2px; }
+
+.cal-who { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.cal-rate { font-family: var(--data); font-size: 0.62rem; color: var(--scarlet); flex: none; }
+.cal-seats { font-family: var(--data); font-size: 0.62rem; color: var(--mute); margin-left: auto; flex: none; }
+.cal-seats.is-full { color: var(--scarlet); }
+
+.cal-unscheduled { margin-top: 1rem; }
+.cal-empty { color: var(--mute); font-size: 0.9rem; }
+
+.cal-more { margin: 0; font-family: var(--data); font-size: 0.6rem; color: var(--scarlet); }

--- a/index.html
+++ b/index.html
@@ -97,6 +97,13 @@
     <main class="centre" id="centre">
       <!-- Stays in the DOM at all times, empty or not. A live region that is
            added or unhidden at announce time is usually not announced. -->
+      <div class="view-bar">
+        <div class="view-toggle" role="group" aria-label="Result view">
+          <button type="button" id="view-list" class="is-on" aria-pressed="true">List</button>
+          <button type="button" id="view-cal" aria-pressed="false">Calendar</button>
+        </div>
+      </div>
+
       <p class="status" id="status" role="status" aria-live="polite" aria-atomic="true"></p>
 
       <div class="results" id="results" role="region" aria-label="Search results" tabindex="-1"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -223,6 +223,21 @@ function paint(term = els.term.value) {
     }
   if (view === "calendar") {
     els.results.replaceChildren(renderCalendar(primary, term));
+    // Related courses are deliberately not plotted, since a grid of a hundred
+    // courses is unreadable. Deliberate is not the same as silent.
+    if (related.length) {
+      const note = document.createElement("p");
+      note.className = "hidden-note";
+      note.append(document.createTextNode(
+        `${related.length} related course${related.length === 1 ? "" : "s"} are not on the grid. `
+      ));
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = "See them in list view";
+      button.addEventListener("click", () => setView("list"));
+      note.append(button);
+      els.results.append(note);
+    }
   } else {
     renderResults(els.results, { primary, related }, term);
   }

--- a/js/app.js
+++ b/js/app.js
@@ -5,6 +5,7 @@ import { loadRatings } from "./ratings.js";
 import { loadSeats, seatsTerm, seatsUpdated } from "./seats.js";
 import { renderDetail } from "./detail.js";
 import { applyFilters, isActive, DEFAULTS } from "./filters.js";
+import { renderCalendar } from "./calendar.js";
 
 const els = {
   app: document.querySelector(".app"),
@@ -15,6 +16,8 @@ const els = {
   detailBody: document.querySelector("#detail-body"),
   detailBack: document.querySelector("#detail-back"),
   filters: document.querySelector("#filters"),
+  viewList: document.querySelector("#view-list"),
+  viewCal: document.querySelector("#view-cal"),
   clear: document.querySelector("#f-clear"),
   query: document.querySelector("#q"),
   term: document.querySelector("#term"),
@@ -34,6 +37,7 @@ let currentEntries = [];
 // rather than refetching.
 let lastResult = null;
 let showHidden = false;
+let view = "list";
 
 function readFilters() {
   const data = new FormData(els.filters);
@@ -98,11 +102,20 @@ function resetDetail() {
   );
 }
 
+function setView(next) {
+  view = next;
+  for (const [button, name] of [[els.viewList, "list"], [els.viewCal, "calendar"]]) {
+    button.classList.toggle("is-on", name === next);
+    button.setAttribute("aria-pressed", String(name === next));
+  }
+  paint();
+}
+
 function selectSection(row) {
   const found = sectionIndex.get(row.dataset.classNumber);
   if (!found) return;
 
-  for (const other of els.results.querySelectorAll(".section.is-selected")) {
+  for (const other of els.results.querySelectorAll(".is-selected")) {
     other.classList.remove("is-selected");
     other.removeAttribute("aria-current");
   }
@@ -208,7 +221,11 @@ function paint(term = els.term.value) {
         sectionIndex.set(String(section.classNumber), { section, course: entry.course });
       }
     }
-  renderResults(els.results, { primary, related }, term);
+  if (view === "calendar") {
+    els.results.replaceChildren(renderCalendar(primary, term));
+  } else {
+    renderResults(els.results, { primary, related }, term);
+  }
   resetDetail();
 
   if (hiddenSections || hiddenCourses) {
@@ -293,6 +310,9 @@ async function init() {
 
   writeFilters(params);
 
+  els.viewList.addEventListener("click", () => setView("list"));
+  els.viewCal.addEventListener("click", () => setView("calendar"));
+
   els.filters.addEventListener("change", () => {
     showHidden = false;
     syncUrl(els.query.value, els.term.value);
@@ -320,7 +340,7 @@ async function init() {
 
   // Selecting a section is delegated, so results can re-render freely.
   els.results.addEventListener("click", (event) => {
-    const row = event.target.closest(".section");
+    const row = event.target.closest(".section, .cal-item");
     if (row && !event.target.closest("a")) selectSection(row);
   });
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,0 +1,195 @@
+// Week grid. Plots the sections of whatever you searched, and nothing else.
+// There is no saved schedule and no course planning here on purpose: Finder is
+// a search tool, so the grid answers "when is this taught and by whom".
+
+import { instructorsOf } from "./format.js";
+import { toMinutes } from "./filters.js";
+import { ratingFor } from "./ratings.js";
+import { seatsFor } from "./seats.js";
+
+const DAYS = [
+  ["monday", "Mon"], ["tuesday", "Tue"], ["wednesday", "Wed"],
+  ["thursday", "Thu"], ["friday", "Fri"], ["saturday", "Sat"], ["sunday", "Sun"],
+];
+
+// Sized so a standard 55 minute class has room for its time label plus three
+// instructor lines, which is the common worst case: CSE 2321 has three sections
+// at MoWeFr 3:00p.
+// These are measured from the rendered page, not estimated. Guessed values were
+// 25% low and silently clipped 9 of 32 instructor lines, including one hidden
+// entirely. If the type scale in the CSS changes, re-measure these.
+const PX_PER_MIN = 1.9;    // 55 min gives 104px, which fits three instructors with margin
+const MIN_SLOT = 44;
+const LINE_H = 21;         // .cal-item
+const CHROME_H = 15;       // .cal-time
+const COUNT_H = 15;        // .cal-count, only when there is more than one section
+const PAD_H = 7;           // .cal-slot vertical padding
+
+function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = text;
+  return node;
+}
+
+function clock(minutes) {
+  const hour = Math.floor(minutes / 60);
+  const suffix = hour < 12 ? "a" : "p";
+  const display = hour % 12 === 0 ? 12 : hour % 12;
+  const mins = minutes % 60;
+  return mins ? `${display}:${String(mins).padStart(2, "0")}${suffix}` : `${display}${suffix}`;
+}
+
+/**
+ * Collapse sections into time slots.
+ *
+ * Several instructors routinely teach the same course at the same hour. CSE
+ * 2321 has three sections at MoWeFr 3:00p. Slicing that column three ways is
+ * unreadable, and since the point of Finder is comparing instructors, one
+ * block naming all three is both clearer and more useful.
+ */
+export function buildSlots(entries, term) {
+  const slots = new Map();
+  const unscheduled = [];
+
+  for (const entry of entries) {
+    for (const section of entry.sections) {
+      const meeting = (section.meetings ?? []).find((m) => m.startTime && DAYS.some(([k]) => m[k]));
+      if (!meeting) { unscheduled.push({ entry, section }); continue; }
+
+      const start = toMinutes(meeting.startTime);
+      const end = toMinutes(meeting.endTime) ?? (start == null ? null : start + 55);
+      if (start == null) { unscheduled.push({ entry, section }); continue; }
+
+      const days = DAYS.filter(([key]) => meeting[key]).map(([key]) => key);
+      const id = `${days.join(",")}|${start}|${end}`;
+      if (!slots.has(id)) slots.set(id, { id, days, start, end, items: [] });
+      slots.get(id).items.push({ entry, section, seats: seatsFor(section.classNumber, term) });
+    }
+  }
+
+  return { slots: [...slots.values()], unscheduled };
+}
+
+/** Worst-case tone for a slot: red if every section in it is full. */
+function slotTone(items) {
+  const known = items.filter((i) => i.seats);
+  if (known.length && known.every((i) => i.seats.full)) return "is-full";
+  if (known.some((i) => i.seats.full)) return "is-part";
+  return "is-open";
+}
+
+export function renderCalendar(entries, term) {
+  const { slots, unscheduled } = buildSlots(entries, term);
+  const wrap = el("div", "cal-wrap");
+
+  if (!slots.length) {
+    wrap.append(el("p", "cal-empty", "Nothing here meets at a scheduled time."));
+    if (unscheduled.length) wrap.append(unscheduledList(unscheduled));
+    return wrap;
+  }
+
+  // Only draw the hours actually used, so a grid of afternoon classes does not
+  // open with four empty morning rows.
+  const first = Math.floor(Math.min(...slots.map((s) => s.start)) / 60) * 60;
+  const last = Math.ceil(Math.max(...slots.map((s) => s.end)) / 60) * 60;
+  const usedDays = DAYS.filter(([key]) => slots.some((s) => s.days.includes(key)));
+
+  const grid = el("div", "cal");
+  grid.style.setProperty("--cal-days", usedDays.length);
+  grid.style.setProperty("--cal-height", `${(last - first) * PX_PER_MIN}px`);
+
+  const gutter = el("div", "cal-gutter");
+  gutter.append(el("div", "cal-head"));
+  for (let m = first; m < last; m += 60) {
+    const mark = el("div", "cal-hour");
+    mark.style.height = `${60 * PX_PER_MIN}px`;
+    mark.append(el("span", null, clock(m)));
+    gutter.append(mark);
+  }
+  grid.append(gutter);
+
+  for (const [key, label] of usedDays) {
+    const column = el("div", "cal-col");
+    column.append(el("div", "cal-head", label));
+
+    const body = el("div", "cal-body");
+    body.style.height = `${(last - first) * PX_PER_MIN}px`;
+    for (let m = first; m < last; m += 60) {
+      const line = el("div", "cal-line");
+      line.style.height = `${60 * PX_PER_MIN}px`;
+      body.append(line);
+    }
+
+    for (const slot of slots.filter((s) => s.days.includes(key))) {
+      body.append(renderSlot(slot, first));
+    }
+    column.append(body);
+    grid.append(column);
+  }
+
+  wrap.append(grid);
+  if (unscheduled.length) wrap.append(unscheduledList(unscheduled));
+  return wrap;
+}
+
+function renderSlot(slot, first) {
+  const box = el("div", `cal-slot ${slotTone(slot.items)}`);
+  const height = Math.max((slot.end - slot.start) * PX_PER_MIN, MIN_SLOT);
+  box.style.top = `${(slot.start - first) * PX_PER_MIN}px`;
+  box.style.height = `${height}px`;
+
+  box.append(el("p", "cal-time", `${clock(slot.start)}–${clock(slot.end)}`));
+
+  // Only draw what actually fits. Clipping silently would hide instructors,
+  // which is the one thing this view exists to show, so anything that does not
+  // fit is counted rather than dropped.
+  const budget = height - PAD_H - CHROME_H - (slot.items.length > 1 ? COUNT_H : 0);
+  const room = Math.max(1, Math.floor(budget / LINE_H));
+  const shown = slot.items.slice(0, room);
+  const spare = slot.items.length - shown.length;
+
+  for (const item of shown) {
+    const people = instructorsOf(item.section);
+    const name = people.length ? people.map((p) => p.name).join(" & ") : "Instructor not listed";
+
+    const line = el("button", "cal-item");
+    line.type = "button";
+    line.dataset.classNumber = String(item.section.classNumber);
+
+    line.append(el("span", "cal-who", name));
+
+    const rating = people.length === 1 ? ratingFor(people[0].name) : null;
+    if (rating) line.append(el("span", "cal-rate", Number(rating.avgRating).toFixed(1)));
+    if (item.seats) {
+      line.append(el("span", item.seats.full ? "cal-seats is-full" : "cal-seats",
+        `${item.seats.enrolled}/${item.seats.limit}`));
+    }
+    box.append(line);
+  }
+
+  if (spare > 0) box.append(el("p", "cal-more", `+${spare} more, see list view`));
+
+  if (slot.items.length > 1) {
+    box.prepend(el("p", "cal-count", `${slot.items.length} sections`));
+  }
+  return box;
+}
+
+/** Online and arranged sections have no place on a grid, but must not vanish. */
+function unscheduledList(items) {
+  const wrap = el("section", "cal-unscheduled");
+  wrap.append(el("p", "eyebrow", `${items.length} without a set time`));
+  for (const { entry, section } of items.slice(0, 12)) {
+    const people = instructorsOf(section);
+    const line = el("button", "cal-item");
+    line.type = "button";
+    line.dataset.classNumber = String(section.classNumber);
+    line.append(el("span", "cal-who",
+      `${entry.course.subject} ${entry.course.catalogNumber} · ${people.map((p) => p.name).join(" & ") || "Instructor not listed"}`));
+    line.append(el("span", "cal-seats", section.instructionMode ?? ""));
+    wrap.append(line);
+  }
+  if (items.length > 12) wrap.append(el("p", "d-note", `and ${items.length - 12} more`));
+  return wrap;
+}


### PR DESCRIPTION
Closes #29

Wireframe C's grid as a view toggle in the centre column. List stays default.

## Course planning is deliberately absent
No saved schedule, no "add to my schedule", no conflict detection against other classes. The wireframe showed all three and they are cut. Finder searches; it does not plan. Adding a schedule means adding state, which means accounts, which is a different product.

## The overlap problem, which was the real design question

Several instructors routinely teach the same course at the same hour. CSE 2321 has three sections at MoWeFr 3:00p taught by Estill, Yarinezhad and Duong. Slicing a column three ways is unreadable, and since the point is comparing instructors, one block naming all three is clearer and more useful.

## Sizing was measured, not guessed, after guessing failed

First attempt used estimated constants. A DOM-presence check said everything was fine. A visibility check said otherwise:

```
instructor lines checked: 32, visually clipped: 9
  CLIPPED: "Luan Duong 4.9 44/40"  over by 22px    <- hidden entirely
  CLIPPED: "Ramin Yarinezhad 42/40" over by 1px
```

The third instructor in the exact slot this feature exists for was invisible, and my first probe passed because it counted DOM nodes rather than checking whether they were on screen.

So I measured the real rendered heights:

```
.cal-item   20.4px   (assumed 15)
.cal-time   14.4px   (assumed 13)
.cal-count  14.4px   (assumed 13)
a 3-section slot needs 96.4px, a 55-min slot gave 71.5px
```

Constants now carry the measured values with a note to re-measure if the type scale changes.

## After, across four courses

```
CSE 2321      lines= 32  most-shown-in-one-slot=3  truncated= 0  visually clipped=0
CSE 2221      lines= 44  most-shown-in-one-slot=2  truncated= 0  visually clipped=0
MATH 1151     lines= 81  most-shown-in-one-slot=3  truncated=14  visually clipped=0
ENGLISH 1110  lines=146  most-shown-in-one-slot=5  truncated=23  visually clipped=0
```

Zero clipping anywhere. Slots too deep to fit say `+N more, see list view` rather than dropping names, so the grid never quietly under-reports how many people teach a slot.

## Other details
- Only the hours actually used are drawn, so an afternoon course does not open with empty morning rows.
- Slot colour is worst-case: red when every section in it is full, amber when some are.
- Sections with no meeting pattern are listed below the grid rather than vanishing.
- Clicking any name fills the detail pane, same as the list.
