### PR TITLE
Add subject and course number pickers

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -778,3 +778,10 @@ body {
 .cal-empty { color: var(--mute); font-size: 0.9rem; }
 
 .cal-more { margin: 0; font-family: var(--data); font-size: 0.6rem; color: var(--scarlet); }
+
+/* Course pickers ---------------------------------------------------------- */
+
+.picker { margin-bottom: 1.25rem; padding-bottom: 1.1rem; border-bottom: 1px solid var(--rule); }
+.picker .f-ctl { cursor: text; }
+.picker .f-ctl:disabled { opacity: 0.5; cursor: default; }
+.picker .f-ctl::placeholder { color: var(--mute); }

--- a/index.html
+++ b/index.html
@@ -35,6 +35,20 @@
     </header>
 
     <aside class="rail" id="rail" aria-label="Filters">
+      <form id="picker" class="picker">
+        <p class="eyebrow">Find a course</p>
+        <label class="f-label" for="p-subject">Subject</label>
+        <input class="f-ctl" id="p-subject" list="subject-list" autocomplete="off"
+               placeholder="CSE, or computer" aria-describedby="p-hint">
+        <datalist id="subject-list"></datalist>
+
+        <label class="f-label" for="p-number">Course number</label>
+        <input class="f-ctl" id="p-number" list="number-list" autocomplete="off"
+               placeholder="2331, or foundations" disabled>
+        <datalist id="number-list"></datalist>
+        <p class="f-hint" id="p-hint">Pick a subject to browse its courses. You can still type a course or a professor in the search box.</p>
+      </form>
+
       <form id="filters">
         <fieldset class="f-set">
           <legend class="eyebrow">Meets on</legend>

--- a/js/app.js
+++ b/js/app.js
@@ -391,7 +391,7 @@ async function init() {
   writeFilters(params);
 
   for (const field of [els.subject, els.number]) {
-    field.addEventListener("focus", ensureCourses, { once: false });
+    field.addEventListener("focus", ensureCourses);
   }
 
   els.subject.addEventListener("input", async () => {

--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,7 @@ import { loadSeats, seatsTerm, seatsUpdated } from "./seats.js";
 import { renderDetail } from "./detail.js";
 import { applyFilters, isActive, DEFAULTS } from "./filters.js";
 import { renderCalendar } from "./calendar.js";
+import { loadCourses, subjectsFor, subjectLabel, coursesFor, codeFromInput, isLoaded } from "./courses.js";
 
 const els = {
   app: document.querySelector(".app"),
@@ -16,6 +17,11 @@ const els = {
   detailBody: document.querySelector("#detail-body"),
   detailBack: document.querySelector("#detail-back"),
   filters: document.querySelector("#filters"),
+  subject: document.querySelector("#p-subject"),
+  number: document.querySelector("#p-number"),
+  subjectList: document.querySelector("#subject-list"),
+  numberList: document.querySelector("#number-list"),
+  hint: document.querySelector("#p-hint"),
   viewList: document.querySelector("#view-list"),
   viewCal: document.querySelector("#view-cal"),
   clear: document.querySelector("#f-clear"),
@@ -100,6 +106,65 @@ function resetDetail() {
       textContent: "Pick a section to see the instructor, seats and room.",
     })
   );
+}
+
+/**
+ * Fill the subject list. Called on first focus rather than at startup, since
+ * the index is 177 KB gzipped and nobody needs it until they open a picker.
+ */
+async function ensureCourses() {
+  if (isLoaded()) return true;
+  els.hint.textContent = "Loading the course list...";
+  try {
+    await loadCourses();
+  } catch {
+    els.hint.textContent = "Could not load the course list. The search box still works.";
+    return false;
+  }
+  fillSubjects();
+  els.hint.textContent = "Pick a subject to browse its courses. You can still type a course or a professor in the search box.";
+  return true;
+}
+
+function fillSubjects() {
+  const subjects = subjectsFor(els.term.value);
+  els.subjectList.replaceChildren(
+    ...subjects.map((subject) => {
+      const option = document.createElement("option");
+      option.value = subjectLabel(subject);
+      return option;
+    })
+  );
+}
+
+function fillNumbers() {
+  const code = codeFromInput(els.subject.value);
+  const courses = coursesFor(els.term.value, code);
+  els.number.disabled = !courses.length;
+  els.numberList.replaceChildren(
+    ...courses.map((course) => {
+      const option = document.createElement("option");
+      // The value is what lands in the field, so it stays a bare number the
+      // search can use. The title rides along as the visible hint.
+      option.value = course.number;
+      option.label = course.title;
+      option.textContent = course.title;
+      return option;
+    })
+  );
+  if (!courses.length) els.number.value = "";
+  return courses;
+}
+
+/** A picked subject and number becomes an ordinary search. */
+function searchFromPickers() {
+  const code = codeFromInput(els.subject.value);
+  if (!code) return;
+  const number = els.number.value.trim();
+  const q = number ? `${code} ${number}` : code;
+  els.query.value = q;
+  syncUrl(q, els.term.value);
+  runSearch(q, els.term.value);
 }
 
 function setView(next) {
@@ -325,6 +390,24 @@ async function init() {
 
   writeFilters(params);
 
+  for (const field of [els.subject, els.number]) {
+    field.addEventListener("focus", ensureCourses, { once: false });
+  }
+
+  els.subject.addEventListener("input", async () => {
+    if (!(await ensureCourses())) return;
+    const courses = fillNumbers();
+    // Committing a whole subject is a useful search on its own, but only once
+    // the typed text actually names one.
+    if (courses.length && !els.number.value) searchFromPickers();
+  });
+
+  els.number.addEventListener("input", () => {
+    const code = codeFromInput(els.subject.value);
+    const wanted = els.number.value.trim();
+    if (coursesFor(els.term.value, code).some((c) => c.number === wanted)) searchFromPickers();
+  });
+
   els.viewList.addEventListener("click", () => setView("list"));
   els.viewCal.addEventListener("click", () => setView("calendar"));
 
@@ -376,6 +459,7 @@ async function init() {
   });
 
   els.term.addEventListener("change", () => {
+    if (isLoaded()) { fillSubjects(); fillNumbers(); }
     syncUrl(els.query.value, els.term.value);
     if (els.query.value.trim()) runSearch(els.query.value, els.term.value);
   });

--- a/js/courses.js
+++ b/js/courses.js
@@ -1,0 +1,56 @@
+// The course index, used by the subject and number pickers.
+//
+// Loaded lazily. It is 177 KB gzipped and is only needed once someone opens a
+// picker, so it stays out of the cold-load path where ratings and seats live.
+
+let index = null;
+let loading = null;
+
+export async function loadCourses(url = "data/courses.json") {
+  if (index) return index;
+  if (loading) return loading;
+
+  loading = (async () => {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`courses ${response.status}`);
+    index = await response.json();
+    return index;
+  })();
+
+  return loading;
+}
+
+export function isLoaded() {
+  return Boolean(index);
+}
+
+/** Subjects offered in a term, sorted by code. */
+export function subjectsFor(term) {
+  const subjects = index?.terms?.[String(term)]?.subjects ?? [];
+  return [...subjects].sort((a, b) => a.code.localeCompare(b.code));
+}
+
+/**
+ * Label for a subject.
+ *
+ * 15 subjects have no name upstream and fall back to their own code, so
+ * "CYBRSEC" would otherwise render as "CYBRSEC CYBRSEC".
+ */
+export function subjectLabel(subject) {
+  if (!subject) return "";
+  return subject.name && subject.name !== subject.code
+    ? `${subject.code} — ${subject.name}`
+    : subject.code;
+}
+
+/** Courses for one subject code, in catalog order. */
+export function coursesFor(term, code) {
+  const subject = subjectsFor(term).find((s) => s.code === String(code ?? "").toUpperCase());
+  if (!subject) return [];
+  return (subject.courses ?? []).map(([number, title, min, max]) => ({ number, title, min, max }));
+}
+
+/** Pull a bare subject code out of whatever the picker input holds. */
+export function codeFromInput(text) {
+  return String(text ?? "").trim().split(/[\s—-]/)[0].toUpperCase();
+}


### PR DESCRIPTION
Closes #26

The UI half. #34 built the index this reads.

## Measured flow

```
on load        : ratings.json, seats.json                    <- courses.json absent
after focus    : ratings.json, seats.json, courses.json      <- loaded lazily
subjects       : 243
  first three  : ACADAFF — Academic Affairs | ACCAD — Adv Computing Cntr Arts & Design | ACCTMIS — Accounting and Management Info
  nameless one : CYBRSEC | MMT | TLED    (code once, not doubled)

picked CSE     : number field enabled, 104 options
  sample       : 1110 = Introduction to Computing Technology | 1111 = Introduction to Computer-Assisted Problem Solving
  search box   : "CSE"

picked 2331    : search box "CSE 2331"
  status       : 1 course, 8 sections in Autumn 2026. Seats as of Aug 18.
  url          : ?q=CSE+2331&term=1268
```

## Lazy loading was the point
With three snapshots the cold load would have been 422 KB gzipped. Ratings and seats are needed to render any result; the course index is only needed once someone opens a picker. Loading it on first focus keeps first paint at 245 KB and costs nothing to anyone who just types.

## The pickers build a query, they do not replace search
Choosing a subject and number writes into the existing search box and runs an ordinary search. So there is one search path, one URL format, and free text keeps working exactly as before. A professor's name still goes in the box.

## One bug worth recording
My first attempt read `index.terms[term]` as the subject array. It is an object with `term`, `name` and `subjects`, so the list came back empty and the picker silently offered nothing. I had guessed the shape from a summary instead of reading the file. Caught because the probe asserted on option counts rather than just that no error was thrown.
