### PR TITLE
Let day filters avoid days as well as require them

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -585,7 +585,13 @@ body {
 
 .f-days { display: flex; gap: 0.3rem; flex-wrap: wrap; }
 
-.f-day input { position: absolute; opacity: 0; width: 0; height: 0; }
+.f-day {
+  font: inherit;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
 
 .f-day span {
   display: block;
@@ -597,17 +603,25 @@ body {
   font-family: var(--data);
   font-size: 0.78rem;
   color: var(--mute);
-  cursor: pointer;
 }
 
-.f-day input:checked + span {
+.f-day[data-state="require"] span {
   background: var(--scarlet);
   border-color: var(--scarlet);
   color: var(--paper);
   font-weight: 600;
 }
 
-.f-day input:focus-visible + span { outline: 2px solid var(--scarlet); outline-offset: 2px; }
+/* Avoided reads as struck out, which needs no legend to understand. */
+.f-day[data-state="avoid"] span {
+  border-style: dashed;
+  border-color: var(--mute);
+  color: var(--mute);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+
+.f-day:focus-visible span { outline: 2px solid var(--scarlet); outline-offset: 2px; }
 
 .f-hint { margin: 0.45rem 0 0; font-size: 0.72rem; color: var(--mute); }
 

--- a/index.html
+++ b/index.html
@@ -52,14 +52,14 @@
       <form id="filters">
         <fieldset class="f-set">
           <legend class="eyebrow">Meets on</legend>
-          <div class="f-days" role="group" aria-label="Days of the week">
-            <label class="f-day"><input type="checkbox" name="day" value="monday"><span>Mo</span></label>
-            <label class="f-day"><input type="checkbox" name="day" value="tuesday"><span>Tu</span></label>
-            <label class="f-day"><input type="checkbox" name="day" value="wednesday"><span>We</span></label>
-            <label class="f-day"><input type="checkbox" name="day" value="thursday"><span>Th</span></label>
-            <label class="f-day"><input type="checkbox" name="day" value="friday"><span>Fr</span></label>
+          <div class="f-days" id="f-days" role="group" aria-label="Days of the week">
+            <button type="button" class="f-day" data-day="monday" data-state="any"><span>Mo</span></button>
+            <button type="button" class="f-day" data-day="tuesday" data-state="any"><span>Tu</span></button>
+            <button type="button" class="f-day" data-day="wednesday" data-state="any"><span>We</span></button>
+            <button type="button" class="f-day" data-day="thursday" data-state="any"><span>Th</span></button>
+            <button type="button" class="f-day" data-day="friday" data-state="any"><span>Fr</span></button>
           </div>
-          <p class="f-hint">Sections must meet on every day you pick.</p>
+          <p class="f-hint">Click once to require a day, twice to avoid it.</p>
         </fieldset>
 
         <fieldset class="f-set">

--- a/js/app.js
+++ b/js/app.js
@@ -17,6 +17,7 @@ const els = {
   detailBody: document.querySelector("#detail-body"),
   detailBack: document.querySelector("#detail-back"),
   filters: document.querySelector("#filters"),
+  days: document.querySelector("#f-days"),
   subject: document.querySelector("#p-subject"),
   number: document.querySelector("#p-number"),
   subjectList: document.querySelector("#subject-list"),
@@ -45,11 +46,39 @@ let lastResult = null;
 let showHidden = false;
 let view = "list";
 
+function dayStates() {
+  const required = [];
+  const avoided = [];
+  for (const button of els.days.querySelectorAll(".f-day")) {
+    if (button.dataset.state === "require") required.push(button.dataset.day);
+    else if (button.dataset.state === "avoid") avoided.push(button.dataset.day);
+  }
+  return { required, avoided };
+}
+
+const DAY_LABELS = {
+  monday: "Monday", tuesday: "Tuesday", wednesday: "Wednesday",
+  thursday: "Thursday", friday: "Friday",
+};
+
+const NEXT_STATE = { any: "require", require: "avoid", avoid: "any" };
+
+/** Tri-state, so one control expresses both "must meet" and "must not meet". */
+function setDayState(button, state) {
+  button.dataset.state = state;
+  const day = DAY_LABELS[button.dataset.day] ?? button.dataset.day;
+  const said = state === "require" ? "required" : state === "avoid" ? "avoided" : "any";
+  button.setAttribute("aria-label", `${day}: ${said}`);
+  button.setAttribute("aria-pressed", String(state !== "any"));
+}
+
 function readFilters() {
   const data = new FormData(els.filters);
+  const { required, avoided } = dayStates();
   return {
     ...DEFAULTS,
-    days: data.getAll("day"),
+    days: required,
+    avoid: avoided,
     from: data.get("from") ?? "",
     to: data.get("to") ?? "",
     rating: data.get("rating") ?? "",
@@ -61,8 +90,11 @@ function readFilters() {
 }
 
 function writeFilters(params) {
-  for (const box of els.filters.querySelectorAll('input[name="day"]')) {
-    box.checked = params.getAll("day").includes(box.value);
+  const required = params.getAll("day");
+  const avoided = params.getAll("noday");
+  for (const button of els.days.querySelectorAll(".f-day")) {
+    const day = button.dataset.day;
+    setDayState(button, required.includes(day) ? "require" : avoided.includes(day) ? "avoid" : "any");
   }
   els.filters.from.value = params.get("from") ?? "";
   els.filters.to.value = params.get("to") ?? "";
@@ -218,7 +250,9 @@ function syncUrl(q, term) {
   // Filters live in the URL so a filtered view can be shared or reloaded.
   const f = readFilters();
   url.searchParams.delete("day");
+  url.searchParams.delete("noday");
   for (const day of f.days) url.searchParams.append("day", day);
+  for (const day of f.avoid) url.searchParams.append("noday", day);
   for (const [key, value] of [["from", f.from], ["to", f.to], ["rating", f.rating]]) {
     if (value) url.searchParams.set(key, value); else url.searchParams.delete(key);
   }
@@ -417,8 +451,18 @@ async function init() {
     paint();
   });
 
+  els.days.addEventListener("click", (event) => {
+    const button = event.target.closest(".f-day");
+    if (!button) return;
+    setDayState(button, NEXT_STATE[button.dataset.state] ?? "require");
+    showHidden = false;
+    syncUrl(els.query.value, els.term.value);
+    paint();
+  });
+
   els.clear.addEventListener("click", () => {
     els.filters.reset();
+    for (const button of els.days.querySelectorAll(".f-day")) setDayState(button, "any");
     showHidden = false;
     syncUrl(els.query.value, els.term.value);
     paint();

--- a/js/filters.js
+++ b/js/filters.js
@@ -8,7 +8,8 @@ import { seatsFor } from "./seats.js";
 const DAY_KEYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
 
 export const DEFAULTS = {
-  days: [],          // empty means no day constraint, not "no days"
+  days: [],          // days that must be met; empty means no constraint
+  avoid: [],         // days that must not be met
   from: "",          // earliest start, as minutes past midnight
   to: "",            // latest end
   rating: "",        // minimum average rating
@@ -58,9 +59,12 @@ function keepSection(section, filters) {
     if (best < Number(filters.rating)) return false;
   }
 
-  if (filters.days.length) {
-    const days = sectionDays(section);
-    if (days.size && !filters.days.every((d) => days.has(d))) return false;
+  // A section with no meeting pattern has no days to judge, so neither rule
+  // applies to it. Online and arranged sections must not vanish either way.
+  const meetsOn = sectionDays(section);
+  if (meetsOn.size) {
+    if (filters.days.length && !filters.days.every((d) => meetsOn.has(d))) return false;
+    if (filters.avoid.length && filters.avoid.some((d) => meetsOn.has(d))) return false;
   }
 
   const meeting = section.meetings?.find((m) => m.startTime) ?? null;
@@ -76,7 +80,7 @@ function keepSection(section, filters) {
 
 export function isActive(filters) {
   return Boolean(
-    filters.days.length || filters.from || filters.to || filters.rating ||
+    filters.days.length || filters.avoid.length || filters.from || filters.to || filters.rating ||
     filters.hideFull || filters.hideOnline || filters.ratedOnly
   );
 }


### PR DESCRIPTION
Closes #41

Day chips are now tri-state rather than on/off: **any → required → avoided → any**. One control, two meanings, no extra rows in the rail.

Avoided renders dashed and struck through, so it reads as "not this" without a legend.

## Measured, CSE 2221 Autumn 2026

```
baseline          22 sections
Fri required      11 sections   fr:require    the WeFr labs
Fri AVOIDED       11 sections   fr:avoid      the TuTh lectures
  url             ?q=CSE+2221&term=1268&noday=friday
  aria            "Friday: avoided"  aria-pressed=true
  sections still meeting Friday: 0
Fri back to any   22 sections
```

The two modes return complementary halves of the same 22 sections, which is the right shape, and nothing meeting Friday survives the avoid filter.

## Details
- **Buttons, not checkboxes**, since a checkbox cannot carry three states. Each announces its own state via `aria-label` ("Friday: avoided") rather than relying on colour and strikethrough, which a screen reader cannot see.
- **URL round-trips both modes**: `day=` for required, `noday=` for avoided.
- **Unknown data still never fails a filter.** A section with no meeting pattern has no days to judge, so neither rule applies and online sections do not vanish under either mode.
- Clear filters resets all chips to any, since `form.reset()` does not touch buttons.
