### PR TITLE
Give the landing screen something to do

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -799,3 +799,76 @@ body {
 .picker .f-ctl { cursor: text; }
 .picker .f-ctl:disabled { opacity: 0.5; cursor: default; }
 .picker .f-ctl::placeholder { color: var(--mute); }
+
+/* Landing screen ---------------------------------------------------------- */
+
+.welcome { max-width: 34rem; }
+
+.w-stats {
+  margin: 0 0 1.4rem;
+  font-family: var(--data);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+
+.w-head {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 1.15rem;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.25rem;
+}
+
+.w-sub { margin: 0 0 1rem; color: var(--mute); font-size: 0.85rem; }
+
+.w-list { list-style: none; margin: 0; padding: 0; }
+
+.w-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0 0.75rem;
+  align-items: baseline;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.w-name {
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  background: none;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+}
+
+.w-name:hover { text-decoration: underline; text-decoration-color: var(--scarlet); }
+
+.w-score {
+  font-family: var(--data);
+  font-size: 0.95rem;
+  color: var(--scarlet);
+}
+
+.w-meta {
+  grid-column: 1 / -1;
+  font-size: 0.75rem;
+  color: var(--mute);
+}
+
+.w-foot { margin: 1.2rem 0 0; font-size: 0.85rem; color: var(--mute); }
+
+.w-example {
+  font: inherit;
+  font-family: var(--data);
+  font-size: 0.82rem;
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--scarlet);
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/index.html
+++ b/index.html
@@ -121,6 +121,15 @@
       <p class="status" id="status" role="status" aria-live="polite" aria-atomic="true"></p>
 
       <div class="results" id="results" role="region" aria-label="Search results" tabindex="-1"></div>
+
+      <section class="welcome" id="welcome" hidden>
+        <p class="w-stats" id="w-stats"></p>
+        <h2 class="w-head">Highest rated instructors at Ohio State</h2>
+        <p class="w-sub" id="w-sub"></p>
+        <ul class="w-list" id="w-list"></ul>
+        <p class="w-foot">Or pick a subject in the rail, or type a course like
+          <button type="button" class="w-example" data-q="CSE 2221">CSE 2221</button>.</p>
+      </section>
     </main>
 
     <aside class="detail" id="detail" aria-label="Section detail" tabindex="-1">

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,8 @@
 import { fetchTerms, defaultTerm, searchAllPages, ApiError } from "./api.js";
 import { filterCourses } from "./rank.js";
 import { renderResults } from "./render.js";
-import { loadRatings } from "./ratings.js";
-import { loadSeats, seatsTerm, seatsUpdated } from "./seats.js";
+import { loadRatings, topRated, ratedCount, profileUrl } from "./ratings.js";
+import { loadSeats, seatsTerm, seatsUpdated, seatsSectionCount } from "./seats.js";
 import { renderDetail } from "./detail.js";
 import { applyFilters, isActive, DEFAULTS } from "./filters.js";
 import { renderCalendar } from "./calendar.js";
@@ -23,6 +23,10 @@ const els = {
   subjectList: document.querySelector("#subject-list"),
   numberList: document.querySelector("#number-list"),
   hint: document.querySelector("#p-hint"),
+  welcome: document.querySelector("#welcome"),
+  wStats: document.querySelector("#w-stats"),
+  wSub: document.querySelector("#w-sub"),
+  wList: document.querySelector("#w-list"),
   viewList: document.querySelector("#view-list"),
   viewCal: document.querySelector("#view-cal"),
   clear: document.querySelector("#f-clear"),
@@ -262,12 +266,62 @@ function syncUrl(q, term) {
   history.replaceState(null, "", url);
 }
 
+/**
+ * The landing screen. Everything here comes from snapshots already in memory,
+ * so it costs no extra request and never delays first paint. It also does not
+ * touch the course index, which #36 made lazy on purpose.
+ */
+function showWelcome(term) {
+  els.welcome.hidden = false;
+  const sections = seatsTerm() === term ? seatsSectionCount() : 0;
+  const bits = [termName(term)];
+  if (sections) bits.push(`${sections.toLocaleString()} sections`);
+  if (seatsTerm() === term && seatsUpdated()) bits.push(`seats as of ${formatDate(seatsUpdated())}`);
+  els.wStats.textContent = bits.join(" · ");
+
+  const best = topRated();
+  const rated = ratedCount();
+  // Deliberately does not claim these people teach this term. The ratings
+  // snapshot covers everyone RateMyProfessors knows about, and checking who is
+  // actually teaching would mean a search per name.
+  els.wSub.textContent = rated
+    ? `From ${rated.toLocaleString()} rated instructors, those with at least 50 ratings. Not all teach every term.`
+    : "";
+
+  els.wList.replaceChildren(
+    ...best.map((person) => {
+      const name = `${person.firstName} ${person.lastName}`;
+      const li = document.createElement("li");
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "w-name";
+      button.dataset.q = name;
+      button.textContent = name;
+      li.append(button);
+
+      const score = document.createElement("span");
+      score.className = "w-score";
+      score.textContent = Number(person.avgRating).toFixed(1);
+      li.append(score);
+
+      const meta = document.createElement("span");
+      meta.className = "w-meta";
+      meta.textContent = `${person.numRatings} ratings · ${person.department ?? ""}`;
+      li.append(meta);
+      return li;
+    })
+  );
+}
+
 async function runSearch(q, term) {
   if (!q.trim()) {
     els.results.replaceChildren();
-    setStatus("Type a course like CSE 2221, or a professor's name.");
+    showWelcome(term);
+    setStatus("");
     return;
   }
+  els.welcome.hidden = true;
 
   const requestId = ++latestRequest;
   setBusy(true);
@@ -508,10 +562,23 @@ async function init() {
     if (els.query.value.trim()) runSearch(els.query.value, els.term.value);
   });
 
+  els.welcome.addEventListener("click", (event) => {
+    const button = event.target.closest("[data-q]");
+    if (!button) return;
+    els.query.value = button.dataset.q;
+    syncUrl(button.dataset.q, els.term.value);
+    runSearch(button.dataset.q, els.term.value);
+  });
+
   const initialQuery = params.get("q") ?? "";
   els.query.value = initialQuery;
   if (initialQuery.trim()) runSearch(initialQuery, els.term.value);
-  else setStatus("Type a course like CSE 2221, or a professor's name.");
+  else {
+    // Ratings and seats are already in flight; fill the landing screen once
+    // they land rather than showing an empty frame in the meantime.
+    setStatus("");
+    Promise.allSettled([loadRatings(), loadSeats()]).then(() => showWelcome(els.term.value));
+  }
 }
 
 init();

--- a/js/ratings.js
+++ b/js/ratings.js
@@ -117,3 +117,21 @@ export function searchUrl(name) {
 export function profileUrl(legacyId) {
   return `https://www.ratemyprofessors.com/professor/${legacyId}`;
 }
+
+/**
+ * Best rated instructors, restricted to those with enough ratings to mean
+ * anything. 332 people clear 50 ratings; a 5.0 from two students does not
+ * belong on a leaderboard.
+ */
+export function topRated({ minRatings = 50, limit = 8 } = {}) {
+  const people = index?.byKey ? [...index.byKey.values()].flat() : [];
+  return people
+    .filter((p) => p.numRatings >= minRatings && p.avgRating != null)
+    .sort((a, b) => b.avgRating - a.avgRating || b.numRatings - a.numRatings)
+    .slice(0, limit);
+}
+
+/** How many instructors carry at least one rating. */
+export function ratedCount() {
+  return index?.byKey ? [...index.byKey.values()].reduce((n, list) => n + list.length, 0) : 0;
+}

--- a/js/seats.js
+++ b/js/seats.js
@@ -61,3 +61,8 @@ export function seatsFor(classNumber, term) {
     full: limit > 0 && enrolled >= limit,
   };
 }
+
+/** How many sections the snapshot covers, for the landing screen. */
+export function seatsSectionCount() {
+  return Object.keys(snapshot?.sections ?? {}).length;
+}


### PR DESCRIPTION
Closes #42

The first screen was an empty pane and a sentence telling you to type. It now shows the highest rated instructors at Ohio State, built entirely from snapshots already in memory.

```
requests on landing : ratings.json, seats.json
courses.json pulled : false                     <- #36's lazy loading intact

AUTUMN 2026 · 17,680 SECTIONS · SEATS AS OF AUG 18

Highest rated instructors at Ohio State
From 7,367 rated instructors, those with at least 50 ratings. Not all teach every term.

  Steve Yao              4.9    313 ratings · Fine Arts
  Amit Vutha             4.9    121 ratings · Mathematics
  Frederick Luis Aldama  4.9    105 ratings · English
  ...
```

Clicking a name runs a real search. Verified: clicking Steve Yao yields 24 courses, 34 sections.

## A claim I had to walk back
The heading first read "Best rated instructors **teaching this term**". That is not something this screen can know. The ratings snapshot covers every OSU instructor RateMyProfessors has, with no notion of who is teaching, and establishing it would mean one search per name on the landing screen.

It now says "Highest rated instructors at Ohio State" and the subtitle carries the caveat. Worth flagging because the false version looked better and read perfectly naturally.

## Constraints respected
- **No extra requests.** Ratings and seats are already in flight for the first search; this reuses them.
- **The course index stays lazy.** Verified `courses.json` is absent from the landing request list.
- **50-rating floor**, so the list means something. 332 instructors clear it, 948 clear 25, 95 clear 100.
- No marketing copy, no modal, no tour. A stat line, a list, and one worked example.
