### PR TITLE
Add a test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # node:test and node:assert only, so there is nothing to install.
+      - name: Run the suite
+        run: node --test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "finder",
+  "version": "0.0.0",
+  "private": true,
+  "description": "OSU course search that leads with the instructor",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,198 @@
+// The client is only tested for the request it builds and the errors it turns
+// responses into. fetch is replaced, so nothing here touches the network.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ApiError, fetchTerms, searchClasses, searchAllPages, termCodeFor, defaultTerm } from "../js/api.js";
+
+/** Record every request and answer each with the given body. */
+function capture(body, init = {}) {
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push(new URL(String(url)));
+    return {
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => {
+        if (init.badJson) throw new SyntaxError("Unexpected token");
+        return typeof body === "function" ? body(calls.length) : body;
+      },
+    };
+  };
+  return calls;
+}
+
+const original = globalThis.fetch;
+test.afterEach(() => { globalThis.fetch = original; });
+
+const searchBody = { data: { totalItems: 2, totalPages: 1, courses: [{ course: { subject: "CSE" }, sections: [] }] } };
+
+// Regression, #12. Upstream dereferences q without checking it exists, so
+// leaving it off returns a 500 rather than an unfiltered search.
+test("regression #12: an empty query still sends q=", () => {
+  const cases = ["", null, undefined];
+  return Promise.all(
+    cases.map(async (q) => {
+      const calls = capture(searchBody);
+      await searchClasses({ q, term: "1268" });
+      const url = calls[0];
+      assert.ok(url.searchParams.has("q"), `q is missing for ${JSON.stringify(q)}`);
+      assert.equal(url.searchParams.get("q"), "");
+      assert.ok(url.search.includes("q="), url.search);
+    })
+  );
+});
+
+test("searchClasses sends the campus, term and page alongside the query", async () => {
+  const calls = capture(searchBody);
+  await searchClasses({ q: "CSE 2221", term: "1268", page: 3 });
+  const url = calls[0];
+  assert.equal(url.origin + url.pathname, "https://content.osu.edu/v2/classes/search");
+  assert.equal(url.searchParams.get("q"), "CSE 2221");
+  assert.equal(url.searchParams.get("campus"), "col");
+  assert.equal(url.searchParams.get("term"), "1268");
+  assert.equal(url.searchParams.get("p"), "3");
+});
+
+test("searchClasses defaults to page one and reports the totals", async () => {
+  capture(searchBody);
+  const result = await searchClasses({ q: "CSE", term: "1268" });
+  assert.equal(result.page, 1);
+  assert.equal(result.totalItems, 2);
+  assert.equal(result.courses.length, 1);
+});
+
+test("searchClasses refuses to search without a term", async () => {
+  capture(searchBody);
+  await assert.rejects(() => searchClasses({ q: "CSE" }), ApiError);
+});
+
+test("an error status becomes a readable ApiError carrying the status", async () => {
+  capture(searchBody, { ok: false, status: 503 });
+  await assert.rejects(
+    () => searchClasses({ q: "", term: "1268" }),
+    (err) => {
+      assert.ok(err instanceof ApiError);
+      assert.equal(err.status, 503);
+      assert.match(err.message, /503/);
+      return true;
+    }
+  );
+});
+
+test("a body that is not JSON becomes an ApiError", async () => {
+  capture(searchBody, { badJson: true });
+  await assert.rejects(() => searchClasses({ q: "", term: "1268" }), ApiError);
+});
+
+test("a body with no data envelope becomes an ApiError", async () => {
+  capture({ error: "nope" });
+  await assert.rejects(() => searchClasses({ q: "", term: "1268" }), ApiError);
+});
+
+test("a failed connection becomes an ApiError rather than a TypeError", async () => {
+  globalThis.fetch = async () => { throw new TypeError("fetch failed"); };
+  await assert.rejects(
+    () => searchClasses({ q: "", term: "1268" }),
+    (err) => {
+      assert.ok(err instanceof ApiError);
+      assert.match(err.message, /Could not reach/);
+      return true;
+    }
+  );
+});
+
+test("an abort becomes the timeout message", async () => {
+  globalThis.fetch = async () => {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    throw err;
+  };
+  await assert.rejects(
+    () => searchClasses({ q: "", term: "1268" }),
+    (err) => {
+      assert.match(err.message, /taking too long/);
+      return true;
+    }
+  );
+});
+
+test("fetchTerms keeps only real terms and sorts them newest first", async () => {
+  capture({
+    data: {
+      data: [
+        { strm: 1262, descr: "Spring 2026", startDate: "2026-01-05", endDate: "2026-04-24" },
+        { descr: "Broken row with no strm" },
+        { strm: 1268, descr: "Autumn 2026" },
+        { strm: 1264 },
+      ],
+    },
+  });
+  const terms = await fetchTerms();
+  assert.deepEqual(terms.map((t) => t.code), ["1268", "1264", "1262"]);
+  assert.equal(terms[2].name, "Spring 2026");
+  assert.equal(terms[1].name, "1264", "a term with no description falls back to its code");
+  assert.equal(terms[0].startDate, null);
+});
+
+test("termCodeFor derives the strm code from the month", () => {
+  assert.equal(termCodeFor(new Date("2026-03-01T12:00:00Z")), "1262");
+  assert.equal(termCodeFor(new Date("2026-06-01T12:00:00Z")), "1264");
+  assert.equal(termCodeFor(new Date("2026-08-18T12:00:00Z")), "1268");
+  assert.equal(termCodeFor(new Date("2026-04-30T12:00:00Z")), "1262", "April is still spring");
+  assert.equal(termCodeFor(new Date("2026-07-31T12:00:00Z")), "1264", "July is still summer");
+  assert.equal(termCodeFor(new Date("2027-01-05T12:00:00Z")), "1272");
+});
+
+test("defaultTerm picks today's term when it is searchable", () => {
+  const terms = [{ code: "1268" }, { code: "1264" }, { code: "1262" }];
+  assert.equal(defaultTerm(terms, new Date("2026-08-18T12:00:00Z")).code, "1268");
+});
+
+test("defaultTerm falls back to the newest term rather than nothing", () => {
+  const terms = [{ code: "1264" }, { code: "1262" }];
+  assert.equal(defaultTerm(terms, new Date("2026-08-18T12:00:00Z")).code, "1264");
+  assert.equal(defaultTerm([], new Date()), null);
+  assert.equal(defaultTerm(null, new Date()), null);
+});
+
+test("searchAllPages merges the pages it fetched", async () => {
+  const calls = capture((n) => ({
+    data: { totalItems: 9, totalPages: 3, courses: [{ course: { subject: "CSE", catalogNumber: String(n) }, sections: [] }] },
+  }));
+  const result = await searchAllPages({ q: "Smith", term: "1268" });
+  assert.equal(result.pagesFetched, 3);
+  assert.equal(result.courses.length, 3);
+  assert.deepEqual(calls.map((u) => u.searchParams.get("p")).sort(), ["1", "2", "3"]);
+});
+
+test("searchAllPages stops at maxPages", async () => {
+  const calls = capture({ data: { totalItems: 100, totalPages: 7, courses: [] } });
+  const result = await searchAllPages({ q: "CSE", term: "1268", maxPages: 2 });
+  assert.equal(result.pagesFetched, 2);
+  assert.equal(calls.length, 2);
+});
+
+test("searchAllPages does not fetch again for a single page", async () => {
+  const calls = capture({ data: { totalItems: 1, totalPages: 1, courses: [] } });
+  const result = await searchAllPages({ q: "CSE 2221", term: "1268" });
+  assert.equal(result.pagesFetched, 1);
+  assert.equal(calls.length, 1);
+});
+
+test("one failing page does not sink the whole search", async () => {
+  let n = 0;
+  globalThis.fetch = async () => {
+    n += 1;
+    if (n > 1) throw new TypeError("fetch failed");
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { totalItems: 4, totalPages: 2, courses: [{ course: {}, sections: [] }] } }),
+    };
+  };
+  const result = await searchAllPages({ q: "Smith", term: "1268" });
+  assert.equal(result.courses.length, 1);
+  assert.equal(result.pagesFetched, 2);
+});

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSlots } from "../js/calendar.js";
+import { entry, meeting, person, section, taught } from "./fixtures.js";
+import { withSeats } from "./helpers.js";
+
+// buildSlots asks seats.js for each section, so the snapshot has to be loaded.
+await withSeats();
+
+const TERM = "1268";
+const MWF = ["monday", "wednesday", "friday"];
+
+// The case the collapse exists for: three sections of one course at the same
+// hour on the same days, taught by three different people.
+const shared = () => [
+  entry("CSE", "2321", "Foundations 1", [
+    taught(1001, MWF, "3:00 PM", "3:55 PM", ["Charles Estill"]),
+    taught(1002, MWF, "3:00 PM", "3:55 PM", ["Ramin Yarinezhad"]),
+    taught(1003, MWF, "3:00 PM", "3:55 PM", ["Luan Duong"]),
+  ]),
+];
+
+// Regression, #33. Slicing one column three ways is unreadable, and the point
+// of the view is comparing the instructors in that hour.
+test("regression #33: sections sharing a day pattern and time collapse into one slot", () => {
+  const { slots, unscheduled } = buildSlots(shared(), TERM);
+  assert.equal(slots.length, 1);
+  assert.equal(slots[0].items.length, 3);
+  assert.deepEqual(slots[0].days, MWF);
+  assert.equal(slots[0].start, 900);
+  assert.equal(slots[0].end, 955);
+  assert.equal(unscheduled.length, 0);
+});
+
+test("regression #33: the collapse holds across different courses at the same hour", () => {
+  const entries = [
+    entry("CSE", "2321", "Foundations 1", [taught(1001, MWF, "3:00 PM", "3:55 PM", ["Charles Estill"])]),
+    entry("MATH", "1151", "Calculus", [taught(3001, MWF, "3:00 PM", "3:55 PM", ["Diana Kline"])]),
+  ];
+  const { slots } = buildSlots(entries, TERM);
+  assert.equal(slots.length, 1);
+  assert.equal(slots[0].items.length, 2);
+});
+
+test("a different time or a different day pattern is a different slot", () => {
+  const entries = [
+    entry("CSE", "2321", "Foundations 1", [
+      taught(1001, MWF, "3:00 PM", "3:55 PM", ["A"]),
+      taught(1002, MWF, "4:00 PM", "4:55 PM", ["B"]),
+      taught(1003, ["tuesday", "thursday"], "3:00 PM", "3:55 PM", ["C"]),
+      taught(1004, ["monday", "wednesday"], "3:00 PM", "3:55 PM", ["D"]),
+    ]),
+  ];
+  const { slots } = buildSlots(entries, TERM);
+  assert.equal(slots.length, 4);
+  for (const slot of slots) assert.equal(slot.items.length, 1);
+});
+
+test("every section lands in exactly one slot or in the unscheduled list", () => {
+  const entries = [
+    entry("CSE", "2321", "Foundations 1", [
+      taught(1001, MWF, "3:00 PM", "3:55 PM", ["A"]),
+      taught(1002, MWF, "3:00 PM", "3:55 PM", ["B"]),
+      section(1005, { meetings: [] }),
+    ]),
+  ];
+  const { slots, unscheduled } = buildSlots(entries, TERM);
+  const placed = slots.reduce((n, s) => n + s.items.length, 0) + unscheduled.length;
+  assert.equal(placed, 3);
+});
+
+test("a section with no usable meeting is unscheduled rather than dropped", () => {
+  const entries = [
+    entry("CSE", "2321", "Foundations 1", [
+      section(1001, { meetings: [] }),
+      section(1002, { instructionMode: "Distance Learning - Online" }),
+      // A time but no day, so it cannot be placed on the grid.
+      section(1003, { meetings: [meeting([], "3:00 PM", "3:55 PM", [person("A")])] }),
+      // A day but no time, likewise.
+      section(1004, { meetings: [meeting(MWF, null, null, [person("B")])] }),
+      // A time that does not parse.
+      section(1005, { meetings: [meeting(MWF, "TBA", "TBA", [person("C")])] }),
+    ]),
+  ];
+  const { slots, unscheduled } = buildSlots(entries, TERM);
+  assert.equal(slots.length, 0);
+  assert.deepEqual(unscheduled.map((u) => u.section.classNumber), [1001, 1002, 1003, 1004, 1005]);
+  assert.equal(unscheduled[0].entry.course.catalogNumber, "2321");
+});
+
+test("a missing end time falls back to a 55 minute class", () => {
+  const entries = [entry("CSE", "2321", "Foundations 1", [taught(1001, MWF, "3:00 PM", null, ["A"])])];
+  const { slots } = buildSlots(entries, TERM);
+  assert.equal(slots[0].start, 900);
+  assert.equal(slots[0].end, 955);
+});
+
+test("buildSlots picks the first meeting that has both a day and a time", () => {
+  const entries = [
+    entry("CSE", "2321", "Foundations 1", [
+      section(1001, {
+        meetings: [
+          meeting([], "8:00 AM", "9:00 AM", [person("A")]),
+          meeting(MWF, "3:00 PM", "3:55 PM", [person("A")]),
+        ],
+      }),
+    ]),
+  ];
+  const { slots } = buildSlots(entries, TERM);
+  assert.equal(slots.length, 1);
+  assert.equal(slots[0].start, 900);
+});
+
+test("each item carries the seats for its own section", () => {
+  const entries = [
+    entry("CSE", "2321", "Foundations 1", [
+      taught(1001, MWF, "3:00 PM", "3:55 PM", ["A"]),  // open
+      taught(1002, MWF, "3:00 PM", "3:55 PM", ["B"]),  // full
+      taught(5555, MWF, "3:00 PM", "3:55 PM", ["C"]),  // not in the snapshot
+    ]),
+  ];
+  const { slots } = buildSlots(entries, TERM);
+  const [open, full, unknown] = slots[0].items;
+  assert.equal(open.seats.full, false);
+  assert.equal(full.seats.full, true);
+  assert.equal(unknown.seats, null);
+});
+
+test("seats stay absent when the term does not match the snapshot", () => {
+  const { slots } = buildSlots(shared(), "1262");
+  for (const item of slots[0].items) assert.equal(item.seats, null);
+});
+
+test("buildSlots handles an empty result set", () => {
+  assert.deepEqual(buildSlots([], TERM), { slots: [], unscheduled: [] });
+  assert.deepEqual(buildSlots([entry("CSE", "2321", "Foundations 1", [])], TERM), { slots: [], unscheduled: [] });
+});

--- a/tests/courses.test.js
+++ b/tests/courses.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { stubFetch } from "./helpers.js";
+
+const INDEX = {
+  built: "2026-08-18",
+  terms: {
+    1268: {
+      subjects: [
+        { code: "MATH", name: "Mathematics", courses: [["1151", "Calculus I", 5, 5], ["1172", "Engineering Calculus", 5, 5]] },
+        { code: "CSE", name: "Computer Science and Engineering", courses: [["2221", "Software I", 4, 4]] },
+        // 15 subjects upstream have no name of their own.
+        { code: "CYBRSEC", name: "CYBRSEC", courses: [] },
+        { code: "NONAME", courses: [] },
+      ],
+    },
+    1262: { subjects: [{ code: "CSE", name: "Computer Science and Engineering", courses: [] }] },
+  },
+};
+
+const courses = await (async () => {
+  const mod = await import("../js/courses.js");
+  const restore = stubFetch({ "courses.json": INDEX });
+  try {
+    await mod.loadCourses("courses.json");
+  } finally {
+    restore();
+  }
+  return mod;
+})();
+
+test("isLoaded flips once the index is in", async () => {
+  const fresh = await import("../js/courses.js?unloaded");
+  assert.equal(fresh.isLoaded(), false);
+  assert.equal(courses.isLoaded(), true);
+});
+
+test("subjectsFor sorts by code and is scoped to one term", () => {
+  assert.deepEqual(courses.subjectsFor("1268").map((s) => s.code), ["CSE", "CYBRSEC", "MATH", "NONAME"]);
+  assert.deepEqual(courses.subjectsFor(1262).map((s) => s.code), ["CSE"]);
+  assert.deepEqual(courses.subjectsFor("9999"), []);
+});
+
+test("subjectsFor does not reorder the stored index", () => {
+  courses.subjectsFor("1268");
+  assert.equal(INDEX.terms[1268].subjects[0].code, "MATH");
+});
+
+test("subjectLabel does not repeat a code that stands in for a name", () => {
+  assert.equal(subjectLabelOf("CSE"), "CSE — Computer Science and Engineering");
+  assert.equal(subjectLabelOf("CYBRSEC"), "CYBRSEC");
+  assert.equal(subjectLabelOf("NONAME"), "NONAME");
+  assert.equal(courses.subjectLabel(null), "");
+});
+
+function subjectLabelOf(code) {
+  return courses.subjectLabel(courses.subjectsFor("1268").find((s) => s.code === code));
+}
+
+test("coursesFor unpacks the compact course tuples", () => {
+  assert.deepEqual(courses.coursesFor("1268", "MATH"), [
+    { number: "1151", title: "Calculus I", min: 5, max: 5 },
+    { number: "1172", title: "Engineering Calculus", min: 5, max: 5 },
+  ]);
+});
+
+test("coursesFor accepts a lowercase code and is empty for an unknown one", () => {
+  assert.equal(courses.coursesFor("1268", "cse").length, 1);
+  assert.deepEqual(courses.coursesFor("1268", "NOPE"), []);
+  assert.deepEqual(courses.coursesFor("1268", null), []);
+  assert.deepEqual(courses.coursesFor("1268", "CYBRSEC"), []);
+});
+
+test("codeFromInput pulls the bare code out of a picker label", () => {
+  assert.equal(courses.codeFromInput("CSE — Computer Science and Engineering"), "CSE");
+  assert.equal(courses.codeFromInput("cse"), "CSE");
+  assert.equal(courses.codeFromInput("  math  "), "MATH");
+  assert.equal(courses.codeFromInput("CYBRSEC"), "CYBRSEC");
+  assert.equal(courses.codeFromInput(""), "");
+  assert.equal(courses.codeFromInput(null), "");
+});

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -1,0 +1,167 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULTS, toMinutes, isActive, applyFilters } from "../js/filters.js";
+import { entry, section, taught } from "./fixtures.js";
+import { withRatings, withSeats } from "./helpers.js";
+
+// filters.js reads seats and ratings through the shared module state, so the
+// real snapshots have to be in place before any of that is exercised.
+await withSeats();
+await withRatings();
+
+const TERM = "1268";
+const filters = (over = {}) => ({ ...DEFAULTS, term: TERM, ...over });
+
+// 1001 is open in the snapshot and 1002 is full. 5003 and 5004 are absent from
+// it, which is the unknown case.
+const morning = taught(1001, ["monday", "wednesday", "friday"], "9:10 AM", "10:05 AM", ["Diana Ikenberry Kline"]);
+const evening = taught(1002, ["tuesday", "thursday"], "6:30 PM", "7:50 PM", ["Nobody Here"]);
+const online = section(5003, {
+  instructionMode: "Distance Learning - Online",
+  meetings: [],
+});
+const arranged = section(5004, { meetings: [] });
+
+const course = () => entry("CSE", "2221", "Software I", [morning, evening, online, arranged]);
+
+test("toMinutes reads a twelve hour clock", () => {
+  assert.equal(toMinutes("8:00 am"), 480);
+  assert.equal(toMinutes("9:10 AM"), 550);
+  assert.equal(toMinutes("12:30 pm"), 750);
+  assert.equal(toMinutes("6:30 pm"), 1110);
+  assert.equal(toMinutes("11:59 pm"), 1439);
+});
+
+test("toMinutes puts midnight and noon on the right side of the day", () => {
+  assert.equal(toMinutes("12:00 am"), 0);
+  assert.equal(toMinutes("12:45 am"), 45);
+  assert.equal(toMinutes("12:00 pm"), 720);
+});
+
+test("toMinutes tolerates a missing m and stray whitespace", () => {
+  assert.equal(toMinutes("8:00a"), 480);
+  assert.equal(toMinutes("  8:00   p  "), 1200);
+});
+
+test("toMinutes returns null rather than guessing", () => {
+  for (const junk of ["", "   ", null, undefined, "8:00", "800am", "Time to be announced", "8:0 am"]) {
+    assert.equal(toMinutes(junk), null, `${junk} should not parse`);
+  }
+});
+
+test("isActive is false for the defaults", () => {
+  assert.equal(isActive(DEFAULTS), false);
+  assert.equal(isActive(filters()), false);
+});
+
+test("isActive notices any one filter", () => {
+  assert.equal(isActive(filters({ days: ["monday"] })), true);
+  assert.equal(isActive(filters({ from: "540" })), true);
+  assert.equal(isActive(filters({ to: "1020" })), true);
+  assert.equal(isActive(filters({ rating: "4" })), true);
+  assert.equal(isActive(filters({ hideFull: true })), true);
+  assert.equal(isActive(filters({ hideOnline: true })), true);
+  assert.equal(isActive(filters({ ratedOnly: true })), true);
+});
+
+test("applyFilters is a pass through when nothing is set", () => {
+  const entries = [course()];
+  const result = applyFilters(entries, filters());
+  assert.equal(result.entries, entries, "the same array comes back, not a copy");
+  assert.equal(result.hiddenSections, 0);
+  assert.equal(result.hiddenCourses, 0);
+});
+
+test("a day filter keeps sections that meet on all the chosen days", () => {
+  const { entries } = applyFilters([course()], filters({ days: ["monday", "friday"] }));
+  const kept = entries[0].sections.map((s) => s.classNumber);
+  assert.ok(kept.includes(1001));
+  assert.ok(!kept.includes(1002), "a TuTh section fails a MoFr filter");
+});
+
+test("unknown days never fail a day filter", () => {
+  const { entries } = applyFilters([course()], filters({ days: ["monday"] }));
+  const kept = entries[0].sections.map((s) => s.classNumber);
+  assert.ok(kept.includes(5003), "an online section has no pattern to judge");
+  assert.ok(kept.includes(5004), "neither does an arranged section");
+});
+
+test("a time window filters on start and end", () => {
+  const early = applyFilters([course()], filters({ to: "780" })).entries[0].sections;
+  assert.deepEqual(early.map((s) => s.classNumber), [1001, 5003, 5004]);
+
+  const late = applyFilters([course()], filters({ from: "720" })).entries[0].sections;
+  assert.deepEqual(late.map((s) => s.classNumber), [1002, 5003, 5004]);
+});
+
+test("unknown times never fail a time filter", () => {
+  const { entries } = applyFilters([course()], filters({ from: "540", to: "660" }));
+  const kept = entries[0].sections.map((s) => s.classNumber);
+  assert.deepEqual(kept, [1001, 5003, 5004]);
+});
+
+test("a section with no end time is judged on its start", () => {
+  const open = entry("CSE", "1", "T", [taught(7001, ["monday"], "9:00 AM", null, ["Someone"])]);
+  assert.equal(applyFilters([open], filters({ to: "600" })).entries.length, 1);
+  assert.equal(applyFilters([open], filters({ to: "500" })).entries.length, 0);
+});
+
+test("hideOnline drops only what the instruction mode says is online", () => {
+  const { entries, hiddenSections } = applyFilters([course()], filters({ hideOnline: true }));
+  assert.deepEqual(entries[0].sections.map((s) => s.classNumber), [1001, 1002, 5004]);
+  assert.equal(hiddenSections, 1);
+});
+
+test("hideFull drops a full section and keeps one with no seat data", () => {
+  const { entries } = applyFilters([course()], filters({ hideFull: true }));
+  const kept = entries[0].sections.map((s) => s.classNumber);
+  assert.ok(kept.includes(1001), "an open section stays");
+  assert.ok(!kept.includes(1002), "a full section goes");
+  assert.ok(kept.includes(5003) && kept.includes(5004), "unknown seats never fail the filter");
+});
+
+test("hideFull hides nothing when the term does not match the snapshot", () => {
+  const { entries, hiddenSections } = applyFilters([course()], filters({ hideFull: true, term: "1262" }));
+  assert.equal(entries[0].sections.length, 4);
+  assert.equal(hiddenSections, 0);
+});
+
+test("ratedOnly keeps sections whose instructor was matched", () => {
+  const { entries } = applyFilters([course()], filters({ ratedOnly: true }));
+  assert.deepEqual(entries[0].sections.map((s) => s.classNumber), [1001]);
+});
+
+test("a minimum rating compares against the best rated instructor on the section", () => {
+  const cotaught = entry("CSE", "2231", "Software II", [
+    taught(8001, ["monday"], "9:00 AM", "9:55 AM", ["Diana Ikenberry Kline", "Nobody Here"]),
+  ]);
+  assert.equal(applyFilters([cotaught], filters({ rating: "4" })).entries.length, 1);
+  assert.equal(applyFilters([cotaught], filters({ rating: "4.5" })).entries.length, 0);
+});
+
+test("a minimum rating does drop a section nobody has rated", () => {
+  // Worth stating plainly, because it is the one place where unknown data does
+  // fail a filter. An unrated instructor scores -1 against any minimum.
+  const { entries } = applyFilters([course()], filters({ rating: "1" }));
+  assert.deepEqual(entries[0].sections.map((s) => s.classNumber), [1001]);
+});
+
+test("applyFilters counts what it removed", () => {
+  const other = entry("CSE", "2231", "Software II", [
+    taught(9001, ["tuesday", "thursday"], "6:30 PM", "7:50 PM", ["Nobody Here"]),
+  ]);
+  const { entries, hiddenSections, hiddenCourses } = applyFilters(
+    [course(), other],
+    filters({ days: ["monday"] })
+  );
+  assert.equal(entries.length, 1, "the course with nothing left drops out");
+  assert.equal(hiddenCourses, 1);
+  assert.equal(hiddenSections, 2, "one TuTh section in each course");
+});
+
+test("applyFilters does not mutate the entries it was given", () => {
+  const entries = [course()];
+  applyFilters(entries, filters({ days: ["monday"] }));
+  assert.equal(entries[0].sections.length, 4);
+});

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -1,0 +1,100 @@
+// Hand-written fixtures. Shapes are copied from the live API and the two data
+// snapshots, trimmed to the fields the code actually reads.
+
+export function person(displayName, extra = {}) {
+  return { displayName, email: extra.email ?? null, role: extra.role ?? "PI" };
+}
+
+/** One meeting pattern. `days` are full lowercase day keys. */
+export function meeting(days, startTime = null, endTime = null, instructors = [], extra = {}) {
+  const m = { startTime, endTime, instructors, ...extra };
+  for (const day of days) m[day] = true;
+  return m;
+}
+
+export function section(classNumber, opts = {}) {
+  return {
+    classNumber,
+    component: opts.component ?? "Lecture",
+    instructionMode: opts.instructionMode ?? "In Person",
+    meetings: opts.meetings ?? [],
+  };
+}
+
+export function entry(subject, catalogNumber, title, sections = [], opts = {}) {
+  return {
+    course: {
+      subject,
+      catalogNumber,
+      title,
+      minUnits: opts.minUnits ?? 3,
+      maxUnits: opts.maxUnits ?? 3,
+    },
+    sections,
+  };
+}
+
+/** A lecture on the given days at the given time, taught by the given names. */
+export function taught(classNumber, days, start, end, names, opts = {}) {
+  return section(classNumber, {
+    ...opts,
+    meetings: [meeting(days, start, end, names.map((n) => person(n)))],
+  });
+}
+
+// Seat snapshot. Term 1268 only, which is what makes the term guard testable.
+export const SEATS = {
+  term: "1268",
+  termName: "Autumn 2026",
+  source: "https://www.asc.ohio-state.edu/barrett.3/schedule/",
+  sourceUpdated: "2026-08-18",
+  fields: ["enrolled", "limit", "waitlist"],
+  sections: {
+    "1001": [30, 40, 0],    // open
+    "1002": [40, 40, 3],    // exactly full, three waiting
+    "1003": [41, 40, 1],    // over cap, which OSU's own API calls open
+    "1004": [0, 0, 1],      // no published capacity, someone already waiting
+    "1005": [12],           // malformed, too short
+    "1006": ["12", 40, 0],  // malformed, enrolled is not a number
+    "1007": [5, 30],        // no waitlist column
+  },
+};
+
+// Ratings snapshot. Every professor here exists to exercise one join case.
+export const RATINGS = {
+  school: { id: "U2Nob29sLTcyNA==", legacyId: 724, name: "Ohio State University" },
+  count: 9,
+  professors: [
+    // Plain unique match, and the middle-name case: OSU says "Diana Ikenberry
+    // Kline", RMP says "Diana Kline".
+    prof(1, "Diana", "Kline", 4.2, 31),
+    // Nickname the query is a prefix of: OSU "Timothy Long", RMP "Tim Long".
+    prof(2, "Tim", "Long", 3.4, 12),
+    // Shared initial only, and the sole Gomori, so the weak rule is allowed.
+    prof(3, "Stephen", "Gomori", 4.8, 60),
+    // Two real people with the same name. Never guess between them.
+    prof(4, "Alan", "Reed", 2.1, 40),
+    prof(5, "Alan", "Reed", 4.6, 9),
+    // Two Vances with the same initial. A shared initial must not be enough.
+    prof(6, "Maria", "Vance", 3.9, 22),
+    prof(7, "Marcus", "Vance", 4.4, 18),
+    // Two plausible expansions of "Jon". Both viable means neither wins.
+    prof(8, "Jonathan", "Park", 3.1, 15),
+    prof(9, "Jonas", "Park", 4.0, 11),
+    // Suffix case: the OSU name is "Ivan C. Smith III".
+    prof(10, "Ivan", "Smith", 3.7, 8),
+  ],
+};
+
+function prof(legacyId, firstName, lastName, avgRating, numRatings) {
+  return {
+    legacyId,
+    firstName,
+    lastName,
+    department: "Computer Science",
+    avgRating,
+    numRatings,
+    avgDifficulty: 3,
+    wouldTakeAgainPercent: null,
+  };
+}

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatDays, formatTime, formatWhen, formatPlace, formatUnits, instructorsOf } from "../js/format.js";
+import { meeting, person, section } from "./fixtures.js";
+
+const DASH = "\u2013";
+
+test("formatDays abbreviates in week order", () => {
+  assert.equal(formatDays(meeting(["monday", "wednesday", "friday"])), "MoWeFr");
+  assert.equal(formatDays(meeting(["friday", "monday"])), "MoFr");
+  assert.equal(formatDays(meeting(["tuesday", "thursday"])), "TuTh");
+  assert.equal(
+    formatDays(meeting(["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"])),
+    "MoTuWeThFrSaSu"
+  );
+});
+
+test("formatDays is empty for no days and for no meeting", () => {
+  assert.equal(formatDays(meeting([])), "");
+  assert.equal(formatDays(null), "");
+  assert.equal(formatDays(undefined), "");
+});
+
+test("formatTime drops the space and the m", () => {
+  assert.equal(formatTime(meeting([], "8:00 AM", "9:20 AM")), `8:00a${DASH}9:20a`);
+  assert.equal(formatTime(meeting([], "12:45 PM", "2:05 PM")), `12:45p${DASH}2:05p`);
+});
+
+test("formatTime handles a start with no end", () => {
+  assert.equal(formatTime(meeting([], "8:00 AM")), "8:00a");
+});
+
+test("formatTime is empty without a start time", () => {
+  assert.equal(formatTime(meeting([])), "");
+  assert.equal(formatTime(null), "");
+});
+
+test("formatWhen joins days and time", () => {
+  assert.equal(formatWhen(meeting(["monday", "wednesday"], "3:00 PM", "3:55 PM")), `MoWe 3:00p${DASH}3:55p`);
+});
+
+test("formatWhen says so when there is nothing to say", () => {
+  assert.equal(formatWhen(meeting([])), "Time to be announced");
+  assert.equal(formatWhen(null), "Time to be announced");
+});
+
+test("formatWhen keeps whichever half it has", () => {
+  assert.equal(formatWhen(meeting(["tuesday"])), "Tu");
+  assert.equal(formatWhen(meeting([], "9:00 AM")), "9:00a");
+});
+
+test("formatPlace prefers the instruction mode when online", () => {
+  const m = meeting(["monday"], "1:00 PM", "2:00 PM", [], { buildingDescriptionShort: "Dreese Labs" });
+  assert.equal(formatPlace(m, { instructionMode: "Distance Learning - Online" }), "Distance Learning - Online");
+  assert.equal(formatPlace(m, { instructionMode: "In Person" }), "Dreese Labs");
+});
+
+test("formatPlace falls back through the building fields", () => {
+  assert.equal(formatPlace({ facilityDescriptionShort: "DL 266" }, null), "DL 266");
+  assert.equal(formatPlace({ facilityDescription: "Dreese Laboratories 266" }, null), "Dreese Laboratories 266");
+  assert.equal(formatPlace({}, null), "Location to be announced");
+  assert.equal(formatPlace(null, null), "Location to be announced");
+});
+
+test("formatUnits pluralises and collapses a fixed range", () => {
+  assert.equal(formatUnits({ minUnits: 4, maxUnits: 4 }), "4 credits");
+  assert.equal(formatUnits({ minUnits: 1, maxUnits: 1 }), "1 credit");
+  assert.equal(formatUnits({ minUnits: 1, maxUnits: 5 }), `1${DASH}5 credits`);
+});
+
+test("formatUnits is empty when the course carries no units", () => {
+  assert.equal(formatUnits({}), "");
+  assert.equal(formatUnits(null), "");
+  assert.equal(formatUnits({ minUnits: 3, maxUnits: null }), "3 credits");
+});
+
+test("instructorsOf dedupes a name repeated across meetings", () => {
+  const s = section(1001, {
+    meetings: [
+      meeting(["monday"], "9:00 AM", "9:55 AM", [person("Paolo Bucci", { email: "bucci@osu.edu" })]),
+      meeting(["wednesday"], "9:00 AM", "9:55 AM", [person("Paolo Bucci")]),
+      meeting(["friday"], "9:00 AM", "9:55 AM", [person("Paolo Bucci")]),
+    ],
+  });
+  const people = instructorsOf(s);
+  assert.equal(people.length, 1);
+  assert.equal(people[0].name, "Paolo Bucci");
+  assert.equal(people[0].email, "bucci@osu.edu");
+  assert.equal(people[0].role, "PI");
+});
+
+test("instructorsOf keeps every distinct instructor in order", () => {
+  const s = section(1002, {
+    meetings: [meeting(["tuesday"], "1:00 PM", "2:20 PM", [person("KT Vandergriff"), person("Steve Gomori")])],
+  });
+  assert.deepEqual(instructorsOf(s).map((p) => p.name), ["KT Vandergriff", "Steve Gomori"]);
+});
+
+test("instructorsOf trims names and skips blank ones", () => {
+  const s = section(1003, {
+    meetings: [meeting(["monday"], "9:00 AM", "9:55 AM", [person("  Paolo Bucci  "), person("   "), person(null)])],
+  });
+  assert.deepEqual(instructorsOf(s).map((p) => p.name), ["Paolo Bucci"]);
+});
+
+test("instructorsOf survives missing meetings and missing instructors", () => {
+  assert.deepEqual(instructorsOf(section(1004)), []);
+  assert.deepEqual(instructorsOf({ classNumber: 1005 }), []);
+  assert.deepEqual(instructorsOf(null), []);
+  assert.deepEqual(instructorsOf({ meetings: [{ startTime: "9:00 AM" }] }), []);
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,48 @@
+// Loading real snapshots into the real modules.
+//
+// ratings.js and seats.js hold their data in module-level state that only
+// loadRatings/loadSeats can fill, and both fill it from fetch. Rather than
+// hand-building the index and skipping the code that builds it, these helpers
+// serve a fixture over a stubbed fetch and let the real loaders run.
+
+import { RATINGS, SEATS } from "./fixtures.js";
+
+/** Swap in a fetch that serves fixtures by URL. Returns a restore function. */
+export function stubFetch(routes) {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const key = String(url);
+    if (!(key in routes)) throw new Error(`unexpected fetch: ${key}`);
+    return { ok: true, status: 200, json: async () => routes[key] };
+  };
+  return () => { globalThis.fetch = original; };
+}
+
+/**
+ * Load a snapshot into a module instance.
+ *
+ * `suffix` picks the instance. Both modules cache after the first load, so a
+ * test that needs a different snapshot, or none at all, asks for a fresh
+ * instance by passing a suffix the import cache has not seen.
+ */
+export async function withSeats(snapshot = SEATS, suffix = "") {
+  const mod = await import(`../js/seats.js${suffix}`);
+  const restore = stubFetch({ "seats.json": snapshot });
+  try {
+    await mod.loadSeats("seats.json");
+  } finally {
+    restore();
+  }
+  return mod;
+}
+
+export async function withRatings(data = RATINGS, suffix = "") {
+  const mod = await import(`../js/ratings.js${suffix}`);
+  const restore = stubFetch({ "ratings.json": data });
+  try {
+    await mod.loadRatings("ratings.json");
+  } finally {
+    restore();
+  }
+  return mod;
+}

--- a/tests/rank.test.js
+++ b/tests/rank.test.js
@@ -1,0 +1,248 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseQuery, mergeCourses, rankCourses, filterCourses, isIndividualStudy } from "../js/rank.js";
+import { entry, section, taught } from "./fixtures.js";
+
+// A small corpus with the shape that caused the noise problem: one course
+// someone actually typed, some near misses, and independent study listings
+// with more sections than the real course.
+function corpus() {
+  return [
+    entry("CSE", "2321", "Foundations 1: Discrete Structures", [
+      taught(2001, ["monday", "wednesday", "friday"], "3:00 PM", "3:55 PM", ["Charles Estill"]),
+      taught(2002, ["monday", "wednesday", "friday"], "3:00 PM", "3:55 PM", ["Ramin Yarinezhad"]),
+      taught(2003, ["tuesday", "thursday"], "9:35 AM", "10:55 AM", ["Luan Duong"]),
+    ]),
+    entry("CSE", "2331", "Foundations 2: Data Structures", [
+      taught(2101, ["monday", "wednesday"], "11:10 AM", "12:30 PM", ["Paolo Bucci"]),
+      taught(2102, ["tuesday", "thursday"], "2:20 PM", "3:40 PM", ["Steve Gomori"]),
+    ]),
+    entry("CSE", "4193", "Individual Studies", [
+      section(4001, { component: "Independent Study" }),
+      section(4002, { component: "Independent Study" }),
+      section(4003, { component: "Independent Study" }),
+    ]),
+    entry("CSE", "6193", "Individual Studies", [
+      section(6001, { component: "Research" }),
+      section(6002, { component: "Research" }),
+    ]),
+    entry("MATH", "2321", "Mathematical Analysis", [
+      taught(3001, ["monday", "wednesday", "friday"], "10:20 AM", "11:15 AM", ["Diana Kline"]),
+    ]),
+    entry("ENGLISH", "1110", "First Year English", [
+      taught(5001, ["tuesday", "thursday"], "8:00 AM", "9:20 AM", ["Ann Taylor"]),
+    ]),
+  ];
+}
+
+test("parseQuery pulls a subject and a number out of a typed query", () => {
+  const parsed = parseQuery("cse 2221");
+  assert.deepEqual(parsed.tokens, ["CSE", "2221"]);
+  assert.equal(parsed.subject, "CSE");
+  assert.equal(parsed.number, "2221");
+  assert.equal(parsed.raw, "cse 2221");
+});
+
+test("parseQuery keeps raw as typed but tokenises uppercase", () => {
+  const parsed = parseQuery("  Math   1151H  ");
+  assert.equal(parsed.raw, "Math   1151H");
+  assert.deepEqual(parsed.tokens, ["MATH", "1151H"]);
+  assert.equal(parsed.number, "1151H");
+});
+
+test("parseQuery handles a bare number and decimal catalog numbers", () => {
+  assert.equal(parseQuery("2221").subject, null);
+  assert.equal(parseQuery("2221").number, "2221");
+  assert.equal(parseQuery("ANIMSCI 2221.01").number, "2221.01");
+});
+
+test("parseQuery is empty for empty input", () => {
+  for (const raw of ["", "   ", null, undefined]) {
+    const parsed = parseQuery(raw);
+    assert.deepEqual(parsed.tokens, []);
+    assert.equal(parsed.subject, null);
+    assert.equal(parsed.number, null);
+    assert.equal(parsed.raw, "");
+  }
+});
+
+test("parseQuery reads a short word as a subject, which is how a name search still ranks", () => {
+  // "Bucci" is not a subject, but it looks like one, and the scorer only pays
+  // out on a subject hit when a course actually matches it.
+  assert.equal(parseQuery("Bucci").subject, "BUCCI");
+  assert.equal(parseQuery("Bucci").number, null);
+});
+
+test("mergeCourses folds duplicate records of the same course", () => {
+  const merged = mergeCourses([
+    entry("CSE", "5052", "Software Components", [section(1001)]),
+    entry("CSE", "5052", "Software Components", [section(1002)]),
+  ]);
+  assert.equal(merged.length, 1);
+  assert.deepEqual(merged[0].sections.map((s) => s.classNumber), [1001, 1002]);
+});
+
+test("mergeCourses does not add a section twice, even across number and string ids", () => {
+  const merged = mergeCourses([
+    entry("CSE", "5052", "Software Components", [section(1001), section(1002)]),
+    entry("CSE", "5052", "Software Components", [section("1001"), section(1003)]),
+  ]);
+  assert.equal(merged.length, 1);
+  assert.deepEqual(merged[0].sections.map((s) => String(s.classNumber)), ["1001", "1002", "1003"]);
+});
+
+test("mergeCourses keeps courses apart when subject, number or title differs", () => {
+  const merged = mergeCourses([
+    entry("CSE", "2221", "Software I", [section(1)]),
+    entry("CSE", "2231", "Software II", [section(2)]),
+    entry("MATH", "2221", "Something Else", [section(3)]),
+    entry("CSE", "2221", "Software I (Honors)", [section(4)]),
+  ]);
+  assert.equal(merged.length, 4);
+});
+
+test("mergeCourses skips records with no course and tolerates junk", () => {
+  assert.deepEqual(mergeCourses(null), []);
+  assert.deepEqual(mergeCourses([]), []);
+  assert.deepEqual(mergeCourses([null, {}, { sections: [section(1)] }]), []);
+  const merged = mergeCourses([{ course: { subject: "CSE", catalogNumber: "2221", title: "Software I" } }]);
+  assert.equal(merged.length, 1);
+  assert.deepEqual(merged[0].sections, []);
+});
+
+test("mergeCourses does not mutate the records it was given", () => {
+  const input = [
+    entry("CSE", "5052", "Software Components", [section(1001)]),
+    entry("CSE", "5052", "Software Components", [section(1002)]),
+  ];
+  mergeCourses(input);
+  assert.equal(input[0].sections.length, 1);
+});
+
+test("rankCourses returns the merged set untouched when nothing was typed", () => {
+  const ranked = rankCourses(corpus(), "");
+  assert.equal(ranked.length, 6);
+  assert.equal(ranked[0].course.subject, "CSE");
+  assert.equal(ranked[0].course.catalogNumber, "2321");
+});
+
+test("rankCourses puts an exact subject and number first", () => {
+  const ranked = rankCourses(corpus(), "CSE 2321");
+  assert.equal(ranked[0].course.subject, "CSE");
+  assert.equal(ranked[0].course.catalogNumber, "2321");
+  // A subject hit outweighs a bare number hit, so every CSE course sits above
+  // MATH 2321, and section count breaks the ties among them.
+  assert.deepEqual(
+    ranked.map((e) => `${e.course.subject} ${e.course.catalogNumber}`),
+    ["CSE 2321", "CSE 4193", "CSE 2331", "CSE 6193", "MATH 2321", "ENGLISH 1110"]
+  );
+});
+
+test("rankCourses lifts a course because of who teaches it", () => {
+  const ranked = rankCourses(corpus(), "GOMORI");
+  assert.equal(ranked[0].course.catalogNumber, "2331");
+});
+
+test("rankCourses breaks a tie by catalog number", () => {
+  const ranked = rankCourses(
+    [entry("CSE", "3901", "A", [section(1)]), entry("CSE", "1223", "B", [section(2)])],
+    "CSE"
+  );
+  assert.deepEqual(ranked.map((e) => e.course.catalogNumber), ["1223", "3901"]);
+});
+
+test("isIndividualStudy flags unscheduled non-teaching sections", () => {
+  const study = corpus()[2];
+  assert.equal(isIndividualStudy(study), true);
+});
+
+test("isIndividualStudy clears anything that actually meets", () => {
+  assert.equal(isIndividualStudy(corpus()[0]), false);
+  // One scheduled section is enough, even among a pile of research sections.
+  const mixed = entry("CSE", "4193", "Individual Studies", [
+    section(1, { component: "Independent Study" }),
+    taught(2, ["monday"], "9:00 AM", "9:55 AM", ["Someone"], { component: "Independent Study" }),
+  ]);
+  assert.equal(isIndividualStudy(mixed), false);
+});
+
+test("isIndividualStudy falls back to the title when the component is ordinary", () => {
+  const byTitle = entry("CSE", "4999", "Undergraduate Thesis Research", [section(1, { component: "Lecture" })]);
+  assert.equal(isIndividualStudy(byTitle), true);
+  const ordinary = entry("CSE", "2501", "Social and Ethical Issues", [section(1, { component: "Lecture" })]);
+  assert.equal(isIndividualStudy(ordinary), false);
+});
+
+test("isIndividualStudy is false for a course with no sections", () => {
+  assert.equal(isIndividualStudy(entry("CSE", "4193", "Individual Studies", [])), false);
+  assert.equal(isIndividualStudy({ course: { title: "Research" } }), false);
+});
+
+test("filterCourses answers an exact subject and number with that course alone", () => {
+  const { primary, related, reason } = filterCourses(corpus(), "CSE 2321");
+  assert.equal(reason, "exact");
+  assert.equal(primary.length, 1);
+  assert.equal(primary[0].course.subject, "CSE");
+  assert.equal(primary[0].course.catalogNumber, "2321");
+  assert.equal(related.length, 5);
+});
+
+test("filterCourses demotes independent study out of a subject search", () => {
+  const { primary, reason } = filterCourses(corpus(), "CSE");
+  assert.equal(reason, "ranked");
+  const numbers = primary.map((e) => e.course.catalogNumber);
+  assert.ok(!numbers.includes("4193"), "independent study is not a primary result");
+  assert.ok(!numbers.includes("6193"), "research is not a primary result");
+  assert.ok(numbers.includes("2321"));
+});
+
+test("filterCourses keeps independent study when it is what was asked for", () => {
+  const { primary } = filterCourses(corpus(), "CSE individual studies");
+  assert.ok(primary.some((e) => e.course.catalogNumber === "4193"));
+});
+
+test("filterCourses reports none for an empty result set", () => {
+  assert.deepEqual(filterCourses([], "CSE 2321"), { primary: [], related: [], reason: "none" });
+});
+
+test("filterCourses still answers when every match is independent study", () => {
+  const onlyStudy = corpus().slice(2, 4);
+  const { primary, related } = filterCourses(onlyStudy, "CSE");
+  assert.equal(primary.length, 2);
+  assert.equal(related.length, 0);
+});
+
+// Regression, #17. The first version of this dropped demoted courses on the
+// floor. Primary plus related must always be the whole ranked set.
+test("regression #17: filterCourses never loses a course", () => {
+  const queries = ["CSE 2321", "CSE", "Gomori", "2321", "individual studies", "MATH 2321", "english"];
+  for (const query of queries) {
+    const ranked = rankCourses(corpus(), query);
+    const { primary, related } = filterCourses(corpus(), query);
+
+    assert.equal(
+      primary.length + related.length,
+      ranked.length,
+      `${query}: primary ${primary.length} + related ${related.length} != ranked ${ranked.length}`
+    );
+
+    const seen = new Set();
+    for (const e of [...primary, ...related]) {
+      const key = `${e.course.subject} ${e.course.catalogNumber} ${e.course.title}`;
+      assert.ok(!seen.has(key), `${query}: ${key} appears twice`);
+      seen.add(key);
+    }
+    for (const e of ranked) {
+      const key = `${e.course.subject} ${e.course.catalogNumber} ${e.course.title}`;
+      assert.ok(seen.has(key), `${query}: ${key} was lost`);
+    }
+  }
+});
+
+test("regression #17: no section disappears between ranking and filtering", () => {
+  const ranked = rankCourses(corpus(), "CSE");
+  const { primary, related } = filterCourses(corpus(), "CSE");
+  const count = (list) => list.reduce((n, e) => n + e.sections.length, 0);
+  assert.equal(count(primary) + count(related), count(ranked));
+});

--- a/tests/ratings.test.js
+++ b/tests/ratings.test.js
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { nameKey, surnameKey, searchUrl, profileUrl } from "../js/ratings.js";
+import { withRatings } from "./helpers.js";
+
+const ratings = await withRatings();
+const { ratingFor } = ratings;
+
+test("nameKey keeps first and last name only", () => {
+  assert.equal(nameKey("Diana Ikenberry Kline"), "diana kline");
+  assert.equal(nameKey("Paolo Bucci"), "paolo bucci");
+  assert.equal(nameKey("PAOLO BUCCI"), "paolo bucci");
+});
+
+test("nameKey strips punctuation and collapses whitespace", () => {
+  assert.equal(nameKey("Ivan C. Smith"), "ivan smith");
+  assert.equal(nameKey("Sean O'Brien"), "sean obrien");
+  assert.equal(nameKey("Anne-Marie Dubois"), "annemarie dubois");
+  assert.equal(nameKey("  Paolo   Bucci  "), "paolo bucci");
+});
+
+test("nameKey skips generational suffixes", () => {
+  assert.equal(nameKey("Ivan C. Smith III"), "ivan smith");
+  assert.equal(nameKey("John Doe Jr."), "john doe");
+  assert.equal(nameKey("Henry Ford Sr"), "henry ford");
+  assert.equal(nameKey("Robert King IV"), "robert king");
+});
+
+test("nameKey handles a single name and no name at all", () => {
+  assert.equal(nameKey("Cher"), "cher");
+  assert.equal(nameKey(""), "");
+  assert.equal(nameKey(null), "");
+  assert.equal(nameKey("   "), "");
+});
+
+test("surnameKey is the last name after suffixes are dropped", () => {
+  assert.equal(surnameKey("Ivan C. Smith III"), "smith");
+  assert.equal(surnameKey("Diana Ikenberry Kline"), "kline");
+  assert.equal(surnameKey("Cher"), "cher");
+  assert.equal(surnameKey(""), "");
+});
+
+test("ratingFor matches a professor through the middle name", () => {
+  const found = ratingFor("Diana Ikenberry Kline");
+  assert.equal(found.legacyId, 1);
+  assert.equal(found.avgRating, 4.2);
+});
+
+test("ratingFor matches through a generational suffix", () => {
+  assert.equal(ratingFor("Ivan C. Smith III").legacyId, 10);
+});
+
+test("ratingFor expands a nickname the query is a prefix of", () => {
+  // OSU says Timothy Long, RateMyProfessors says Tim Long.
+  assert.equal(ratingFor("Timothy Long").legacyId, 2);
+});
+
+test("ratingFor accepts a shared initial only when the surname is unique", () => {
+  // Steve against Stephen, and Gomori is the only one.
+  assert.equal(ratingFor("Steve Gomori").legacyId, 3);
+});
+
+test("ratingFor refuses to guess between two people with the same name", () => {
+  assert.equal(ratingFor("Alan Reed"), null);
+});
+
+test("ratingFor refuses a shared initial when two people could be meant", () => {
+  // Mark Vance is neither Maria nor Marcus, and a shared M is not evidence.
+  assert.equal(ratingFor("Mark Vance"), null);
+});
+
+test("ratingFor refuses when two candidates are both plausible expansions", () => {
+  // Jon Park could be Jonathan or Jonas.
+  assert.equal(ratingFor("Jon Park"), null);
+});
+
+test("ratingFor returns null for a name that is not in the snapshot", () => {
+  assert.equal(ratingFor("Nobody Here"), null);
+  assert.equal(ratingFor(""), null);
+  assert.equal(ratingFor(null), null);
+});
+
+test("ratingFor returns null when no index is loaded", async () => {
+  const fresh = await import("../js/ratings.js?unloaded");
+  assert.equal(fresh.ratingFor("Diana Kline"), null);
+  assert.equal(ratingFor("Diana Kline", null), null);
+});
+
+test("loadRatings caches, so a second call does not fetch again", async () => {
+  const again = await ratings.loadRatings("never-fetched.json");
+  assert.equal(again.byKey.get("diana kline").length, 1);
+  assert.equal(again.bySurname.get("reed").length, 2);
+});
+
+test("the RateMyProfessors links point at Ohio State", () => {
+  assert.equal(
+    searchUrl("Paolo Bucci"),
+    "https://www.ratemyprofessors.com/search/professors/724?q=Paolo%20Bucci"
+  );
+  assert.equal(profileUrl(3069), "https://www.ratemyprofessors.com/professor/3069");
+});

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1,0 +1,101 @@
+// Only groupByInstructor is covered here. Everything else in render.js builds
+// DOM nodes and needs a document, which is out of scope for this suite.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { groupByInstructor } from "../js/render.js";
+import { section, taught } from "./fixtures.js";
+
+const MWF = ["monday", "wednesday", "friday"];
+
+test("groupByInstructor gathers a teacher's sections under one heading", () => {
+  const sections = [
+    taught(1001, MWF, "9:00 AM", "9:55 AM", ["Paolo Bucci"]),
+    taught(1002, MWF, "10:20 AM", "11:15 AM", ["Paolo Bucci"]),
+    taught(1003, MWF, "9:00 AM", "9:55 AM", ["Steve Gomori"]),
+  ];
+  const groups = groupByInstructor(sections);
+  assert.equal(groups.length, 2);
+  assert.equal(groups.find((g) => g.key === "Paolo Bucci").sections.length, 2);
+  assert.equal(groups.find((g) => g.key === "Steve Gomori").sections.length, 1);
+});
+
+test("a co-taught section is filed once, under both names together", () => {
+  const groups = groupByInstructor([taught(1001, MWF, "9:00 AM", "9:55 AM", ["Ann Taylor", "Bob Roberts"])]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].key, "Ann Taylor & Bob Roberts");
+  assert.deepEqual(groups[0].people.map((p) => p.name), ["Ann Taylor", "Bob Roberts"]);
+});
+
+test("the key does not depend on the order the API listed the pair", () => {
+  const groups = groupByInstructor([
+    taught(1001, MWF, "9:00 AM", "9:55 AM", ["Ann Taylor", "Bob Roberts"]),
+    taught(1002, MWF, "1:00 PM", "1:55 PM", ["Bob Roberts", "Ann Taylor"]),
+  ]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].sections.length, 2);
+});
+
+test("a section with no instructor is kept and sorted last", () => {
+  const groups = groupByInstructor([
+    section(1001),
+    taught(1002, MWF, "9:00 AM", "9:55 AM", ["Ann Taylor"]),
+  ]);
+  assert.deepEqual(groups.map((g) => g.key), ["Ann Taylor", "Instructor not listed"]);
+  assert.deepEqual(groups[1].people, []);
+});
+
+test("groupByInstructor handles no sections at all", () => {
+  assert.deepEqual(groupByInstructor([]), []);
+  assert.deepEqual(groupByInstructor(null), []);
+});
+
+// Regression, #15. The acceptance criterion was that no section may disappear,
+// and filing a co-taught section under each name would inflate the count the
+// other way.
+test("regression #15: grouping preserves the section count exactly", () => {
+  const sections = [
+    taught(1001, MWF, "9:00 AM", "9:55 AM", ["Paolo Bucci"]),
+    taught(1002, MWF, "10:20 AM", "11:15 AM", ["Paolo Bucci"]),
+    taught(1003, MWF, "9:00 AM", "9:55 AM", ["Steve Gomori"]),
+    taught(1004, MWF, "1:00 PM", "1:55 PM", ["Ann Taylor", "Bob Roberts"]),
+    taught(1005, MWF, "2:00 PM", "2:55 PM", ["Bob Roberts", "Ann Taylor"]),
+    section(1006),
+  ];
+  const groups = groupByInstructor(sections);
+
+  const grouped = groups.reduce((n, g) => n + g.sections.length, 0);
+  assert.equal(grouped, sections.length, "no section added or lost");
+
+  const numbers = groups.flatMap((g) => g.sections.map((s) => s.classNumber)).sort();
+  assert.deepEqual(numbers, [1001, 1002, 1003, 1004, 1005, 1006]);
+});
+
+// Regression, #15. "Ivan C. Smith III" sorts under Smith, not under III.
+test("regression #15: sorting skips generational suffixes", () => {
+  const groups = groupByInstructor([
+    taught(1001, MWF, "9:00 AM", "9:55 AM", ["Ann Taylor"]),
+    taught(1002, MWF, "9:00 AM", "9:55 AM", ["Ivan C. Smith III"]),
+    taught(1003, MWF, "9:00 AM", "9:55 AM", ["Bob Roberts"]),
+  ]);
+  assert.deepEqual(groups.map((g) => g.key), ["Bob Roberts", "Ivan C. Smith III", "Ann Taylor"]);
+});
+
+test("regression #15: the suffix is skipped with or without a trailing dot", () => {
+  const groups = groupByInstructor([
+    taught(1001, MWF, "9:00 AM", "9:55 AM", ["Ann Taylor"]),
+    taught(1002, MWF, "9:00 AM", "9:55 AM", ["John Doe Jr."]),
+    taught(1003, MWF, "9:00 AM", "9:55 AM", ["Henry Ford Sr"]),
+  ]);
+  assert.deepEqual(groups.map((g) => g.key), ["John Doe Jr.", "Henry Ford Sr", "Ann Taylor"]);
+});
+
+test("a co-taught key is alphabetical and sorts on its first name", () => {
+  const groups = groupByInstructor([
+    taught(1001, MWF, "9:00 AM", "9:55 AM", ["Zoe Adams", "Bob Roberts"]),
+    taught(1002, MWF, "9:00 AM", "9:55 AM", ["Ann Taylor"]),
+  ]);
+  // The key is built from the sorted names, so the pair files under Roberts.
+  assert.deepEqual(groups.map((g) => g.key), ["Bob Roberts & Zoe Adams", "Ann Taylor"]);
+});

--- a/tests/seats.test.js
+++ b/tests/seats.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { SEATS } from "./fixtures.js";
+import { withSeats } from "./helpers.js";
+
+const seats = await withSeats();
+
+test("seatsFor reports an open section", () => {
+  assert.deepEqual(seats.seatsFor("1001", "1268"), { enrolled: 30, limit: 40, waitlist: 0, full: false });
+});
+
+test("seatsFor calls a section at capacity full", () => {
+  const row = seats.seatsFor("1002", "1268");
+  assert.equal(row.full, true);
+  assert.equal(row.waitlist, 3);
+});
+
+test("seatsFor calls a section over capacity full, which OSU's own API does not", () => {
+  const row = seats.seatsFor("1003", "1268");
+  assert.equal(row.enrolled, 41);
+  assert.equal(row.limit, 40);
+  assert.equal(row.full, true);
+});
+
+test("seatsFor accepts a numeric class number and a numeric term", () => {
+  assert.equal(seats.seatsFor(1001, 1268).enrolled, 30);
+});
+
+test("seatsFor defaults a missing waitlist column to zero", () => {
+  assert.equal(seats.seatsFor("1007", "1268").waitlist, 0);
+});
+
+test("an absent class number is unknown, never zero", () => {
+  assert.equal(seats.seatsFor("9999", "1268"), null);
+  assert.equal(seats.seatsFor(undefined, "1268"), null);
+});
+
+test("seatsFor refuses a malformed row", () => {
+  assert.equal(seats.seatsFor("1005", "1268"), null, "row too short");
+  assert.equal(seats.seatsFor("1006", "1268"), null, "enrolled is not a number");
+});
+
+// Regression, #31. [0, 0, 1] is a section with no published capacity, often
+// with someone already waiting. Rendering it as 0/0 reads as wide open.
+test("regression #31: a zero limit is unknown capacity, not an empty section", () => {
+  assert.equal(seats.seatsFor("1004", "1268"), null);
+});
+
+// Regression, #23. The snapshot covers one term while the UI offers three.
+test("regression #23: seatsFor returns null when the snapshot is for another term", () => {
+  assert.equal(seats.seatsTerm(), "1268");
+  assert.equal(seats.seatsFor("1001", "1262"), null, "Spring 2026 must not read Autumn seats");
+  assert.equal(seats.seatsFor("1001", "1264"), null, "Summer 2026 must not read Autumn seats");
+  assert.equal(seats.seatsFor("1001", "1268").enrolled, 30, "the matching term still resolves");
+});
+
+test("regression #23: seatsFor returns null when no term was asked for", () => {
+  assert.equal(seats.seatsFor("1001", null), null);
+  assert.equal(seats.seatsFor("1001", undefined), null);
+  assert.equal(seats.seatsFor("1001", ""), null);
+});
+
+test("seatsTerm and seatsUpdated report the snapshot", () => {
+  assert.equal(seats.seatsTerm(), SEATS.term);
+  assert.equal(seats.seatsUpdated(), "2026-08-18");
+});
+
+test("nothing is known before a snapshot is loaded", async () => {
+  const fresh = await import("../js/seats.js?unloaded");
+  assert.equal(fresh.seatsTerm(), null);
+  assert.equal(fresh.seatsUpdated(), null);
+  assert.equal(fresh.seatsFor("1001", "1268"), null);
+});
+
+test("loadSeats caches, so a second call does not fetch again", async () => {
+  // fetch is no longer stubbed here, so a real fetch would throw or hang.
+  const again = await seats.loadSeats("never-fetched.json");
+  assert.equal(again.term, "1268");
+});


### PR DESCRIPTION
Closes #37

133 tests, 315 assertions, no dependencies, `node:test` and `node:assert` only. Runs offline against small hand-written fixtures.

```
$ node --test          (from a clean clone of this branch)
# tests 133
# pass 133
# fail 0
# duration_ms 307
```

| file | tests | asserts | covers |
| --- | --- | --- | --- |
| `tests/rank.test.js` | 25 | 59 | `parseQuery`, `mergeCourses`, `rankCourses`, `filterCourses`, `isIndividualStudy` |
| `tests/filters.test.js` | 20 | 47 | `toMinutes`, `isActive`, `applyFilters`, the unknown-data rule |
| `tests/api.test.js` | 17 | 46 | the request built, the errors returned, `termCodeFor`, `defaultTerm`, paging |
| `tests/format.test.js` | 16 | 39 | `formatDays`, `formatTime`, `formatWhen`, `formatPlace`, `formatUnits`, `instructorsOf` |
| `tests/ratings.test.js` | 16 | 36 | `nameKey`, `surnameKey`, `ratingFor` and its refusals |
| `tests/seats.test.js` | 13 | 26 | `seatsFor`, the term guard, the zero-limit rule |
| `tests/calendar.test.js` | 10 | 24 | `buildSlots` |
| `tests/render.test.js` | 9 | 17 | `groupByInstructor` only, the rest of the file needs a document |
| `tests/courses.test.js` | 7 | 21 | `subjectsFor`, `subjectLabel`, `coursesFor`, `codeFromInput` |

## The reverts, which is the part that matters

A regression test that passes against the broken code is worthless, so I put the bug back for each of the seven and watched the test fail. All seven were checked, not four.

**#12, empty query must send `q=`.** Changed `q: q ?? ""` back to `q: q || undefined` in `js/api.js`.
```
not ok 1 - regression #12: an empty query still sends q=
  error: 'q is missing for ""'
```

**#15, grouping must preserve the section count.** Filed each section under every instructor instead of under the whole set.
```
not ok 6 - regression #15: grouping preserves the section count exactly
  error: |-
    no section added or lost

    8 !== 6
```
Six sections became eight. Four other tests fell over with it, which is what a co-taught section counted twice looks like from every angle.

**#15, `surname()` must skip generational suffixes.** Replaced the backwards scan with `parts[parts.length - 1]`.
```
not ok 7 - regression #15: sorting skips generational suffixes
  + actual - expected
    [
  +   'Ivan C. Smith III',
      'Bob Roberts',
  -   'Ivan C. Smith III',
      'Ann Taylor'
    ]
```
Sorted under I for III, exactly the reported bug.

**#17, `filterCourses` must never lose a course.** Dropped `...setAside` from the related list on the exact-match path.
```
not ok 24 - regression #17: filterCourses never loses a course
  error: |-
    CSE 2321: primary 1 + related 3 != ranked 6

    4 !== 6
```
Two independent study courses vanished, which is the failure #17 described catching by hand.

**#31, `seatsFor` must return null for a zero limit.** Removed `if (limit <= 0) return null;`.
```
not ok 8 - regression #31: a zero limit is unknown capacity, not an empty section
  + actual - expected
  + { enrolled: 0, full: false, limit: 0, waitlist: 1 }
  - null
```
`full: false` on a section with someone already on the waitlist, rendered as `0/0`.

**#23, `seatsFor` must return null on a term mismatch.** Cut the guard down to `if (!snapshot) return null;`.
```
not ok 9 - regression #23: seatsFor returns null when the snapshot is for another term
  error: |-
    Spring 2026 must not read Autumn seats
    + actual - expected

    + { enrolled: 30, full: false, limit: 40, waitlist: 0 }
    - null

not ok 10 - regression #23: seatsFor returns null when no term was asked for
```
Autumn numbers reported against a Spring section, which is the confident lie the guard exists to prevent.

**#33, `buildSlots` must collapse a shared time.** Added `classNumber` to the slot id.
```
not ok 1 - regression #33: sections sharing a day pattern and time collapse into one slot
  error: |-
    Expected values to be strictly equal:

    3 !== 1
```
Three slots where the MoWeFr 3:00p block should be one, the sliced column the feature was built to avoid.

`js/` was restored with `git checkout` after each one and the full suite was re-run green afterwards. Nothing under `js/` is touched by this branch.

## How the loaded modules are tested

`ratings.js`, `seats.js` and `courses.js` keep their data in module-level state that only their loader can fill, and the loaders read `fetch`. Rather than hand-build the index and skip the code that builds it, `tests/helpers.js` serves a small fixture over a stubbed `fetch` and lets the real loader run, so `loadRatings` really does build the `byKey` and `bySurname` maps that `ratingFor` then queries. A test that needs a different snapshot, or none at all, imports a fresh instance with a query string on the specifier.

`api.js` is tested the same way. The stub records the URL, so the `q=` regression is an assertion about the request the client builds, not about a live response. Nothing in the suite opens a socket.

## What is deliberately not covered

Everything that needs a `document`: `renderCalendar`, `renderSlot`, `renderCourse`, `renderSection`, `renderResults`, all of `detail.js` and `app.js`. `groupByInstructor` is exported and pure, so it is tested; the rest of `render.js` is not.

Worth saying plainly: the measured pixel constants in `calendar.js` are the one thing a unit test can never protect. The clipping bug in #33 was invisible to a DOM-presence check and only showed up in a rendered page, and this suite would not catch it coming back. Re-measuring after a type scale change is still a manual step.

## Two things noticed while reading, neither fixed here

Both are behaviour as written, and both now have a test that locks in what the code actually does rather than what the comment implies.

- A minimum rating filter is the one place where unknown data does fail a filter. An unrated instructor scores `-1` against any minimum, so `rating: "1"` hides every section nobody has rated, which duplicates `ratedOnly`. Defensible, but it is not what the "unknown data never fails a filter" comment above `keepSection` says.
- `formatUnits({ minUnits: null, maxUnits: 3 })` renders `null–3 credits`. I did not find a course with that shape in the snapshot, so it may be unreachable, and it is untested rather than fixed.

No real bugs found otherwise. Every regression behaved exactly as its module documents.

## Workflow

`.github/workflows/test.yml` runs `node --test` on Node 22 for every push and pull request. No install step, since there is nothing to install. YAML parses.

`package.json` is new and holds only `"type": "module"` plus a `test` script. Without it Node reads `js/*.js` as CommonJS and every `export` is a syntax error. It adds no dependencies and the browser never sees it.
