### PR TITLE
Stop the minimum rating from hiding unrated instructors

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -54,9 +54,16 @@ function keepSection(section, filters) {
   if (filters.ratedOnly && !people.some((p) => ratingFor(p.name))) return false;
 
   if (filters.rating) {
-    const best = people.map((p) => ratingFor(p.name)).filter(Boolean)
-      .reduce((max, r) => Math.max(max, Number(r.avgRating) || 0), -1);
-    if (best < Number(filters.rating)) return false;
+    // Unrated is unknown, not bad. Seeding this at -1 made every unrated
+    // instructor fail every threshold, which silently removed most of the
+    // catalogue since only about a third are rated, and made this control
+    // imply the rated-only checkbox. Judge only instructors we have a rating
+    // for; use ratedOnly to exclude the rest.
+    const known = people.map((p) => ratingFor(p.name)).filter(Boolean);
+    if (known.length) {
+      const best = known.reduce((max, r) => Math.max(max, Number(r.avgRating) || 0), 0);
+      if (best < Number(filters.rating)) return false;
+    }
   }
 
   // A section with no meeting pattern has no days to judge, so neither rule

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -140,11 +140,34 @@ test("a minimum rating compares against the best rated instructor on the section
   assert.equal(applyFilters([cotaught], filters({ rating: "4.5" })).entries.length, 0);
 });
 
-test("a minimum rating does drop a section nobody has rated", () => {
-  // Worth stating plainly, because it is the one place where unknown data does
-  // fail a filter. An unrated instructor scores -1 against any minimum.
+test("regression #50: a minimum rating keeps sections nobody has rated", () => {
+  // Unrated is unknown, not bad. This used to seed the comparison at -1, so
+  // every unrated instructor failed every threshold. With only about a third
+  // of instructors rated, that silently removed most of the catalogue and made
+  // this control imply the rated-only checkbox.
   const { entries } = applyFilters([course()], filters({ rating: "1" }));
+  assert.deepEqual(
+    entries[0].sections.map((s) => s.classNumber),
+    [1001, 1002, 5003, 5004],
+    "unrated instructors survive a minimum rating"
+  );
+});
+
+test("regression #50: ratedOnly is what excludes the unrated", () => {
+  // The two controls have to stay independent: rating filters quality,
+  // ratedOnly filters presence.
+  const { entries } = applyFilters([course()], filters({ ratedOnly: true }));
   assert.deepEqual(entries[0].sections.map((s) => s.classNumber), [1001]);
+});
+
+test("regression #50: a known rating below the threshold still fails", () => {
+  // The fix must not turn the control off. Kline is rated 4.2 in the fixture.
+  const { entries } = applyFilters([course()], filters({ rating: "4.5" }));
+  assert.deepEqual(
+    entries[0].sections.map((s) => s.classNumber),
+    [1002, 5003, 5004],
+    "the rated instructor below 4.5 is dropped, the unrated are not"
+  );
 });
 
 test("applyFilters counts what it removed", () => {


### PR DESCRIPTION
Closes #50

Found by #49's test suite within an hour of it landing, which is a reasonable argument for the test suite.

## Before and after, CSE 2331 live

```
                      before                                    after
baseline              Alilooee | Painter 4.8 | Salih 2.7        same
rating >= 3           Painter 4.8                               Alilooee | Painter 4.8
rating >= 4           Painter 4.8                               Alilooee | Painter 4.8
rated only            -                                         Painter 4.8 | Salih 2.7
rated only + >= 4     -                                         Painter 4.8
```

Ali Alilooee is unrated. He used to vanish at a 3.0 threshold alongside Salih, who is genuinely below it. Those are different reasons and the interface presented them identically.

The two controls now compose the way they look like they should: **rating filters quality, rated-only filters presence.**

## Why it happened

```js
.reduce((max, r) => Math.max(max, Number(r.avgRating) || 0), -1)
```

The seed. An instructor with no rating contributes nothing, so the reduce returns `-1`, which is below every threshold. It restores the rule documented three lines above it, which exists so online and arranged sections do not vanish when someone touches a time control.

## Tests
The test that locked in the old behaviour is **inverted, not deleted**, and two were added:
- `ratedOnly` still excludes the unrated, so the controls stay independent
- a known rating below the threshold still fails, so the fix does not just turn the control off

135 tests pass, up from 133.
