### PR TITLE
Reflect a shared query back into the pickers

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 import { fetchTerms, defaultTerm, searchAllPages, ApiError } from "./api.js";
-import { filterCourses } from "./rank.js";
+import { filterCourses, parseQuery } from "./rank.js";
 import { renderResults } from "./render.js";
 import { loadRatings, topRated, ratedCount, profileUrl } from "./ratings.js";
 import { loadSeats, seatsTerm, seatsUpdated, seatsSectionCount } from "./seats.js";
@@ -190,6 +190,29 @@ function fillNumbers() {
   );
   if (!courses.length) els.number.value = "";
   return courses;
+}
+
+/**
+ * Reflect a query back into the pickers.
+ *
+ * Deliberately does not touch the course index: a subject and number are
+ * parseable from the query itself, so a shared link fills the rail without
+ * pulling the 177 KB index that #36 made lazy. The dropdown options still
+ * arrive on first focus.
+ */
+function reflectQuery(q) {
+  const parsed = parseQuery(q);
+  // A query only maps onto the pickers when it names both. "Bucci" and bare
+  // "CSE" are searches, not course selections, and should leave them empty.
+  if (!parsed.subject || !parsed.number) {
+    els.subject.value = "";
+    els.number.value = "";
+    els.number.disabled = true;
+    return;
+  }
+  els.subject.value = parsed.subject;
+  els.number.value = parsed.number;
+  els.number.disabled = false;
 }
 
 /** A picked subject and number becomes an ordinary search. */
@@ -552,6 +575,7 @@ async function init() {
     event.preventDefault();
     if (els.submit.getAttribute("aria-disabled") === "true") return;
     const q = els.query.value;
+    reflectQuery(q);
     syncUrl(q, els.term.value);
     runSearch(q, els.term.value);
   });
@@ -566,13 +590,17 @@ async function init() {
     const button = event.target.closest("[data-q]");
     if (!button) return;
     els.query.value = button.dataset.q;
+    reflectQuery(button.dataset.q);
     syncUrl(button.dataset.q, els.term.value);
     runSearch(button.dataset.q, els.term.value);
   });
 
   const initialQuery = params.get("q") ?? "";
   els.query.value = initialQuery;
-  if (initialQuery.trim()) runSearch(initialQuery, els.term.value);
+  if (initialQuery.trim()) {
+    reflectQuery(initialQuery);
+    runSearch(initialQuery, els.term.value);
+  }
   else {
     // Ratings and seats are already in flight; fill the landing screen once
     // they land rather than showing an empty frame in the meantime.


### PR DESCRIPTION
Closes #44

```
?q=CSE 2221     subject="CSE"  number="2221"  numberDisabled=false  courses.json=false
?q=Bucci        subject=""     number=""      numberDisabled=true   courses.json=false
?q=CSE (bare)   subject=""     number=""      numberDisabled=true   courses.json=false
no query        subject=""     number=""      numberDisabled=true   courses.json=false
```

The last column is the point. The obvious implementation looks up the query in the course index to confirm the course exists, which would force the 177 KB index onto every shared link and undo #36.

It is not needed. A subject and number are parseable from the query string itself, so the fields fill from `parseQuery` alone and the dropdown options still arrive on first focus. `courses.json` stays absent from the load in all four cases.

Only a query naming **both** a subject and a number maps onto the pickers. `Bucci` is an instructor search and bare `CSE` is a subject-wide search; neither is a course selection, so both correctly leave the rail empty rather than half-filling it.

Also applied on submit and when clicking a name on the landing screen, so the rail tracks the query however it was set rather than only on load.
