### PR TITLE
Make search deterministic with sort=catalogNumber

### DIFF
--- a/docs/osu-api.md
+++ b/docs/osu-api.md
@@ -52,12 +52,12 @@ The main endpoint.
 
 | Parameter | Notes |
 |---|---|
-| `q` | Free text. Matches subject, catalog number, course title, and instructor name |
+| `q` | Free text. Matches subject, catalog number, course title, and instructor name. Multi-word queries are a union, not an intersection: `CSE 2331` matches anything with `CSE` or `2331` |
 | `campus` | `col` for Columbus |
 | `term` | A `strm` code, for example `1268` |
 | `p` | 1-based page number |
 | `sort` | `catalogNumber`, `subject`, or `-` prefixed for descending. Default is relevance, which is the source of the paging trouble below |
-| `subject` | Subject code, lowercase. Exact, unlike putting the code in `q` |
+| `subject` | Subject code, lowercase. Exact, unlike putting the code in `q`. Combines with `q` as an intersection |
 
 Neither `sort` nor `subject` needs guessing. Every response carries `sort` and
 `filters` arrays, and each entry in them spells out the parameter and value that
@@ -136,8 +136,8 @@ the section's own limit. `facilityCapacity` is the room's capacity and is not th
 same number. So Finder shows enrolled counts and `enrollmentStatus`, and does not
 draw a percent-full meter it cannot honestly compute.
 
-**Paged search is not deterministic.** Pulling the identical query three times
-back to back returns a different set of sections each time:
+**Paged search is not deterministic in its default order.** Pulling the identical
+query three times back to back returns a different set of sections each time:
 
 ```
 run 1: 1001 CSE sections    totalPages=7
@@ -150,16 +150,104 @@ missing from run 1:      63
 ```
 
 Roughly 6% of sections differ per pull, so any single multi-page pull silently
-misses some. This is the default relevance ordering shuffling ties, and
-`sort=catalogNumber` pins it, which is measured under Enumerating the catalog
-below. Without that, the practical rule is **keep queries narrow enough to fit on
-one page.**
-A user searching `CSE 2221` is unaffected because the result fits on page 1. A
-feature that tries to enumerate an entire subject would be quietly lossy, and
-should not be built on this endpoint without reconciling several pulls.
+misses some. The cause is the default relevance ordering reshuffling ties, and
+`sort=catalogNumber` pins it. Eight identical `q=Smith` pulls, Autumn 2026, a
+674 section result over four pages:
+
+| Order | Sections per pull | In every pull | Sections that moved |
+|---|---|---|---|
+| relevance | 635 to 674 | 565 | 109 |
+| `catalogNumber` | 673 or 674 | 672 | 2 |
+
+Sorting does not make paging perfect, it makes it about 98% better. Two sections
+still came and went across those eight pulls, so a stable order is an observation
+and not a promise. At course level the same eight pulls returned 93 courses
+taught by a Smith seven times and 92 once, against 86 to 93 unsorted.
 
 **Future terms appear late.** Querying `term=1272` (Spring 2027) returned zero
 results on 2026-08-18 while the term was already visible elsewhere on campus.
+
+## Searching from the client
+
+`js/api.js` serves one student typing one query, so it cannot walk the whole
+result the way the catalog build does. It reads at most five pages, and that
+budget is what makes the choice of order and parameters matter. Three findings
+shape it, all measured on Autumn 2026.
+
+### Five pages is still the right budget
+
+The multi-page fetch exists because relevance does not put a match on page 1.
+Sorting did not remove the need for it. Distinct courses found as the pull gets
+deeper, counting only courses the query should actually return:
+
+| Query | Pages | Page 1 | 2 | 3 | 4 | 5 | All |
+|---|---|---|---|---|---|---|---|
+| `Smith`, relevance | 4 | 0 | 0 | 57 | 93 | 93 | 93 |
+| `Smith`, `catalogNumber` | 4 | 4 | 14 | 62 | 92 | 92 | 93 |
+| `Chen`, relevance | 4 | 0 | 0 | 63 | 87 | 87 | 87 |
+| `Lee`, `catalogNumber` | 3 | 79 | 168 | 192 | 192 | 192 | 192 |
+| `organic chemistry`, relevance | 6 | 11 | 13 | 13 | 13 | 13 | 13 |
+| `CSE`, relevance | 7 | 44 | 65 | 83 | 95 | 102 | 104 |
+| `Bucci` | 1 | 9 | 9 | 9 | 9 | 9 | 9 |
+
+`Smith` and `Chen` are the case that #14 was filed for, and they are unchanged:
+the first two pages carry none of that professor's courses under relevance, and
+the answer is only complete on page 4. Sorting starts finding them earlier but
+still needs page 4. Nothing in the data supports cutting the budget below five,
+so it stays at five. Common surnames run to four pages and rare ones to one, so
+the budget is rarely spent in full.
+
+### Sorting has a price when the result is truncated
+
+A sorted page 1 is the lowest catalog numbers, not the best matches. That is what
+you want when you intend to read every page and the opposite of what you want
+when you stop early. Distinct courses found in five pages:
+
+| Query | Pages | Relevance | `catalogNumber` | All |
+|---|---|---|---|---|
+| `MATH` | 11 | 89 | 21 | 89 |
+| `creative writing` | 9 | 3 | 3 | 3 |
+| `CSE` | 7 | 102 | 101 | 104 |
+| `organic chemistry` | 6 | 13 | 13 | 13 |
+| `machine learning` | 4 | 5 | 5 | 5 |
+| `Smith` | 4 | 86 to 93 | 92 to 93 | 93 |
+
+`MATH` is the worst case and it explains the rule. MATH 1151 alone has 173
+sections, so a thousand sections in catalog order never reach the 2000s. So the
+client sorts, reads `totalPages` off the first response, and keeps the sorted
+order only when the whole result fits in the budget. When it does not fit it
+pulls the relevance pages as well and merges, since `mergeCourses` in
+`js/rank.js` dedupes by class number and the sorted page it already paid for is
+then extra coverage rather than waste.
+
+### `q` is a union, `subject` is a filter
+
+`q` matches on any token, not all of them. `q=CSE 2331` returns 1248 sections
+over seven pages spread across nine subjects, because a section matches on `CSE`
+or on `2331`. The two parameters do combine, so moving the subject out of `q`
+turns the same question into one page:
+
+| Request | Items | Pages |
+|---|---|---|
+| `q=CSE 2331` | 1248 | 7 |
+| `subject=cse&q=2331` | 50 | 1 |
+
+Checked over 18 course lookups, the narrow form returned the identical course
+records and the identical set of class numbers as the five page relevance pull,
+section for section, nothing missing. All 102 sections of PHYSICS 1250 and all
+107 of CHEM 1210 came back either way. What it drops is the thousand sections
+nobody asked for.
+
+The catch is telling a subject code from a surname. `CSE` and `Smith` are the
+same shape to a regular expression, and `subject=smith` returns zero rather than
+an error, so a wrong guess costs a wasted round trip on the commonest search
+there is. The client only reads a token as a subject when the query also carries
+a catalog number, which a bare surname never does, and it falls back to plain
+text if the subject turns out not to be offered. A bare `MATH` is therefore left
+as free text on purpose.
+
+Across a 37 query mix this cut requests by 26% and median wall time by 29%.
+`CSE 2331` went from five requests and 572 ms to one request and 101 ms.
 
 ## Enumerating the catalog
 
@@ -289,21 +377,32 @@ strictly worse as a primary source. Compared head to head for CSE, Autumn 2026:
 
 | | OSU API | Barrett |
 |---|---|---|
-| Sections returned | about 1000, varies per pull | 468, stable |
+| Sections returned | 1064, stable | 484, stable |
 | Instructor names | full, plus email address | initials only, `D.Kline` |
-| Sections it has that the other lacks | about 580 | about 80 |
+| Sections it has that the other lacks | 657 | 77 |
 
-The API counts are deliberately approximate. Paged search is non-deterministic,
-so repeated identical pulls disagree by a few percent. See the paging note above.
-Barrett is a static file and its count is exact.
+Both counts are now exact. The API side is a `subject=cse&sort=catalogNumber`
+walk, which returned the identical 1064 class numbers on three consecutive full
+pulls, so the older "about 1000, varies per pull" caveat no longer applies. See
+the paging note above.
+
+Of the 77 sections only Barrett lists, 16 carry a regional campus code and so
+cannot appear in a `campus=col` pull at all. The other 61 are Columbus rows the
+API genuinely does not return, spot checked by class number.
 
 Coverage is one question and instructor naming is a different one, so they are
-measured separately. Restricted to the 388 sections both sources actually list:
+measured separately. Restricted to the 407 sections both sources actually list:
 
 | | count |
 |---|---|
 | Barrett names an instructor where the API is blank | **0** |
 | API names an instructor where Barrett is blank | 0 |
+| Both name an instructor | 401 |
+| Neither names one | 6 |
+
+Two of those 407 have something in Barrett's instructor column where the API has
+nobody, but the content is `{7W2}`, a seven week session code rather than a
+person, so the count above is 0 and not 2.
 
 That first row is the decisive one. On shared sections the two sources agree
 completely, so Barrett does not surface a single instructor the API is missing.
@@ -317,6 +416,15 @@ The API is the live system of record.
 
 Barrett may still be worth revisiting for enrollment limits. It is not worth
 depending on for instructors.
+
+**Count Barrett sections with the real parser.** The numbers in this section were
+originally wrong because they came from a hand rolled fixed column slice at
+columns 20 to 30, which swallows the campus code on regional campus rows, so a
+line like `CSE 2111  NWK  4816 L` never parsed as a section at all. That dropped
+exactly the 16 regional rows and produced the old figure of 468. `parseSubjectFile`
+in `scripts/fetch-seats.mjs` carries the column map that #19 verified against
+every subject file, and it parses all 484 CSE rows with zero residue. Use it, or
+read `data/seats.json`, rather than slicing columns by hand.
 
 ## Courtesy
 

--- a/js/api.js
+++ b/js/api.js
@@ -3,6 +3,9 @@
 const BASE = "https://content.osu.edu/v2";
 const CAMPUS = "col";
 const TIMEOUT_MS = 12000;
+// Relevance is the upstream default and it reshuffles between identical
+// requests. Catalog order does not. See docs/osu-api.md.
+const SORT = "catalogNumber";
 
 export class ApiError extends Error {
   constructor(message, { status = null, cause = null } = {}) {
@@ -100,12 +103,19 @@ export function defaultTerm(terms, date = new Date()) {
 /**
  * Search classes. Returns { totalItems, totalPages, page, courses }.
  *
- * Paging is non-deterministic upstream, so callers should keep queries narrow
- * enough to fit on one page rather than trying to enumerate everything.
+ * `sort` and `subject` are both real upstream parameters, documented in
+ * docs/osu-api.md. `subject` has to be lowercase: `subject=CSE` returns zero.
  */
-export async function searchClasses({ q, term, page = 1 }) {
+export async function searchClasses({ q, term, page = 1, sort, subject }) {
   if (!term) throw new ApiError("Pick a term before searching.");
-  const data = await getJson("/classes/search", { q: q ?? "", campus: CAMPUS, term, p: page });
+  const data = await getJson("/classes/search", {
+    q: q ?? "",
+    campus: CAMPUS,
+    term,
+    p: page,
+    sort,
+    subject,
+  });
   return {
     totalItems: data?.totalItems ?? 0,
     totalPages: data?.totalPages ?? 0,
@@ -114,28 +124,77 @@ export async function searchClasses({ q, term, page = 1 }) {
   };
 }
 
+const SUBJECT_TOKEN = /^[A-Za-z]{2,8}$/;
+const NUMBER_TOKEN = /^\d{3,4}(\.\d+)?[A-Za-z]*$/;
+
+/**
+ * Read "CSE 2331" as a subject plus a catalog number.
+ *
+ * Only a query that carries both shapes is treated this way. A lone word is
+ * left alone because "Smith" and "MATH" look identical from here, and guessing
+ * wrong on a professor's name costs a wasted round trip on the commonest
+ * search there is.
+ */
+export function subjectScope(raw) {
+  const tokens = String(raw ?? "").trim().split(/\s+/).filter(Boolean);
+  const s = tokens.findIndex((t) => SUBJECT_TOKEN.test(t));
+  if (s < 0 || !tokens.some((t, i) => i !== s && NUMBER_TOKEN.test(t))) return null;
+  return { subject: tokens[s].toLowerCase(), q: tokens.filter((_, i) => i !== s).join(" ") };
+}
+
 /**
  * Search across several pages and merge.
  *
- * Relevance does not reliably put a match on page 1: "Smith" returns 674 items
- * over 4 pages with zero of that professor's courses on the first. Upstream
- * paging is also non-deterministic, so pulling more pages raises coverage
- * rather than lowering it.
+ * Two things upstream shape this, both measured in docs/osu-api.md.
+ *
+ * Relevance order does not reliably put a match on page 1: "Smith" returns 674
+ * sections over 4 pages with zero of that professor's courses on either of the
+ * first two, which is why this fetches more than one page at all.
+ *
+ * Relevance order is also not repeatable. Three identical "Smith" pulls
+ * returned 93, 86 and 93 of his courses. `sort=catalogNumber` pins it, so it is
+ * the default here.
+ *
+ * The catch is that a sorted page 1 is the lowest catalog numbers rather than
+ * the best matches, which only hurts when the result runs past `maxPages` and
+ * gets truncated. Bare "MATH" is the worst case: 11 pages, and five of them in
+ * catalog order carry 21 of the 89 courses that relevance finds in three. So
+ * when the answer does not fit, the relevance pass runs as well and both are
+ * merged. rank.js dedupes by class number, so the extra page is free coverage.
  */
 export async function searchAllPages({ q, term, maxPages = 5 }) {
-  const first = await searchClasses({ q, term, page: 1 });
-  const pages = Math.min(first.totalPages ?? 1, maxPages);
-  if (pages <= 1) return { ...first, pagesFetched: 1 };
+  const scope = subjectScope(q);
+  let params = scope ? { q: scope.q, subject: scope.subject } : { q };
 
-  const rest = await Promise.all(
-    Array.from({ length: pages - 1 }, (_, i) =>
-      searchClasses({ q, term, page: i + 2 }).catch(() => ({ courses: [] }))
-    )
-  );
+  let first = await searchClasses({ ...params, term, sort: SORT, page: 1 });
+
+  // The subject guess was wrong, so that word was a name or a title, not a
+  // subject code. Nothing matches a subject that is not offered.
+  if (scope && first.totalItems === 0) {
+    params = { q };
+    first = await searchClasses({ ...params, term, sort: SORT, page: 1 });
+  }
+
+  const totalPages = first.totalPages ?? 1;
+  const truncated = totalPages > maxPages;
+
+  // When the whole result fits, catalog order is both complete and repeatable,
+  // so the rest of it comes back the same way. When it does not fit, that first
+  // sorted page is the wrong 200 sections, so the pull restarts in relevance
+  // order and the sorted page stays in as extra coverage rather than a waste.
+  const pending = truncated
+    ? Array.from({ length: maxPages }, (_, i) => searchClasses({ ...params, term, page: i + 1 }))
+    : Array.from({ length: totalPages - 1 }, (_, i) =>
+        searchClasses({ ...params, term, sort: SORT, page: i + 2 })
+      );
+
+  const rest = await Promise.all(pending.map((r) => r.catch(() => ({ courses: [] }))));
 
   return {
     ...first,
     courses: [...first.courses, ...rest.flatMap((r) => r.courses)],
-    pagesFetched: pages,
+    pagesFetched: 1 + pending.length,
+    sorted: !truncated,
+    subject: params.subject ?? null,
   };
 }


### PR DESCRIPTION
Closes #35

`sort=catalogNumber` is now passed from `searchAllPages`, but the measurement turned up two things the issue did not anticipate, so the change is not a one-liner. Everything below is measured against the live API for Autumn 2026 (`term=1268`), three or more identical runs each.

## Sorting does fix the paging, by about 98%

Eight identical `q=Smith` pulls, a 674 section result over four pages:

| Order | Sections per pull | In every pull | Sections that moved |
|---|---|---|---|
| relevance | 635 to 674 | 565 | 109 |
| `catalogNumber` | 673 or 674 | 672 | 2 |

Repeating whole five page walks three times:

| Query | relevance | `catalogNumber` |
|---|---|---|
| `Lee` | 435, 443, 443 sections, differs | 464, 464, 464, identical |
| `organic chemistry` | 969, 979, 969, differs | 1000, 1000, 1000, identical |
| `MATH` | 936, 963, 941, differs | 1000, 1000, 1000, identical |
| `CSE` | 928, 1000, 1000, differs | 1000, 1000, 1000, identical |
| `Chen` | 672 every time | 672 every time |

It is not perfect. Two sections still came and went across eight sorted `Smith` pulls, so the doc says a stable order is an observation and not a promise.

## Sorting is not free when the result gets truncated

This is the part I did not expect. A sorted page 1 is the lowest catalog numbers, not the best matches, and `searchAllPages` reads five pages rather than all of them. Distinct courses the query should find, within five pages:

| Query | Pages | Relevance | `catalogNumber` | All of them |
|---|---|---|---|---|
| `MATH` | 11 | 89 | **21** | 89 |
| `creative writing` | 9 | 3 | 3 | 3 |
| `CSE` | 7 | 102 | 101 | 104 |
| `organic chemistry` | 6 | 13 | 13 | 13 |
| `machine learning` | 4 | 5 | 5 | 5 |
| `Smith` | 4 | 86 to 93 | 92 to 93 | 93 |

MATH 1151 alone has 173 sections, so a thousand sections in catalog order never reach the 2000s. Sorting `MATH` blindly would have dropped 68 of its 89 courses.

So the client sorts, reads `totalPages` off the first response, and keeps the sorted order only when the whole result fits in the budget. When it does not fit it pulls the relevance pages too and merges. `mergeCourses` already dedupes by class number, so the sorted page it has already paid for becomes extra coverage rather than waste.

## Five pages is still the right budget

Re-measured, and the answer is no, do not cut it. Distinct real matches by depth:

| Query | Pages | p1 | p2 | p3 | p4 | p5 | All |
|---|---|---|---|---|---|---|---|
| `Smith`, relevance | 4 | 0 | 0 | 57 | 93 | 93 | 93 |
| `Smith`, sorted | 4 | 4 | 14 | 62 | 92 | 92 | 93 |
| `Chen`, relevance | 4 | 0 | 0 | 63 | 87 | 87 | 87 |
| `Chen`, sorted | 4 | 21 | 66 | 74 | 87 | 87 | 87 |
| `Lee`, sorted | 3 | 79 | 168 | 192 | 192 | 192 | 192 |
| `CSE`, relevance | 7 | 44 | 65 | 83 | 95 | 102 | 104 |
| `organic chemistry` | 6 | 11 | 13 | 13 | 13 | 13 | 13 |
| `Bucci` | 1 | 9 | 9 | 9 | 9 | 9 | 9 |

The #14 bug is exactly as real as it was. `Smith` and `Chen` still have zero of that professor's courses on the first two pages under relevance, and are only complete on page 4. The budget stays at five. It is rarely spent in full: rare surnames are one page and common ones are three or four.

## Adopting `subject=`, but only when the query names a number too

`q` turns out to be a union, not an intersection. `q=CSE 2331` matches anything with `CSE` **or** `2331`, which is why it costs seven pages across nine subjects.

| Request | Items | Pages |
|---|---|---|
| `q=CSE 2331` | 1248 | 7 |
| `subject=cse&q=2331` | 50 | 1 |

Checked over 18 course lookups, the narrow form returns the identical course records and the identical set of class numbers as the old five page pull, section for section, nothing missing. All 102 sections of PHYSICS 1250, all 107 of CHEM 1210, all 74 of MATH 1151. What it drops is the thousand sections nobody asked for.

The catch is that `CSE` and `Smith` are the same shape to a regular expression, and `subject=smith` returns zero rather than an error, so a wrong guess wastes a round trip on the commonest search there is. So a token is only read as a subject when the query **also** carries a catalog number, which a bare surname never does, and it falls back to plain text if the subject is not offered. `Smith 2331` takes that fallback and costs one extra request. Bare `MATH` is deliberately left as free text.

## Latency and requests

Six interleaved repeats per query, medians:

| Query | Before | After | Change |
|---|---|---|---|
| `CSE 2331` | 5 req, 572 ms | 1 req, 101 ms | -82% |
| `MATH 1151` | 5 req, 551 ms | 1 req, 139 ms | -75% |
| `PSYCH 1100` | 4 req, 363 ms | 1 req, 117 ms | -68% |
| `PHYSICS 1250` | 5 req, 453 ms | 2 req, 278 ms | -39% |
| `CSE` | 5 req, 445 ms | 6 req, 369 ms | -17% |
| `Bucci` | 1 req, 67 ms | 1 req, 65 ms | -3% |
| `Smith` | 4 req, 379 ms | 4 req, 405 ms | +7% |
| `organic chemistry` | 5 req, 399 ms | 6 req, 434 ms | +9% |
| `machine learning` | 4 req, 343 ms | 4 req, 398 ms | +16% |
| `MATH` | 5 req, 469 ms | 6 req, 558 ms | +19% |
| **total** | **43 req, 4041 ms** | **32 req, 2864 ms** | **-26% requests, -29% time** |

Queries that run past five pages pay one extra request for the sorted first page before the code learns it has to fall back. Course lookups more than pay it back.

## Regression check

37 queries, three runs each, compared through the real `filterCourses`.

- `Smith` returns **93 courses** taught by a Smith, in 7 of 8 sorted runs and 92 in the eighth. Unsorted it ranged 86 to 93. The `primary` list is 25 either way and stopped flapping.
- `Bucci` 9 courses, `Zweben` 3, `Kline` 11, `Soundarajan` 12, `Chen` 87, `Lee` 192. All unchanged or better. `Lee` was 177 to 192 before and is a flat 192 now.
- `CSE 2331` 1 course, 8 sections, identical to before. `MATH 1151` 1 course, 74 sections, identical.
- Across the 18 course lookups: zero sections missing, zero extra.
- Across every non-subject query: zero courses lost against the union of three runs of the old code.
- `primary` results flapped on 6 of 37 queries before and 2 of 37 after. Both remaining are the deliberate relevance fallback for results over five pages.

Edge cases smoke tested: empty query, whitespace, `cse 2331` lowercase, `CSE 2231.01`, `CSE 2331 Bucci`, `ZZZZ 9999`, `Smith 2331`, bare `2331`, and a missing term still raising `ApiError`.

## Also in here: the stale Barrett numbers

Asked for separately, and it touches the same file. The Barrett comparison table in `docs/osu-api.md` came from a hand rolled fixed column slice at columns 20 to 30, which swallows the campus code on regional campus rows, so a line like `CSE 2111  NWK  4816 L` never parsed. Re-measured with `parseSubjectFile` from `scripts/fetch-seats.mjs`, which is the column map #19 verified:

| | Was | Now |
|---|---|---|
| Barrett sections, CSE | 468 | **484**, zero parse residue, all 484 present in `data/seats.json` |
| API sections, CSE | about 1000, varies per pull | **1064**, identical on three full sorted walks |
| Shared by both | 388 | **407** |
| Only Barrett has | about 80 | **77**, of which 16 are regional campus rows |
| Only the API has | about 580 | **657** |
| Barrett names an instructor where the API is blank | 0 | **0**, unchanged |

Every figure in that table was affected, not just the 468, because they all came off the same parse. The headline conclusion survives: Barrett still does not surface a single instructor the API is missing. Two shared sections do carry something in Barrett's instructor column where the API has nobody, but it is `{7W2}`, a session code rather than a person, and the doc now says so. The section also gained a line saying per-section counts must come from the real parser rather than a hand rolled slice, and why.

Barrett's 337 subject files were re-counted and that number was already right.

## Scope

`js/api.js` and `docs/osu-api.md` only. `js/rank.js` needed no change: `mergeCourses` already dedupes sections by class number, which is what lets the sorted and relevance passes be merged safely.
