### PR TITLE
Wire the UI and tests to per-term seats

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -296,10 +296,10 @@ function syncUrl(q, term) {
  */
 function showWelcome(term) {
   els.welcome.hidden = false;
-  const sections = seatsTerm() === term ? seatsSectionCount() : 0;
+  const sections = seatsSectionCount(term);
   const bits = [termName(term)];
   if (sections) bits.push(`${sections.toLocaleString()} sections`);
-  if (seatsTerm() === term && seatsUpdated()) bits.push(`seats as of ${formatDate(seatsUpdated())}`);
+  if (seatsUpdated(term)) bits.push(`seats as of ${formatDate(seatsUpdated(term))}`);
   els.wStats.textContent = bits.join(" · ");
 
   const best = topRated();
@@ -356,7 +356,7 @@ async function runSearch(q, term) {
     const [{ courses }] = await Promise.all([
       searchAllPages({ q, term }),
       loadRatings().catch(() => null),
-      loadSeats().catch(() => null),
+      loadSeats(term).catch(() => null),
     ]);
     if (requestId !== latestRequest) return; // a newer search already answered
     lastResult = filterCourses(courses, q);
@@ -450,7 +450,7 @@ function paint(term = els.term.value) {
   const noun = primary.length === 1 ? "course" : "courses";
   // Barrett refreshes once a day, so the numbers are dated, and during a
   // registration window that distinction matters.
-  const dated = seatsTerm() === term && seatsUpdated() ? ` Seats as of ${formatDate(seatsUpdated())}.` : "";
+  const dated = seatsTerm(term) && seatsUpdated(term) ? ` Seats as of ${formatDate(seatsUpdated(term))}.` : "";
   setStatus(`${primary.length} ${noun}, ${sections} sections in ${termName(term)}.${dated}`);
 }
 
@@ -468,7 +468,7 @@ function termName(code) {
 async function init() {
   // Start the ratings download early so the first search rarely waits on it.
   loadRatings().catch((error) => console.warn("ratings unavailable", error));
-  loadSeats().catch((error) => console.warn("seats unavailable", error));
+  loadSeats(els.term.value).catch((error) => console.warn("seats unavailable", error));
 
   const params = new URLSearchParams(location.search);
   setBusy(false);
@@ -582,6 +582,9 @@ async function init() {
 
   els.term.addEventListener("change", () => {
     if (isLoaded()) { fillSubjects(); fillNumbers(); }
+    // Seats are per term since #48, so the new term has to arrive before the
+    // repaint, or the first view after a switch shows none.
+    loadSeats(els.term.value).then(() => paint()).catch(() => {});
     syncUrl(els.query.value, els.term.value);
     if (els.query.value.trim()) runSearch(els.query.value, els.term.value);
   });
@@ -605,7 +608,7 @@ async function init() {
     // Ratings and seats are already in flight; fill the landing screen once
     // they land rather than showing an empty frame in the meantime.
     setStatus("");
-    Promise.allSettled([loadRatings(), loadSeats()]).then(() => showWelcome(els.term.value));
+    Promise.allSettled([loadRatings(), loadSeats(els.term.value)]).then(() => showWelcome(els.term.value));
   }
 }
 

--- a/js/detail.js
+++ b/js/detail.js
@@ -123,7 +123,8 @@ export function renderDetail({ section, course, term, entries, formatDate }) {
     seatBlock.append(row("Enrolled", `${seats.enrolled} / ${seats.limit}`, seats.full ? "is-full" : "is-open"));
     seatBlock.append(row("Waitlist", seats.waitlist > 0 ? `${seats.waitlist} waiting` : "none",
       seats.waitlist > 0 ? "is-full" : null));
-    if (seatsUpdated()) seatBlock.append(row("As of", formatDate ? formatDate(seatsUpdated()) : seatsUpdated()));
+    const asOf = seatsUpdated(term);
+    if (asOf) seatBlock.append(row("As of", formatDate ? formatDate(asOf) : asOf));
   } else {
     seatBlock.append(el("p", "d-note", "No seat data for this section."));
   }

--- a/js/seats.js
+++ b/js/seats.js
@@ -143,7 +143,12 @@ export function seatsFor(classNumber, term) {
   };
 }
 
-/** How many sections the snapshot covers, for the landing screen. */
-export function seatsSectionCount() {
-  return Object.keys(snapshot?.sections ?? {}).length;
+/**
+ * How many sections a term covers, for the landing screen.
+ *
+ * Answers from the index, so it is available as soon as the 361-byte index
+ * lands rather than waiting for that term's seats.
+ */
+export function seatsSectionCount(term) {
+  return entryFor(String(term ?? ""))?.sections ?? 0;
 }

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -43,20 +43,39 @@ export function taught(classNumber, days, start, end, names, opts = {}) {
 }
 
 // Seat snapshot. Term 1268 only, which is what makes the term guard testable.
-export const SEATS = {
-  term: "1268",
-  termName: "Autumn 2026",
+// Seats, in the same shape as the real snapshot since #48: a small index plus
+// one file per term, so the loader under test does the real two-step fetch.
+export const SEATS_INDEX = {
   source: "https://www.asc.ohio-state.edu/barrett.3/schedule/",
-  sourceUpdated: "2026-08-18",
   fields: ["enrolled", "limit", "waitlist"],
-  sections: {
-    "1001": [30, 40, 0],    // open
-    "1002": [40, 40, 3],    // exactly full, three waiting
-    "1003": [41, 40, 1],    // over cap, which OSU's own API calls open
-    "1004": [0, 0, 1],      // no published capacity, someone already waiting
-    "1005": [12],           // malformed, too short
-    "1006": ["12", 40, 0],  // malformed, enrolled is not a number
-    "1007": [5, 30],        // no waitlist column
+  note: "A missing class number means unknown, not zero.",
+  terms: [
+    { term: "1262", termName: "Spring 2026", sourceUpdated: "2026-04-27", sections: 2, file: "seats-1262.json" },
+    { term: "1268", termName: "Autumn 2026", sourceUpdated: "2026-08-18", sections: 7, file: "seats-1268.json" },
+  ],
+};
+
+export const SEATS_TERMS = {
+  "1268": {
+    term: "1268",
+    sections: {
+      "1001": [30, 40, 0],    // open
+      "1002": [40, 40, 3],    // exactly full, three waiting
+      "1003": [41, 40, 1],    // over cap, which OSU's own API calls open
+      "1004": [0, 0, 1],      // no published capacity, someone already waiting
+      "1005": [12],           // malformed, too short
+      "1006": ["12", 40, 0],  // malformed, enrolled is not a number
+      "1007": [5, 30],        // no waitlist column
+    },
+  },
+  // A second term proves the guard: 1001 exists in both with different numbers,
+  // so serving one term's row for another would be visible rather than subtle.
+  "1262": {
+    term: "1262",
+    sections: {
+      "1001": [10, 55, 0],
+      "2001": [55, 55, 2],
+    },
   },
 };
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -5,7 +5,7 @@
 // hand-building the index and skipping the code that builds it, these helpers
 // serve a fixture over a stubbed fetch and let the real loaders run.
 
-import { RATINGS, SEATS } from "./fixtures.js";
+import { RATINGS, SEATS_INDEX, SEATS_TERMS } from "./fixtures.js";
 
 /** Swap in a fetch that serves fixtures by URL. Returns a restore function. */
 export function stubFetch(routes) {
@@ -25,11 +25,16 @@ export function stubFetch(routes) {
  * test that needs a different snapshot, or none at all, asks for a fresh
  * instance by passing a suffix the import cache has not seen.
  */
-export async function withSeats(snapshot = SEATS, suffix = "") {
+export async function withSeats(terms = ["1268"], suffix = "", index = SEATS_INDEX) {
   const mod = await import(`../js/seats.js${suffix}`);
-  const restore = stubFetch({ "seats.json": snapshot });
+  const routes = { "seats.json": index };
+  for (const entry of index.terms ?? []) {
+    if (SEATS_TERMS[entry.term]) routes[entry.file] = SEATS_TERMS[entry.term];
+  }
+  const restore = stubFetch(routes);
   try {
-    await mod.loadSeats("seats.json");
+    // One call per term, the same way app.js loads the term on screen.
+    for (const term of terms) await mod.loadSeats(term, "seats.json");
   } finally {
     restore();
   }

--- a/tests/seats.test.js
+++ b/tests/seats.test.js
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { SEATS } from "./fixtures.js";
 import { withSeats } from "./helpers.js";
 
-const seats = await withSeats();
+// Both terms loaded, so the cross-term guard can be tested for real rather
+// than by the absence of data.
+const seats = await withSeats(["1268", "1262"]);
 
 test("seatsFor reports an open section", () => {
   assert.deepEqual(seats.seatsFor("1001", "1268"), { enrolled: 30, limit: 40, waitlist: 0, full: false });
@@ -48,11 +49,20 @@ test("regression #31: a zero limit is unknown capacity, not an empty section", (
 });
 
 // Regression, #23. The snapshot covers one term while the UI offers three.
-test("regression #23: seatsFor returns null when the snapshot is for another term", () => {
-  assert.equal(seats.seatsTerm(), "1268");
-  assert.equal(seats.seatsFor("1001", "1262"), null, "Spring 2026 must not read Autumn seats");
-  assert.equal(seats.seatsFor("1001", "1264"), null, "Summer 2026 must not read Autumn seats");
-  assert.equal(seats.seatsFor("1001", "1268").enrolled, 30, "the matching term still resolves");
+test("regression #23: a term that is not loaded reads as unknown, not as another term", async () => {
+  // The original guard compared one snapshot's term against the requested one.
+  // Since #48 seats are keyed by term, so the guard is structural: a term with
+  // nothing loaded has no map to read and cannot borrow another term's rows.
+  const partial = await withSeats(["1268"], "?autumn-only");
+  assert.equal(partial.seatsFor("1001", "1268").enrolled, 30, "the loaded term resolves");
+  assert.equal(partial.seatsFor("1001", "1262"), null, "Spring is listed but not loaded");
+  // Three distinct answers, none of which collapse into each other:
+  //   ready   its seats are in hand
+  //   unknown Barrett has this term, we have not fetched it
+  //   missing Barrett publishes nothing for this term, which is settled
+  assert.equal(partial.seatsStatus("1268"), "ready");
+  assert.equal(partial.seatsStatus("1262"), "unknown", "listed but never fetched");
+  assert.equal(partial.seatsStatus("9999"), "missing", "not published at all");
 });
 
 test("regression #23: seatsFor returns null when no term was asked for", () => {
@@ -61,20 +71,39 @@ test("regression #23: seatsFor returns null when no term was asked for", () => {
   assert.equal(seats.seatsFor("1001", ""), null);
 });
 
-test("seatsTerm and seatsUpdated report the snapshot", () => {
-  assert.equal(seats.seatsTerm(), SEATS.term);
-  assert.equal(seats.seatsUpdated(), "2026-08-18");
+test("seatsTerm and seatsUpdated answer per term", () => {
+  // #48: Barrett freezes a term once it is over, so the dates genuinely differ.
+  // A single snapshot-wide date would stamp Autumn's freshness onto Spring.
+  assert.equal(seats.seatsTerm("1268"), "1268");
+  assert.equal(seats.seatsUpdated("1268"), "2026-08-18");
+  assert.equal(seats.seatsUpdated("1262"), "2026-04-27");
+});
+
+test("regression #23: the same class number resolves per term, never across", () => {
+  // 1001 exists in both fixtures with different numbers, so a cross-term leak
+  // would show up as the wrong figure rather than as missing data.
+  assert.equal(seats.seatsFor("1001", "1268").enrolled, 30);
+  assert.equal(seats.seatsFor("1001", "1262").enrolled, 10);
+  assert.equal(seats.seatsFor("2001", "1268"), null, "a Spring-only section is not served for Autumn");
+});
+
+test("a term the index does not list is settled, not pending", () => {
+  // "missing" and "loading" must not collapse: one is an answer, one is a wait.
+  assert.equal(seats.seatsStatus("1268"), "ready");
+  assert.equal(seats.seatsStatus("9999"), "missing");
+  assert.equal(seats.seatsFor("1001", "9999"), null);
 });
 
 test("nothing is known before a snapshot is loaded", async () => {
   const fresh = await import("../js/seats.js?unloaded");
-  assert.equal(fresh.seatsTerm(), null);
-  assert.equal(fresh.seatsUpdated(), null);
+  assert.equal(fresh.seatsTerm("1268"), null);
+  assert.equal(fresh.seatsUpdated("1268"), null);
   assert.equal(fresh.seatsFor("1001", "1268"), null);
+  assert.equal(fresh.seatsStatus("1268"), "unknown", "not loaded is not the same as not published");
 });
 
 test("loadSeats caches, so a second call does not fetch again", async () => {
   // fetch is no longer stubbed here, so a real fetch would throw or hang.
-  const again = await seats.loadSeats("never-fetched.json");
-  assert.equal(again.term, "1268");
+  const again = await seats.loadSeats("1268", "never-fetched.json");
+  assert.ok(again.terms.some((t) => t.term === "1268"));
 });


### PR DESCRIPTION
`main` went red when #48 merged. That PR was scoped away from `app.js`, `detail.js` and the tests so it would not collide with work I was doing, which was right, and this is the other half.

## The payoff, measured live

```
AUTUMN 2026
  seats files fetched : seats.json, seats-1268.json
  status              : 1 course, 22 sections in Autumn 2026. Seats as of Aug 18.
  sections with seats : 22 of 22

AFTER SWITCH TO SPRING 2026
  seats files fetched : seats.json, seats-1268.json, seats-1262.json
  status              : 1 course, 26 sections in Spring 2026. Seats as of Apr 27.
  sections with seats : 26 of 26
```

Spring 2026 has real seat counts for the first time, its own file is fetched only on the switch, and it carries **its own** freshness date. Barrett freezes a term once it ends, so Apr 27 is correct for Spring and stamping Autumn's Aug 18 on it would have been a quiet lie.

## A bug the merge introduced

`seatsSectionCount()` still read `snapshot?.sections`, which no longer exists, so it returned 0 without erroring and the landing screen would have shown a term with no section count. It now answers from the index, which also makes it available as soon as the 361-byte index lands rather than after a term's seats.

## Tests

Fixtures restructured to the real two-step shape so the loader does the real fetch. Both fixture terms carry class `1001` with different numbers, so a cross-term leak shows up as a **wrong figure** rather than as missing data, which is the failure mode that matters.

The old #23 guard asserted `seatsFor` returns null when "the snapshot is for another term". That concept is gone: seats are keyed by term, so the guarantee is now structural rather than a comparison that could be forgotten. Rewritten to assert that, plus the four states `seatsStatus` distinguishes.

One assertion in my first attempt was wrong, not the code: I expected `loading` for a term listed but never requested. It returns `unknown`, and `loading` is reserved for a fetch actually in flight. That is the more precise distinction and the test now documents it.

138 tests pass, up from 136.
