### PR TITLE
Re-verify accessibility against the v2 layout

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -8,7 +8,7 @@
   --ink: #16171a;
   --mute: #5f646c;
   --rule: #dee0e5;
-  --field: #8a9099;
+  --field: #80858c;
   --scarlet: #bb0000;
   --open: #0e7a50;
   --wait: #a65b00;
@@ -201,7 +201,7 @@ body {
 
 /* Course records ---------------------------------------------------------- */
 
-.results { display: grid; gap: 0.75rem; }
+.results { display: grid; grid-template-columns: minmax(0, 1fr); gap: 0.75rem; }
 
 .course {
   background: var(--paper);
@@ -310,7 +310,6 @@ body {
 
   .rail-toggle {
     display: inline-block;
-    order: 3;
     font: inherit;
     font-size: 0.85rem;
     padding: 0.45rem 0.7rem;
@@ -454,7 +453,6 @@ body {
 }
 
 .score::before { content: "★"; color: var(--scarlet); font-size: 0.75rem; }
-.score[data-thin="true"] { opacity: 0.65; }
 .score[data-thin="true"]::before { color: var(--mute); }
 /* Parenthesised, because "2.7 / 3" reads as a score out of three when 3 is
    actually how many people rated them. */
@@ -474,7 +472,7 @@ body {
 }
 
 .seats[data-state="full"] { color: var(--scarlet); font-weight: 500; }
-.waitlist { margin-left: 0.25rem; opacity: 0.85; }
+.waitlist { margin-left: 0.25rem; }
 
 @media (max-width: 34rem) {
   .seats { grid-column: 1 / -1; text-align: left; }
@@ -687,7 +685,9 @@ body {
 
 .view-bar { display: flex; margin-bottom: 0.8rem; }
 
-.view-toggle { display: inline-flex; border: 1px solid var(--field); border-radius: var(--radius); overflow: hidden; }
+/* No overflow:hidden here: it clipped the focus ring off both buttons, which
+   #38 measured at 0 visible pixels. The corners round on the buttons instead. */
+.view-toggle { display: inline-flex; border: 1px solid var(--field); border-radius: var(--radius); }
 
 .view-toggle button {
   font: inherit;
@@ -699,12 +699,22 @@ body {
   cursor: pointer;
 }
 
+.view-toggle button:first-child { border-radius: calc(var(--radius) - 1px) 0 0 calc(var(--radius) - 1px); }
+.view-toggle button:last-child { border-radius: 0 calc(var(--radius) - 1px) calc(var(--radius) - 1px) 0; }
 .view-toggle button + button { border-left: 1px solid var(--field); }
 .view-toggle button.is-on { background: var(--scarlet); color: var(--paper); font-weight: 600; }
 
+.cal-scroll { overflow-x: auto; }
+.cal-scroll:focus-visible { outline: 2px solid var(--scarlet); outline-offset: 2px; }
+
 .cal {
   display: grid;
-  grid-template-columns: 3rem repeat(var(--cal-days), minmax(0, 1fr));
+  grid-template-columns: 3rem repeat(var(--cal-days), minmax(9rem, 1fr));
+  /* fit-content, not auto: with a floor under the columns the grid is wider
+     than a phone, and it has to say so or overflow:hidden eats the difference
+     instead of handing it to .cal-scroll. */
+  width: fit-content;
+  min-width: 100%;
   border: 1px solid var(--rule);
   border-radius: var(--radius);
   background: var(--paper);

--- a/index.html
+++ b/index.html
@@ -17,9 +17,6 @@
       <h1 class="wordmark">Finder</h1>
       <p class="tagline">Who teaches it, before everyone else finds out.</p>
 
-      <button class="rail-toggle" id="rail-toggle" type="button"
-              aria-expanded="false" aria-controls="rail">Filters</button>
-
       <form class="search" id="search" role="search" aria-label="Course search">
         <label class="visually-hidden" for="q">Course or professor</label>
         <input id="q" name="q" type="search" autocomplete="off" autocapitalize="none"
@@ -32,6 +29,12 @@
 
         <button id="go" type="submit">Search</button>
       </form>
+
+      <!-- After the search in the DOM as well as on screen: the collapsed
+           layout paints it below the search box, and #38 measured the tab
+           order jumping backwards when `order: 3` was the only thing moving it. -->
+      <button class="rail-toggle" id="rail-toggle" type="button"
+              aria-expanded="false" aria-controls="rail">Filters</button>
     </header>
 
     <aside class="rail" id="rail" aria-label="Filters">
@@ -53,11 +56,16 @@
         <fieldset class="f-set">
           <legend class="eyebrow">Meets on</legend>
           <div class="f-days" id="f-days" role="group" aria-label="Days of the week">
-            <button type="button" class="f-day" data-day="monday" data-state="any"><span>Mo</span></button>
-            <button type="button" class="f-day" data-day="tuesday" data-state="any"><span>Tu</span></button>
-            <button type="button" class="f-day" data-day="wednesday" data-state="any"><span>We</span></button>
-            <button type="button" class="f-day" data-day="thursday" data-state="any"><span>Th</span></button>
-            <button type="button" class="f-day" data-day="friday" data-state="any"><span>Fr</span></button>
+            <button type="button" class="f-day" data-day="monday" data-state="any"
+                    aria-label="Monday: any"><span>Mo</span></button>
+            <button type="button" class="f-day" data-day="tuesday" data-state="any"
+                    aria-label="Tuesday: any"><span>Tu</span></button>
+            <button type="button" class="f-day" data-day="wednesday" data-state="any"
+                    aria-label="Wednesday: any"><span>We</span></button>
+            <button type="button" class="f-day" data-day="thursday" data-state="any"
+                    aria-label="Thursday: any"><span>Th</span></button>
+            <button type="button" class="f-day" data-day="friday" data-state="any"
+                    aria-label="Friday: any"><span>Fr</span></button>
           </div>
           <p class="f-hint">Click once to require a day, twice to avoid it.</p>
         </fieldset>
@@ -133,7 +141,7 @@
     </main>
 
     <aside class="detail" id="detail" aria-label="Section detail" tabindex="-1">
-      <button class="detail-back" id="detail-back" type="button" hidden>Back to results</button>
+      <button class="detail-back" id="detail-back" type="button">Back to results</button>
       <div id="detail-body">
         <p class="detail-idle">Pick a section to see the instructor, seats and room.</p>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -72,8 +72,10 @@ function setDayState(button, state) {
   button.dataset.state = state;
   const day = DAY_LABELS[button.dataset.day] ?? button.dataset.day;
   const said = state === "require" ? "required" : state === "avoid" ? "avoided" : "any";
+  // Deliberately no aria-pressed. It is a boolean and this control has three
+  // states, so "required" and "avoided" both came out as pressed=true and the
+  // one that mattered was announced as the other. The state lives in the name.
   button.setAttribute("aria-label", `${day}: ${said}`);
-  button.setAttribute("aria-pressed", String(state !== "any"));
 }
 
 function readFilters() {
@@ -252,7 +254,10 @@ function selectSection(row) {
 
 function closeDetail() {
   els.app.dataset.view = "results";
-  els.results.focus();
+  // Back to the row that opened the pane where possible, so a keyboard user
+  // resumes where they left off instead of at the top of the results.
+  const selected = els.results.querySelector(".is-selected");
+  (selected ?? els.results).focus();
 }
 
 // The status element is never removed or hidden, only its text changes. A live
@@ -475,6 +480,11 @@ async function init() {
   setStatus("Loading terms...");
   els.term.disabled = true;
 
+  // Before the network, not after: a shared link's filters and the day chips'
+  // spoken state must not wait on the term service, which #38 measured
+  // leaving all five chips announcing as "Mo" when it failed.
+  writeFilters(params);
+
   try {
     terms = await fetchTerms();
   } catch (error) {
@@ -498,8 +508,6 @@ async function init() {
   const wanted = params.get("term");
   els.term.value = terms.some((t) => t.code === wanted) ? wanted : defaultTerm(terms).code;
   els.term.disabled = false;
-
-  writeFilters(params);
 
   for (const field of [els.subject, els.number]) {
     field.addEventListener("focus", ensureCourses);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -7,9 +7,12 @@ import { toMinutes } from "./filters.js";
 import { ratingFor } from "./ratings.js";
 import { seatsFor } from "./seats.js";
 
+// Short label for the column head, full name for the accessible name: a screen
+// reader gets the day from the label, since the grid only says it by position.
 const DAYS = [
-  ["monday", "Mon"], ["tuesday", "Tue"], ["wednesday", "Wed"],
-  ["thursday", "Thu"], ["friday", "Fri"], ["saturday", "Sat"], ["sunday", "Sun"],
+  ["monday", "Mon", "Monday"], ["tuesday", "Tue", "Tuesday"], ["wednesday", "Wed", "Wednesday"],
+  ["thursday", "Thu", "Thursday"], ["friday", "Fri", "Friday"],
+  ["saturday", "Sat", "Saturday"], ["sunday", "Sun", "Sunday"],
 ];
 
 // Sized so a standard 55 minute class has room for its time label plus three
@@ -109,7 +112,7 @@ export function renderCalendar(entries, term) {
   }
   grid.append(gutter);
 
-  for (const [key, label] of usedDays) {
+  for (const [key, label, fullDay] of usedDays) {
     const column = el("div", "cal-col");
     column.append(el("div", "cal-head", label));
 
@@ -122,18 +125,26 @@ export function renderCalendar(entries, term) {
     }
 
     for (const slot of slots.filter((s) => s.days.includes(key))) {
-      body.append(renderSlot(slot, first));
+      body.append(renderSlot(slot, first, fullDay));
     }
     column.append(body);
     grid.append(column);
   }
 
-  wrap.append(grid);
+  // A week is two-dimensional, so it scrolls sideways rather than crushing its
+  // columns. #38 measured the instructor name at 0-8px wide on every phone
+  // width while the grid was squeezing to fit.
+  const scroll = el("div", "cal-scroll");
+  scroll.tabIndex = 0;
+  scroll.setAttribute("role", "group");
+  scroll.setAttribute("aria-label", "Week grid");
+  scroll.append(grid);
+  wrap.append(scroll);
   if (unscheduled.length) wrap.append(unscheduledList(unscheduled));
   return wrap;
 }
 
-function renderSlot(slot, first) {
+function renderSlot(slot, first, fullDay) {
   const box = el("div", `cal-slot ${slotTone(slot.items)}`);
   const height = Math.max((slot.end - slot.start) * PX_PER_MIN, MIN_SLOT);
   box.style.top = `${(slot.start - first) * PX_PER_MIN}px`;
@@ -159,12 +170,24 @@ function renderSlot(slot, first) {
 
     line.append(el("span", "cal-who", name));
 
+    // Spoken, "Paolo Bucci 3.0 32/40" is three numbers with no units, and the
+    // day and time exist only as a position in the grid. The label says all of
+    // it out loud.
+    const said = [`${fullDay} ${clock(slot.start)} to ${clock(slot.end)}`, name];
+
     const rating = people.length === 1 ? ratingFor(people[0].name) : null;
-    if (rating) line.append(el("span", "cal-rate", Number(rating.avgRating).toFixed(1)));
+    if (rating) {
+      line.append(el("span", "cal-rate", Number(rating.avgRating).toFixed(1)));
+      said.push(`rated ${Number(rating.avgRating).toFixed(1)} out of 5`);
+    }
     if (item.seats) {
       line.append(el("span", item.seats.full ? "cal-seats is-full" : "cal-seats",
         `${item.seats.enrolled}/${item.seats.limit}`));
+      said.push(item.seats.full
+        ? `full, ${item.seats.enrolled} of ${item.seats.limit} seats taken`
+        : `${item.seats.enrolled} of ${item.seats.limit} seats taken`);
     }
+    line.setAttribute("aria-label", said.join(", "));
     box.append(line);
   }
 
@@ -182,12 +205,15 @@ function unscheduledList(items) {
   wrap.append(el("p", "eyebrow", `${items.length} without a set time`));
   for (const { entry, section } of items.slice(0, 12)) {
     const people = instructorsOf(section);
+    const who = people.map((p) => p.name).join(" & ") || "Instructor not listed";
+    const course = `${entry.course.subject} ${entry.course.catalogNumber}`;
     const line = el("button", "cal-item");
     line.type = "button";
     line.dataset.classNumber = String(section.classNumber);
-    line.append(el("span", "cal-who",
-      `${entry.course.subject} ${entry.course.catalogNumber} · ${people.map((p) => p.name).join(" & ") || "Instructor not listed"}`));
+    line.append(el("span", "cal-who", `${course} · ${who}`));
     line.append(el("span", "cal-seats", section.instructionMode ?? ""));
+    line.setAttribute("aria-label",
+      [course, who, "no set time", section.instructionMode].filter(Boolean).join(", "));
     wrap.append(line);
   }
   if (items.length > 12) wrap.append(el("p", "d-note", `and ${items.length - 12} more`));


### PR DESCRIPTION
Closes #38

#20 measured the old single-column page. Everything it verified has since been replaced by the three-pane shell (#30), the detail pane (#31), the filter rail (#32), the calendar (#33), the pickers (#36), the tri-state day chips (#43), the landing screen (#45) and per-term seats (#48, #55). This re-measures all of it from scratch.

## How it was measured

Chrome headless over CDP, driving the live app inside a sized iframe served from the same origin, because `--headless=new --window-size` is ignored for layout and leaves `innerWidth` at 500. Ratios computed from the painted colours read back out of `getComputedStyle`, with alpha and inherited `opacity` composited against the resolved ancestor background, not eyeballed. Focus rings verified by screenshot pixel diff (focused capture minus the same clip with `outline: none` forced) rather than by `getComputedStyle(el, ':focus-visible')`, which reads pseudo-elements and returns nothing. Focus driven by real `Tab` key events, never programmatic `.focus()`, and never under `--force-prefers-reduced-motion`, which replaces the author ring with Chrome's own.

332 colour pairings, 6 states, 2 schemes, 7 widths, 2 views.

## Contrast

Every pairing #38 names, before and after. The full 332-row sweep found no others.

| Pairing | Scheme | Need | Before | After |
|---|---|---|---|---|
| `.view-toggle` frame | light | 3:1 | **2.85 FAIL** | 3.29 pass |
| `.view-toggle` frame | dark | 3:1 | 3.43 pass | 3.43 pass |
| `.score` | light | 4.5:1 | **2.82 FAIL** | 5.96 pass |
| `.score` | dark | 4.5:1 | **3.69 FAIL** | 7.07 pass |
| `.score-count` | light | 4.5:1 | **2.82 FAIL** | 5.96 pass |
| `.score-count` | dark | 4.5:1 | **3.69 FAIL** | 7.07 pass |
| `.waitlist` | light | 4.5:1 | **4.25 FAIL** | 5.96 pass |
| `.waitlist` | dark | 4.5:1 | 4.65 pass | 6.04 pass |
| `.cal-time` on `--wash` | light / dark | 4.5:1 | 5.27 / 6.55 pass | 5.27 / 6.55 pass |
| `.cal-rate` | light / dark | 4.5:1 | 5.97 / 5.60 pass | 5.97 / 5.60 pass |
| `.cal-seats` | light / dark | 4.5:1 | 5.27 / 6.55 pass | 5.27 / 6.55 pass |
| `.cal-seats.is-full` | light / dark | 4.5:1 | 5.97 / 5.60 pass | 5.97 / 5.60 pass |
| `.cal-more` | light / dark | 4.5:1 | 5.97 / 5.60 pass | 5.97 / 5.60 pass |
| `.cal-count` | light / dark | 4.5:1 | 5.97 / 5.60 pass | 5.97 / 5.60 pass |
| `.cal-who` | light / dark | 4.5:1 | 15.87 / 14.69 pass | 15.87 / 14.69 pass |
| `.cal-head` | light / dark | 4.5:1 | 5.96 / 7.07 pass | 5.96 / 7.07 pass |
| `.cal-slot.is-open` edge | light / dark | 3:1 | 5.36 / 8.32 pass | 5.36 / 8.32 pass |
| `.cal-slot.is-part` edge | light / dark | 3:1 | 5.10 / 8.40 pass | 5.10 / 8.40 pass |
| `.cal-slot.is-full` edge | light / dark | 3:1 | 6.75 / 6.04 pass | 6.75 / 6.04 pass |
| `.d-num.is-rating` | light / dark | 3:1 | 6.75 / 6.04 pass | 6.75 / 6.04 pass |
| `.d-val.is-full` | light / dark | 4.5:1 | 6.75 / 6.04 pass | 6.75 / 6.04 pass |
| `.d-val.is-open` | light / dark | 4.5:1 | 5.36 / 8.32 pass | 5.36 / 8.32 pass |
| `.d-val.is-none` | light / dark | 4.5:1 | 5.96 / 7.07 pass | 5.96 / 7.07 pass |
| `.f-day` any, text | light / dark | 4.5:1 | 5.96 / 7.07 pass | 5.96 / 7.07 pass |
| `.f-day` any, border | light / dark | 3:1 | 3.22 / 3.70 pass | 3.72 / 3.70 pass |
| `.f-day` required, text | light / dark | 4.5:1 | 6.75 / 6.04 pass | 6.75 / 6.04 pass |
| `.f-day` avoided, text | light / dark | 4.5:1 | 5.96 / 7.07 pass | 5.96 / 7.07 pass |
| `.view-toggle` off | light / dark | 4.5:1 | 5.27 / 6.55 pass | 5.27 / 6.55 pass |
| `.view-toggle` on | light / dark | 4.5:1 | 6.75 / 6.04 pass | 6.75 / 6.04 pass |
| `.hidden-note` text | light / dark | 4.5:1 | 5.27 / 6.55 pass | 5.27 / 6.55 pass |
| `.hidden-note` button | light / dark | 4.5:1 | 5.97 / 5.60 pass | 5.97 / 5.60 pass |
| `.f-hint` | light / dark | 4.5:1 | 5.96 / 7.07 pass | 5.96 / 7.07 pass |
| `.eyebrow` | light / dark | 4.5:1 | 5.96 / 7.07 pass | 5.96 / 7.07 pass |
| `.seats[data-state=full]` | light / dark | 4.5:1 | 5.97 / 5.60 pass | 6.75 / 6.04 pass |
| `.w-score` | light / dark | 4.5:1 | 5.97 / 5.60 pass | 5.97 / 5.60 pass |
| `.w-example` | light / dark | 4.5:1 | 5.97 / 5.60 pass | 5.97 / 5.60 pass |
| `.status[data-kind=error]` | light / dark | 4.5:1 | 5.97 / 5.60 pass | 5.97 / 5.60 pass |
| `#q` and `.f-ctl` frames | light / dark | 3:1 | 3.22 / 3.70 pass | 3.72 / 3.70 pass |
| `#go` label on scarlet | light / dark | 4.5:1 | 6.75 / 5.88 pass | 6.75 / 5.88 pass |

Text failures after: 0. Component-boundary failures after: 0.

Three of the four failures were caused by `opacity` rather than by a colour, which is why reading the palette alone would not have caught them.

`--field` is the token #20 introduced for form-control borders when `--rule` failed at 3:1. It was only ever checked against `--paper`. On `--wash`, where the view toggle sits, it measured 2.85. It is now `#80858c`, which clears 3:1 on `--paper` (3.72), `--wash` (3.29) and `--sunk` (3.06). The dark value already cleared all three and is unchanged. No new token was needed.

Not changed, and why: the `--rule` hairlines between rows, panes and grid lines measure 1.17 to 1.37 in both schemes. They are decorative separators, not the visual information required to identify a control or its state, so 1.4.11 does not apply to them. `#p-number` when disabled measures 1.78; inactive components are explicitly exempt. Changing either would be the redesign #38 rules out.

## Focus

Every interactive element, walked with real Tab presses, each ring verified by pixel diff. Numbers are changed pixels within the element's bounding box plus 8px, focused minus unfocused.

| Control | Ring | Before | After |
|---|---|---|---|
| `#q` search field | 2px scarlet, offset 2 | 1064 visible | 1064 visible |
| `#term` term select | 2px scarlet, offset 2 | 844 visible | 844 visible |
| `#go` search button | 2px `--ink`, offset 2 | 551 visible | 551 visible |
| `#rail-toggle` Filters | 2px scarlet, offset 2 | 464 visible | 464 visible |
| `#p-subject` subject picker | 2px scarlet, offset 2 | 1064 visible | 1064 visible |
| `#p-number` number picker | 2px scarlet, offset 2 | 1064 visible | 1064 visible |
| `.f-day` x5 day chips | 2px scarlet on the span, offset 2 | 71 visible | 71 visible |
| `#f-from`, `#f-to`, `#f-rating` | 2px scarlet, offset 2 | 1064 visible | 1064 visible |
| `#f-rated`, `#f-full`, `#f-online` | 2px scarlet, offset 2 | 168 visible | 168 visible |
| `#f-clear` clear filters | 2px scarlet, offset 2 | visible | visible |
| `#view-list` | 2px scarlet, offset 2 | **0 / 60, clipped away** | 295 / 359 visible |
| `#view-cal` | 2px scarlet, offset 2 | **0 / 60, clipped away** | 424 / 492 visible |
| `.cal-scroll` week grid | 2px scarlet, offset 2 | did not exist | visible |
| `.cal-item` calendar entry, all 44 | 2px scarlet, offset 2 | 912 visible | 636 to 912 visible |
| `.section` row, `role=button` | 2px scarlet, offset -2 | 3832 visible | 1840 to 3832 visible |
| `.teacher-link` | 2px scarlet, offset 2 | 432 visible | 432 to 520 visible |
| `.related` summary | 2px scarlet, offset 2 | 3836 visible | 1652 visible |
| `#detail-back` | 2px scarlet, offset 2 | 672 visible | 672 visible |
| `.w-name` landing entry | 2px scarlet, offset 2 | 2164 visible | 2164 visible |
| `.w-example` | 2px scarlet, offset 2 | 380 visible | 380 visible |
| `.hidden-note` button | 2px scarlet, offset 2 | 628 visible | 628 visible |

The view toggle was the one real failure and it was total: `overflow: hidden` on the container clipped a 2px-offset outline off two buttons sitting flush inside it, in both schemes. Nothing else in the app is reachable only by mouse. Section rows answer Enter and Space, calendar entries are real `<button>` elements, and focusing an off-screen calendar entry scrolls it into view.

Two focus-order fixes on top:

- `.rail-toggle` carried `order: 3`, so it painted below the search box while remaining the first tab stop after the wordmark. Measured DOM order `wordmark -> Filters -> search` against visual order `wordmark -> search -> Filters`. It now follows the search in the DOM as well, and the two match.
- Back from the detail takeover landed on `#results`. It now returns to the row that opened the pane.

## Overflow

`documentElement.scrollWidth` against `clientWidth`, at every width, in both views, with the rail sheet open and with the detail taking over. 42 combinations.

| Width | List | List + rail | List + detail | Calendar | Calendar + rail | Calendar + detail |
|---|---|---|---|---|---|---|
| 320 | none | none | none | none | none | none |
| 360 | none | none | none | none | none | none |
| 390 | none | none | none | none | none | none |
| 414 | none | none | none | none | none | none |
| 768 | none | none | none | none | none | none |
| 1024 | none | none | none | none | none | none |
| 1600 | none | none | none | none | none | none |

Identical before and after, so overflow was never the calendar's problem. Content loss was.

| Width | `.cal` column | `.cal-who` min/median/max | Slots overflowing their box | Seat counts clipped away |
|---|---|---|---|---|
| 320 | 60 -> 144 | **0/0/0** -> 54/69/69 | **40 of 40** -> 0 | **44** -> 0 |
| 360 | 70 -> 144 | **0/0/0** -> 54/69/69 | 0 -> 0 | **44** -> 0 |
| 390 | 77 -> 144 | **2/2/2** -> 54/69/69 | 0 -> 0 | 0 -> 0 |
| 414 | 83 -> 144 | **8/8/8** -> 54/69/69 | 0 -> 0 | 0 -> 0 |
| 768 | 170 | 54/72/95 | 0 | 0 |
| 1024 | 231 | 54/72/108 | 0 | 0 |
| 1600 | 214 | 54/72/108 | 0 | 0 |

The grid had no minimum column width, so on a phone it kept its shape by crushing the instructor name, the only reason the view exists, down to nothing. `minmax(9rem, 1fr)` puts a floor under the columns and the grid scrolls sideways inside `.cal-scroll`, which is labelled, focusable and keyboard-scrollable, verified at 268px of travel from ArrowRight and End. `.results` gained `grid-template-columns: minmax(0, 1fr)` so its auto track stops sizing to the grid instead of clamping it. Nothing changes at 768 and above.

## Day chips

All three states, read back out of the accessibility tree rather than off the attribute.

| State | Accessible name | Non-colour cue | Before | After |
|---|---|---|---|---|
| any | `Friday: any` | plain solid chip | `pressed=false` | no `aria-pressed` |
| required | `Friday: required` | filled, weight 600 | `pressed=true` | no `aria-pressed` |
| avoided | `Friday: avoided` | dashed border, `line-through` | **`pressed=true`** | no `aria-pressed` |

The names were right; `aria-pressed` was not. It is a boolean and the control has three states, so "required" and "avoided" both reported pressed, and a screen reader user heard "avoided, pressed" with nothing distinguishing the two. It is dropped, and the state stays in the accessible name.

Separately, those names were written by `writeFilters()`, which ran after `await fetchTerms()`. Measured with the term service blocked: all five chips announced as "Mo", "Tu", "We", "Th", "Fr" with no state at all, and a shared link's filters were silently dropped. The initial names are now in the markup and `writeFilters()` runs before the network. The same test now reports `Monday: required` and `Friday: avoided` with `hideFull` checked, with the API still down.

## Live regions

`#status` is `role=status`, `aria-live=polite`, `aria-atomic=true`, permanently in the DOM and never hidden. Text captured through a MutationObserver.

| Trigger | Text | Announced |
|---|---|---|
| baseline | `1 course, 22 sections in Autumn 2026. Seats as of Aug 18.` | — |
| Hide full sections | `1 course, 4 sections in Autumn 2026. Seats as of Aug 18.` | yes |
| Friday chip | `1 course, 2 sections in Autumn 2026. Seats as of Aug 18.` | yes |
| Clear filters | `1 course, 22 sections in Autumn 2026. Seats as of Aug 18.` | yes |
| List / Calendar | unchanged | no, and correctly so: the pressed state on the focused toggle carries it |

4 mutations for 4 filter changes. No change needed.

## Also fixed

`#detail-back` carried the `hidden` attribute while `.app[data-view="detail"] .detail-back` set `display: inline-block` on it. The cascade won, so the button rendered and worked, but the attribute claimed otherwise and the only way back out of the detail takeover depended on that one rule staying put. The attribute is gone; the existing `.detail-back { display: none }` base rule already hides it.

Calendar entries announced as `Paolo Bucci 3.0 32/40`, three numbers with no units, with the day and the time carried only by the entry's position in the grid. They now carry `aria-label="Tuesday 8a to 8:55a, Paolo Bucci, rated 3.0 out of 5, 32 of 40 seats taken"`, and unscheduled entries name the course, the instructor, "no set time" and the mode.

## Not done

Escape does not close the rail sheet. It is a disclosure rather than a modal, there is no keyboard trap, and every control inside it is reachable by Tab, so nothing fails. It is a nicety, and out of scope for a correctness pass.

No test file was touched. 138 tests pass before and after.
