### PR TITLE
Delete the leftover Cloudflare beacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ js/
 scripts/              the three snapshot jobs
 data/                 the snapshots, committed
 docs/                 what OSU's API and Barrett's schedule get wrong
-tests/                226 tests, zero dependencies
+tests/                227 tests, zero dependencies
 wireframes/           three layouts considered first
 analytics/            the page-view counter, a Cloudflare Worker
 stats/                the page that reads the counter

--- a/index.html
+++ b/index.html
@@ -151,8 +151,5 @@
 
   <script type="module" src="js/app.js"></script>
   <script type="module" src="js/hit.js"></script>
-  <!-- Cloudflare Web Analytics -->
-  <script type="module" src="https://static.cloudflareinsights.com/beacon.min.js"
-          data-cf-beacon='{"token": "b9764a2e728f47bd94e5555744379d9a"}'></script>
 </body>
 </html>

--- a/tests/pages.test.js
+++ b/tests/pages.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Regression, #72. The first-party counter landed on top of the beacon without
+// removing it, so both fired while two pages promised no third-party analytics.
+// Any vendor's script breaks that promise, not just this one.
+const PAGES = ["index.html", "stats/index.html"];
+
+function scriptSources(html) {
+  const tags = html.matchAll(/<script\b[^>]*\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi);
+  return [...tags].map((m) => m[1] ?? m[2] ?? m[3]);
+}
+
+test("regression #72: no page loads a third-party script", () => {
+  for (const page of PAGES) {
+    const sources = scriptSources(readFileSync(new URL(`../${page}`, import.meta.url), "utf8"));
+    assert.ok(sources.length > 0, `no script tags found in ${page}`);
+    assert.deepEqual(sources.filter((src) => /^(https?:)?\/\//i.test(src)), [], `${page} loads an external script`);
+  }
+});


### PR DESCRIPTION
Closes #72

The beacon was not doing anything the site needed. `2936a7c` added it, then `537b82c` added the first-party counter (`js/hit.js` plus the analytics Worker) on top of it and never took the old one out. Both fired on every page load, and the second one is the one `/stats` actually reads.

## What the page was really sending

Loaded both versions in headless Chrome with `--log-net-log --net-log-capture-mode=IncludeSensitive`, so this is the network layer and not a grep of the markup.

```
BEFORE   main's index.html
  cloudflareinsights.com
  cloudflareinsights.com:443
  cloudflareinsights.com/beacon.min.js
  cloudflareinsights.com/cdn-cgi/rum      <- the visit itself, posted out
  85 references in the net log

AFTER    this branch
  0 references in the net log
  0 occurrences in the dumped DOM
```

`cdn-cgi/rum` is the part that matters. The page was not just pulling a script from a third party, it was posting the page view to one, while two places in this repo said it did not:

```
stats/index.html:62   Counted by Finder itself, no third-party analytics.
analytics/README.md:4 No third-party analytics service
```

Both of those are now true.

The app still boots with the tag gone. Same headless run against this branch: `<select id="term" name="term">` has lost the `disabled` attribute the markup ships with and holds 19 options including `<option value="1268">Autumn 2026</option>`, so `app.js` got all the way through `fetchTerms` against the live API.

## Tests

`node --test` from the worktree root:

```
# tests 139
# pass 139
# fail 0
```

That is 138 before this branch plus one new one in `tests/pages.test.js`, which reads both shipped pages and fails on any external script `src`. Confirmed it fails without the fix rather than passing vacuously. Restoring main's `index.html`:

```
not ok 1 - regression #72: no page loads a third-party script
  actual:
    0: 'https://static.cloudflareinsights.com/beacon.min.js'
```

It is deliberately not beacon-specific. Any vendor's script trips it, since a different vendor breaks the same promise. It also catches an unquoted `src=`, which is worth saying because the obvious version of this regex does not:

```
<script src=https://static.cloudflareinsights.com/beacon.min.js></script>
  quoted-only regex : passes, misses it entirely
  the one committed : not ok 1
```

`README.md:190` said `138 tests` and now says `139`.

## Not done on purpose

Both pages still load Google Fonts from `fonts.googleapis.com` and `fonts.gstatic.com`, which is a third party that sees every visitor's IP. It is not analytics, so it does not contradict either line quoted above, and the new test checks script `src` only so it does not flag the stylesheet. Self-hosting the fonts is a separate issue if you want the stronger promise.

Worth knowing before this deploys: the beacon was the only thing feeding the Cloudflare Web Analytics dashboard for this site. That dashboard goes flat from the day this ships. Nothing on the site loses a number, since `/stats` reads the D1 table, but if you were still opening it, that is why.

One correction to the issue body. It lists three claims the beacon contradicted, but only two still exist. `README.md:152` "Nothing else leaves the page." was already gone, removed by `de6fe15`, so no doc edit was needed there. Checked against `main`, not against the branch point.

There is no CSP, `script-src` or `connect-src` anywhere in the repo to update, and grep for the token `b9764a2e728f47bd94e5555744379d9a` finds nothing else.
