### PR TITLE
Stop one empty pass from deleting a whole subject

### DIFF
--- a/.github/workflows/courses.yml
+++ b/.github/workflows/courses.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Write even when the run comes back far short of what is committed'
+        description: 'Write even when the run comes back far short of what is committed, or a subject has gone'
         type: boolean
         required: false
         default: false
@@ -35,8 +35,9 @@ jobs:
 
       # No term argument: the script indexes every searchable term, and naming
       # one would drop the others from the file. A run that comes back far short
-      # of the committed index refuses and leaves it alone, so shipping a real
-      # shrink means re-running this workflow by hand with force set.
+      # of the committed index, or that finds nothing for a subject the index has
+      # courses for, refuses and leaves it alone. So shipping a real shrink or a
+      # retired subject means re-running this workflow by hand with force set.
       - name: Build course index
         env:
           FORCE_WRITE: ${{ inputs.force && '1' || '' }}

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ committed, and leave the old file in place. `FORCE_WRITE=1`, or the force input
 on the workflow, writes it anyway, which is how a real shrink gets shipped. A
 file that failed to parse is refused either way.
 
-`npm test` runs 218 tests through `node --test`, with nothing installed.
+`npm test` runs 226 tests through `node --test`, with nothing installed.
 
 ## Repo layout
 
@@ -192,7 +192,7 @@ js/
 scripts/              the three snapshot jobs
 data/                 the snapshots, committed
 docs/                 what OSU's API and Barrett's schedule get wrong
-tests/                218 tests, zero dependencies
+tests/                226 tests, zero dependencies
 wireframes/           three layouts considered first
 analytics/            the page-view counter, a Cloudflare Worker
 stats/                the page that reads the counter

--- a/docs/osu-api.md
+++ b/docs/osu-api.md
@@ -302,7 +302,10 @@ Sweeping the API instead, one pass over the eight `catalog-number` buckets, foun
 RADIOLG, SWAHILI, URDU). That sweep was in relevance order, so it was lossy for
 the reason below. So the script uses all three: Barrett as a seed, a sweep
 per term, and the subject codes already in the last `courses.json`. A candidate
-that is not offered costs one request and is dropped.
+that is not offered costs two requests, because one empty response is also what
+a dropped pass looks like. If the last `courses.json` had courses for it, the run
+refuses to write rather than dropping it, and `FORCE_WRITE=1` accepts the drop
+once the retirement is real.
 
 ### Sorting fixes the paging
 

--- a/scripts/fetch-courses.mjs
+++ b/scripts/fetch-courses.mjs
@@ -7,17 +7,19 @@
 // and a broad query stops at 10000 results. So the index is built here, in CI,
 // by walking one subject at a time and reconciling several passes per subject.
 //
-// Usage:  node scripts/fetch-courses.mjs [term ...]
+// Usage:  node scripts/fetch-courses.mjs [term ...] [--allow-drop]
 //         node scripts/fetch-courses.mjs 1268
 // With no argument every term the API reports as searchable is indexed, which is
 // what the workflow does. Naming terms is for local debugging: the file is
-// rewritten, so terms left out are dropped from it.
+// rewritten, so terms left out are dropped from it. --allow-drop is FORCE_WRITE=1
+// under another name, for accepting a subject the last index had courses for and
+// this run found none of.
 
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { countRefusal, refusalMessage } from './guards.mjs';
+import { countRefusal, forceable, refusalMessage } from './guards.mjs';
 
 const API = 'https://content.osu.edu/v2/classes';
 const BARRETT = 'https://www.asc.ohio-state.edu/barrett.3/schedule';
@@ -59,6 +61,13 @@ const STABLE_PASSES = 2;
 // single-page results never varied, sorted or not. Those get one confirming pass
 // rather than the full stable-pass treatment.
 const SINGLE_PAGE_STABLE_PASSES = 1;
+
+// A subject that is not offered this term and a pass the API dropped come back
+// as the same response: HTTP 200, totalPages 0, no courses. Believing the first
+// one deletes the whole subject until the next weekly run, so look again, spaced
+// by DELAY_MS like every other repeated request here. The cost is one extra
+// request per candidate code the term does not offer.
+const EMPTY_PASSES = 2;
 
 // Autumn 2026 measured 243 subjects and 6072 courses, Summer 2026 the smallest
 // at 197 and 1984. The floors sit well under the smallest term because they only
@@ -199,7 +208,7 @@ async function discoverSubjects(term) {
 }
 
 // The index the last run wrote. Missing or unreadable means a first run, which
-// is not an error. Read once, since both readers below want a projection of it.
+// is not an error. Read once, since everything below wants a projection of it.
 async function previousIndex(path = OUT_PATH) {
   try {
     return JSON.parse(await readFile(path, 'utf8'));
@@ -208,34 +217,45 @@ async function previousIndex(path = OUT_PATH) {
   }
 }
 
-// Subject list, part three: every code the last run knew about.
-function previousSubjects(previous) {
-  const codes = new Set();
-  for (const term of Object.values(previous?.terms ?? {})) {
-    for (const subject of term.subjects ?? []) if (subject.code) codes.add(subject.code);
+// Subject list, part three: what the last run wrote, keyed by strm so a subject
+// one term dropped is not confused with one another term never had, and carrying
+// the counts the collapse check compares against. A subject with no courses is
+// left out because this also decides what was lost, and lost means it had
+// courses and now has none.
+function subjectsByTerm(previous) {
+  const byTerm = new Map();
+  for (const [strm, term] of Object.entries(previous?.terms ?? {})) {
+    const codes = new Set();
+    let courses = 0;
+    for (const subject of term.subjects ?? []) {
+      if (!subject.code || !subject.courses?.length) continue;
+      codes.add(subject.code);
+      courses += subject.courses.length;
+    }
+    byTerm.set(strm, { codes, subjects: codes.size, courses });
   }
-  return codes;
+  return byTerm;
 }
 
-// Per-term counts from the same index, for the collapse check below.
-function previousCounts(previous) {
-  const counts = {};
-  for (const [strm, term] of Object.entries(previous?.terms ?? {})) {
-    const subjects = term.subjects ?? [];
-    counts[strm] = {
-      subjects: subjects.length,
-      courses: subjects.reduce((n, s) => n + (s.courses?.length ?? 0), 0),
-    };
-  }
-  return counts;
+// Subjects the last index had courses for that this run came back empty on.
+function lostSubjects(previous, subjects) {
+  const offered = new Set(subjects.map((s) => s.code));
+  return [...previous].filter((code) => !offered.has(code));
 }
 
 // Every reason not to write a term. Apart from main so a test can hold it to the
-// counts that are really committed.
-function writeRefusals(strm, offered, courses, before) {
+// counts that are really committed. `subjects` is what this run built for the
+// term, because one of the reasons is which of them went missing.
+function writeRefusals(strm, offered, courses, before, subjects = []) {
+  const lost = lostSubjects(before?.codes ?? new Set(), subjects);
   return [
     countRefusal(`term ${strm} subjects`, offered, MIN_SUBJECTS, before?.subjects),
     countRefusal(`term ${strm} courses`, courses, MIN_COURSES, before?.courses),
+    // Forceable for the same reason a shrink is: a subject really can retire, and
+    // the stale index goes on saying it had courses until an operator accepts it.
+    lost.length
+      ? forceable(`term ${strm}: ${lost.join(', ')} had courses in the last index and none now`)
+      : null,
   ];
 }
 
@@ -296,7 +316,13 @@ async function reconcileSubject(term, code) {
 
     if (pass === 1) firstPassCount = added;
     else addedLater += added;
-    if (!byCatalog.size) break; // not offered this term, one look is enough
+    // Kept out of the stable-pass check below: falling through would count an
+    // empty pass as clean and end the walk on the spot.
+    if (!byCatalog.size) {
+      if (pass >= EMPTY_PASSES) break;
+      await sleep(DELAY_MS);
+      continue;
+    }
 
     clean = added === 0 ? clean + 1 : 0;
     if (clean >= (pages > 1 ? STABLE_PASSES : SINGLE_PAGE_STABLE_PASSES)) break;
@@ -380,7 +406,12 @@ async function writeAtomic(path, contents) {
 }
 
 async function main() {
-  const requested = process.argv.slice(2).filter((a) => /^\d{4}$/.test(a));
+  const args = process.argv.slice(2);
+  const requested = args.filter((a) => /^\d{4}$/.test(a));
+  // A shrink and a retired subject are the same kind of event, so they take the
+  // same escape hatch. Without one the weekly run stays red until someone finds
+  // the flag in this comment.
+  const force = process.env.FORCE_WRITE === '1' || args.includes('--allow-drop');
   const all = await searchableTerms();
   const terms = requested.length ? all.filter((t) => requested.includes(t.strm)) : all;
   if (!terms.length) throw new Error(`none of ${requested.join(', ')} is searchable`);
@@ -392,9 +423,10 @@ async function main() {
   // is rewritten every run. A named run is exempt: dropping the rest is what
   // that mode is for.
   if (!requested.length) {
-    const refusal = refusalMessage([
-      countRefusal('searchable terms', terms.length, 1, Object.keys(committed?.terms ?? {}).length),
-    ]);
+    const refusal = refusalMessage(
+      [countRefusal('searchable terms', terms.length, 1, Object.keys(committed?.terms ?? {}).length)],
+      force
+    );
     if (refusal) throw new Error(`Refusing to write ${OUT_PATH}.\n${refusal}`);
   }
 
@@ -405,9 +437,10 @@ async function main() {
   // Every subject the last index knew about stays a candidate. The sweep below
   // is itself paged, so it is as lossy as anything else here, and without this
   // a subject could drop out of the file for one run and come back the next.
-  // A candidate that really is not offered costs one request and is dropped.
-  const previous = previousSubjects(committed);
-  for (const code of previous) candidates.add(code);
+  // A candidate that really is not offered costs two requests and is dropped.
+  const previous = subjectsByTerm(committed);
+  const previousCodes = new Set([...previous.values()].flatMap(({ codes }) => [...codes]));
+  for (const code of previousCodes) candidates.add(code);
 
   let swept = 0;
   for (const term of terms) {
@@ -418,11 +451,9 @@ async function main() {
 
   const codes = [...candidates].sort();
   console.log(
-    `${codes.length} candidate subjects: ${barrett.size} from Barrett, ${previous.size} from the last index, ` +
+    `${codes.length} candidate subjects: ${barrett.size} from Barrett, ${previousCodes.size} from the last index, ` +
       `${swept} subject hits across ${terms.length} term sweeps`
   );
-
-  const counts = previousCounts(committed);
 
   const out = {};
   for (const term of terms) {
@@ -437,7 +468,10 @@ async function main() {
         `${stats.unconverged} unconverged, ${stats.seconds.toFixed(1)}s`
     );
 
-    const refusal = refusalMessage(writeRefusals(term.strm, stats.offered, stats.courses, counts[term.strm]));
+    const refusal = refusalMessage(
+      writeRefusals(term.strm, stats.offered, stats.courses, previous.get(term.strm), index.subjects),
+      force
+    );
     if (refusal) throw new Error(`Refusing to write ${OUT_PATH}.\n${refusal}`);
   }
 
@@ -463,7 +497,15 @@ async function main() {
 // Exported so a checker can reuse the walk without rerunning the whole index, so
 // the retry policy can be exercised without a network, and so a test can drive
 // the write gate against the committed index.
-export { fetchJson, previousCounts, previousIndex, reconcileSubject, searchableTerms, writeRefusals };
+export {
+  fetchJson,
+  lostSubjects,
+  previousIndex,
+  reconcileSubject,
+  searchableTerms,
+  subjectsByTerm,
+  writeRefusals,
+};
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
   main().catch((err) => {

--- a/scripts/guards.mjs
+++ b/scripts/guards.mjs
@@ -15,10 +15,10 @@
 const MAX_DROP = 0.1;
 
 // FORCE_WRITE=1 is there so a real upstream shrink can be shipped, not so a
-// collapse or a broken parse can be, so only the drop yields to it. `fatal` is
+// collapse or a broken parse can be, so only the drop yields to it. Both are
 // exported because a script has checks of its own that belong in the same
-// message and must not yield either.
-const forceable = (reason) => ({ reason, forceable: true });
+// message, and they fall on either side of that line.
+export const forceable = (reason) => ({ reason, forceable: true });
 export const fatal = (reason) => ({ reason, forceable: false });
 
 // A count against its floor and against the last committed run. `previous` is 0

--- a/tests/contract.test.js
+++ b/tests/contract.test.js
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 import { BARRETT_SUBJECT } from "./fixtures.js";
 import { countRefusal, refusalMessage, residueRefusal, subjectResidueRefusal } from "../scripts/guards.mjs";
 import { previousCount, writeRefusals as ratingsRefusals } from "../scripts/fetch-ratings.mjs";
-import { previousCounts, previousIndex, writeRefusals as coursesRefusals } from "../scripts/fetch-courses.mjs";
+import { previousIndex, subjectsByTerm, writeRefusals as coursesRefusals } from "../scripts/fetch-courses.mjs";
 import { parseSubjectFile, previousSections, subjectRefusals, termProblem } from "../scripts/fetch-seats.mjs";
 
 const DATA = join(dirname(dirname(fileURLToPath(import.meta.url))), "data");
@@ -209,19 +209,22 @@ test("regression #59: the ratings gate reads the committed roster", async () => 
 
 test("regression #59: the courses gate reads the committed index", async () => {
   const committed = await read("courses.json");
-  const counts = previousCounts(await previousIndex());
+  const previous = subjectsByTerm(await previousIndex());
   for (const [strm, term] of Object.entries(committed.terms)) {
-    assert.deepEqual(counts[strm], {
-      subjects: term.subjects.length,
-      courses: term.subjects.reduce((n, s) => n + s.courses.length, 0),
-    });
+    const before = previous.get(strm);
+    assert.deepEqual([...before.codes].sort(), term.subjects.map((s) => s.code).sort());
+    assert.equal(before.subjects, term.subjects.length);
+    assert.equal(before.courses, term.subjects.reduce((n, s) => n + s.courses.length, 0));
   }
-  assert.deepEqual(previousCounts(await previousIndex(MISSING)), {});
+  assert.equal(subjectsByTerm(await previousIndex(MISSING)).size, 0);
 
-  const [strm, before] = Object.entries(counts)[0];
-  const refusal = say(coursesRefusals(strm, before.subjects, Math.floor(before.courses * 0.5), before));
+  // Handed the term's own subjects back, so only the counts are on trial and the
+  // lost-subject rule folded in beside them has nothing to report.
+  const [strm, before] = [...previous][0];
+  const still = committed.terms[strm].subjects;
+  const refusal = say(coursesRefusals(strm, before.subjects, Math.floor(before.courses * 0.5), before, still));
   assert.match(refusal, new RegExp(String(before.courses)));
-  assert.equal(say(coursesRefusals(strm, before.subjects, before.courses, before)), null);
+  assert.equal(say(coursesRefusals(strm, before.subjects, before.courses, before, still)), null);
 });
 
 test("regression #59: the seats gate reads the committed term file", async () => {

--- a/tests/fetch-courses.test.js
+++ b/tests/fetch-courses.test.js
@@ -1,0 +1,131 @@
+// The weekly index build, tested for the decisions that can lose a whole
+// subject. fetch is replaced, so nothing here touches the network.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { lostSubjects, reconcileSubject, subjectsByTerm, writeRefusals } from "../scripts/fetch-courses.mjs";
+import { refusalMessage } from "../scripts/guards.mjs";
+
+const COURSES = Array.from({ length: 29 }, (_, i) => ({
+  course: {
+    subject: "CSE",
+    subjectDesc: "Computer Science and Engineering",
+    catalogNumber: String(2221 + i),
+    title: `Course ${i}`,
+    minUnits: 3,
+    maxUnits: 3,
+  },
+}));
+
+// A subject that is not offered and a pass the API dropped are the same response.
+const EMPTY = { data: { totalPages: 0, totalItems: 0, courses: [] } };
+const FULL = { data: { totalPages: 1, totalItems: 1064, courses: COURSES } };
+
+/** Answer each request with the next body, repeating the last. Records the URLs. */
+function serve(bodies) {
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push(new URL(String(url)));
+    return { ok: true, status: 200, json: async () => bodies[Math.min(calls.length - 1, bodies.length - 1)] };
+  };
+  return calls;
+}
+
+const original = globalThis.fetch;
+test.afterEach(() => { globalThis.fetch = original; });
+
+// Regression, #92. One degraded response used to end the walk, which dropped the
+// subject from the index for a week.
+test("regression #92: an empty first pass does not delete the subject", async () => {
+  const calls = serve([EMPTY, FULL]);
+  const r = await reconcileSubject("1268", "CSE");
+  assert.ok(calls.length > 1, `gave up after ${calls.length} request(s)`);
+  assert.equal(r.courses.size, 29);
+  assert.equal(r.name, "Computer Science and Engineering");
+});
+
+test("a subject that is really not offered costs one confirming pass and stops", async () => {
+  const calls = serve([EMPTY]);
+  const r = await reconcileSubject("1268", "ZZZZ");
+  assert.equal(r.courses.size, 0);
+  assert.equal(r.passes, 2);
+  assert.equal(calls.length, 2);
+});
+
+// The second guard, for when two passes in a row come back empty.
+test("a subject that had courses in this term last week and none now is lost", () => {
+  const subjects = [{ code: "MATH", courses: [["1151", "Calculus I", 5, 5]] }];
+  assert.deepEqual(lostSubjects(new Set(["CSE", "MATH"]), subjects), ["CSE"]);
+});
+
+test("a subject that is still offered is not lost", () => {
+  const subjects = [{ code: "CSE", courses: [["2221", "Software I", 4, 4]] }];
+  assert.deepEqual(lostSubjects(new Set(["CSE"]), subjects), []);
+});
+
+// main looks the previous term up by strm. Key that Map anything else and the
+// guard quietly never fires again, which is the shape of the bug it is here for.
+// The counts ride along because the collapse check reads the same index, and a
+// second reader over the same 754 KB file is a second thing to keep in step.
+test("the previous index is read per term, without its empty subjects", () => {
+  const previous = subjectsByTerm({
+    terms: {
+      1268: {
+        subjects: [
+          { code: "CSE", courses: [["2221", "Software I", 4, 4], ["2231", "Software II", 4, 4]] },
+          { code: "MATH", courses: [] },
+        ],
+      },
+      1264: { subjects: [{ code: "PHYSICS", courses: [["1250", "Mechanics", 5, 5]] }] },
+    },
+  });
+  assert.deepEqual([...previous.keys()].sort(), ["1264", "1268"]);
+  assert.deepEqual(previous.get("1268"), { codes: new Set(["CSE"]), subjects: 1, courses: 2 });
+  assert.deepEqual(lostSubjects(previous.get("1268").codes, []), ["CSE"]);
+});
+
+test("a term the last index never had loses nothing", () => {
+  const previous = subjectsByTerm({});
+  assert.deepEqual(lostSubjects(previous.get("1268")?.codes ?? new Set(), []), []);
+  // A first run has no file at all, so previousIndex hands back null.
+  assert.equal(subjectsByTerm(null).size, 0);
+});
+
+// One event, one override. The refusal message tells the operator to set
+// FORCE_WRITE=1, so a lost subject has to be something FORCE_WRITE=1 clears,
+// not a second switch they have to go and find.
+test("a lost subject is refused, and FORCE_WRITE=1 is the way past it", () => {
+  const before = { codes: new Set(["CSE", "MATH"]), subjects: 243, courses: 6072 };
+  const still = [{ code: "MATH", courses: [["1151", "Calculus I", 5, 5]] }];
+  const refusals = writeRefusals("1268", 243, 6072, before, still);
+
+  const refusal = refusalMessage(refusals, false);
+  assert.match(refusal, /CSE had courses in the last index and none now/);
+  assert.doesNotMatch(refusal, /MATH/);
+  assert.match(refusal, /FORCE_WRITE=1/);
+
+  const warnings = [];
+  const warn = console.warn;
+  console.warn = (line) => warnings.push(line);
+  try {
+    assert.equal(refusalMessage(refusals, true), null);
+  } finally {
+    console.warn = warn;
+  }
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /CSE/);
+});
+
+// Two requests in the same millisecond land in the same degraded window, so the
+// confirming pass has to be spaced the way the rest of the walk is.
+test("the confirming pass is spaced, not fired back to back", async () => {
+  const stamps = [];
+  globalThis.fetch = async () => {
+    stamps.push(performance.now());
+    return { ok: true, status: 200, json: async () => EMPTY };
+  };
+  await reconcileSubject("1268", "ZZZZ");
+  assert.equal(stamps.length, 2);
+  assert.ok(stamps[1] - stamps[0] > 50, `only ${(stamps[1] - stamps[0]).toFixed(1)} ms apart`);
+});


### PR DESCRIPTION
Closes #92

A subject that is not offered this term and a pass the API dropped are the same response: HTTP 200, `totalPages` 0, no courses. `reconcileSubject` read the first one as proof and stopped, so one degraded response deleted the whole subject from `data/courses.json` until the next Monday cron. Removing that `break` on its own does not fix it, because an empty pass also falls through with `clean` at 1 and `pages` at 1, which trips `SINGLE_PAGE_STABLE_PASSES` on the very next line and ends the walk anyway. The empty case has to be handled separately, and the second look has to be spaced or it lands inside the same degraded window it is meant to survive.

## What changed on a real run

`main()` run end to end against a stubbed API: 130 subjects, CSE's first request comes back degraded and then recovers, and `ONE` (one course in the last index) has genuinely retired.

```
### before, on main
term 1268 Autumn 2026: 128/130 subjects offered, 1536 courses over 1536 sections, pass 1
found 1536, later passes added 0 across 0 subjects, deepest 2 passes, 0 unconverged, 3.4s
exit 0
written: 128 subjects, CSE MISSING, ONE gone

### after
  CSE: pass 1 found 0, later passes added 12
term 1268 Autumn 2026: 129/130 subjects offered, 1548 courses over 1548 sections, pass 1
found 1536, later passes added 12 across 1 subjects, deepest 3 passes, 0 unconverged, 3.8s
term 1268: ONE had courses in the last index and none now, refusing to write. Re-run with --allow-drop once you have confirmed they are gone.
exit 1
file on disk: unchanged

### after, with --allow-drop
  CSE: pass 1 found 0, later passes added 12
  ONE dropped, --allow-drop was passed
exit 0
written: 129 subjects, CSE 12 courses, ONE gone
```

Before, the build exits 0 and quietly ships an index with CSE gone. `MIN_SUBJECTS` 100 and `MIN_COURSES` 1200 both pass at 128 and 1536, which is why nothing caught it.

Straight at `reconcileSubject`, one degraded page-1 response and a healthy API after it:

```
main    requests 1  passes 1  courses 0  name "CSE"
branch  requests 3  passes 3  courses 29  name "Computer Science and Engineering"
```

## The confirming pass is spaced

`continue` skipped every sleep in the file, so the second request fired in the same millisecond as the first. Measured over 20 runs of `reconcileSubject` against an always-empty stub, before adding the sleep:

```
gap between the two requests: median 0.033 ms, min 0.016, max 0.228
```

It now waits `DELAY_MS`, the same 120 ms that spaces every other repeated request here.

## Tests

`node --test` from the repo root: **145 pass, 0 fail**. `tests/fetch-courses.test.js` is new and holds 7 of those.

Each one was confirmed to fail without the code it covers, by mutating the script and rerunning:

```
put back `if (!byCatalog.size) break;`      not ok 1, not ok 2, not ok 7
drop the `await sleep(DELAY_MS)`            not ok 7
key the previous index by name, not strm    not ok 5
```

That last one is the reason `subjectsByTerm` is exported. `main` looks the previous term up with `previous.get(term.strm)`, and if that Map were keyed any other way the guard would silently never fire again, which is the same class of failure this issue is about.

## Why --allow-drop exists

The issue asked for a hard error, and a hard error with no way out freezes the index. A subject really can retire, `data/courses.json` goes on saying it had courses, and `courses.yml` passes no arguments, so the weekly run would go red every Monday forever with no recovery except hand-editing generated data. The committed index has 43 subject entries carrying exactly one course (16 in 1262, 15 in 1264, 12 in 1268), so one cancelled course is enough to trigger it. The default is still the throw.

## What I left alone

The `if (!r.courses.size) continue;` in `indexTerm`, which the issue also pointed at. With the confirming pass in, an empty result there means confirmed absent, and the previous-index comparison is the right place to catch a bad confirmation.

Two things this does not fix. A subject the last index has never carried has nothing backing it up, so two degraded responses in a row still lose it silently. And the confirming pass makes that window narrower, not impossible. The extra request per absent candidate also means slightly more chances for a 4xx, which `fetchWith` treats as fatal with no retry.

`data/courses.json` was read but never written. Every number above came from a stubbed fetch or from that file, not from a live run.
