### PR TITLE
Scroll the 1y stats chart inside its card instead of widening the page

### DIFF
--- a/css/stats.css
+++ b/css/stats.css
@@ -134,6 +134,7 @@ main[hidden]{ display: none; }
   border: 1px solid var(--rule);
   border-radius: var(--radius);
   padding: 1rem;
+  min-width: 0;
 }
 
 .card h2 {
@@ -144,13 +145,16 @@ main[hidden]{ display: none; }
 }
 
 /* Chart. Bars are a flex row so the whole thing stays responsive without
-   measuring anything in JS. */
+   measuring anything in JS. #75 measured a year of them at 1458px against a
+   1088px page, so the row scrolls and .card takes min-width: 0 to let it,
+   instead of the whole document going sideways. */
 .chart {
   display: flex;
   align-items: flex-end;
   gap: 2px;
   height: 9rem;
   padding-top: 0.25rem;
+  overflow-x: auto;
 }
 
 .bar {

--- a/js/stats.js
+++ b/js/stats.js
@@ -98,6 +98,10 @@ function render(data) {
   $('stamp').textContent = `Updated ${new Date(data.generated).toLocaleString()}. Counts can lag by up to two minutes.`;
   $('status').hidden = true;
   $('main').hidden = false;
+
+  // Long ranges scroll, and their oldest days are the empty ones, so open on
+  // the newest bars. After the unhide, or there is no width to scroll yet.
+  $('chart').scrollLeft = $('chart').scrollWidth;
 }
 
 async function load(days) {

--- a/stats/index.html
+++ b/stats/index.html
@@ -39,7 +39,7 @@
 
       <section class="card">
         <h2>Page views per day</h2>
-        <div class="chart" id="chart"></div>
+        <div class="chart" id="chart" tabindex="0" role="group" aria-label="Page views per day"></div>
         <div class="chart-axis"><span id="ax-from"></span><span id="ax-to"></span></div>
       </section>
 

--- a/tests/stats-css.test.js
+++ b/tests/stats-css.test.js
@@ -1,0 +1,29 @@
+// The stats chart is CSS only, so this reads the stylesheet rather than a
+// layout. The 1y range draws 365 bars whose 2px floor plus 2px gaps is 1458px,
+// wider than .page will ever be.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const css = readFileSync(new URL("../css/stats.css", import.meta.url), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "");
+
+/** Declarations of the rule whose selector list has `selector`, keyed by property. */
+function rule(selector) {
+  const block = css.split("}").find((b) => b.slice(0, b.indexOf("{"))
+    .split(",").map((s) => s.trim()).includes(selector));
+  assert.ok(block, `no ${selector} rule in css/stats.css`);
+  return Object.fromEntries(block.slice(block.indexOf("{") + 1)
+    .split(";")
+    .map((d) => [d.slice(0, d.indexOf(":")).trim(), d.slice(d.indexOf(":") + 1).trim()])
+    .filter(([prop, value]) => prop && value));
+}
+
+test("the chart scrolls its own bars instead of widening the card", () => {
+  const chart = rule(".chart");
+  assert.ok(["auto", "scroll"].includes(chart["overflow-x"] || chart.overflow),
+    ".chart must scroll horizontally or 365 bars push the page sideways");
+  assert.equal(parseFloat(rule(".card")["min-width"]), 0,
+    ".card is a grid item, so it only shrinks around the chart with min-width: 0");
+});


### PR DESCRIPTION
Closes #75

`.chart` is a flex row and `.bar` is `flex: 1 1 0` with `min-width: 2px`, so 365 bars plus 364 2px gaps have a hard floor of 1,458px. That should have overflowed the card, but the card is a grid item of `main` and a grid item's default `min-width` is `auto`, so the card refused to shrink and grew to 1,492px instead, dragging `.page` past its own 68rem and carrying the range nav off the right edge of the document. `min-width: 0` lets the card shrink and `overflow-x: auto` keeps the extra width inside the chart.

## Before and after

Real page, real stylesheet, real module, in headless Chrome, laid out in fixed-width iframes because the outer `--window-size` is ignored for layout. The analytics fetch is stubbed with traffic on the last two days only, which is what the live 1y range looks like right now. All numbers below are from that run, 365 bars:

```
                          1440px viewport       360px viewport
                          before     after      before     after
document scrollWidth      1696       1440       1508       360
page scrolls sideways     yes        no         yes        no
card width                1492       1032       1492       328
chart client width        1458        998       1458       294
chart scroll width        1458       1458       1458      1458
chart scrollLeft on open     0        460          0      1164
#ranges right edge        1696       1236       1508       200
first non-zero bar at x   1673       1213       1485       321
```

On a 360px phone both the range buttons and the only two days with traffic used to sit past x=1,485, so tapping 1y stranded you. Now nothing leaves the viewport and the year scrolls inside its own card.

90d was over the edge too, just less visibly: document scrollWidth 408 against a 360px viewport before, 360 after. 30d, the default, is untouched at both widths. No scroll, bars still 7.86px at 360px and 31.33px at 1440px, chart still the full 144px tall.

## The chart also has to open on the data

With the page no longer scrolling sideways, the chart opens at `scrollLeft` 0, which is the oldest end of the year and the empty one. That is the "sees a blank chart" half of the issue and the CSS does not fix it, so `render()` now pins the chart to the newest bars once it is on screen. It goes after the unhide because a hidden chart has no `scrollWidth` to move to. That is what puts the first non-zero bar at 1213 and 321 in the table. 7d and 30d do not scroll, so they clamp to 0 and nothing changes.

A scroll region also needs a keyboard route in, so `#chart` gets `tabindex="0"`, `role="group"` and a label, the same treatment `.cal-scroll` already has on the week grid. Without it the scrolled part of the year is unreachable without a mouse in Firefox and Safari, where page scroll used to reach it.

## Tests

139 pass, measured 138 with the new file removed. It reads the stylesheet rather than laying anything out, since there is nothing here to render with. Confirmed red on main's stylesheet:

```
not ok 1 - the chart scrolls its own bars instead of widening the card
  error: '.chart must scroll horizontally or 365 bars push the page sideways'
```

Same failure with either declaration removed on its own. It stays green through `overflow: auto` in place of `overflow-x: auto`, `min-width: 0px` in place of `0`, and `.card, .panel {`, so a rewrite that keeps the behaviour does not turn it red for nothing.

## Left alone deliberately

On platforms that draw classic scrollbars the new horizontal scrollbar eats 15px out of the chart's 9rem: client height 144 to 129, tallest bar 140.00px to 125.00px, on any range that scrolls. 30d keeps the full height, so the same peak draws slightly shorter on 1y than on 30d. `scrollbar-gutter: stable` would even that out but reserves the gutter in every range including the default, so I left it.

The `.chart-axis` labels still name the ends of the range, not the ends of what is scrolled into view. Recomputing them on scroll is a bigger change than this issue needs.
