### PR TITLE
Retry the ratings and course loads instead of caching the failure

### DIFF
--- a/js/courses.js
+++ b/js/courses.js
@@ -15,7 +15,11 @@ export async function loadCourses(url = "data/courses.json") {
     if (!response.ok) throw new Error(`courses ${response.status}`);
     index = await response.json();
     return index;
-  })();
+  })().catch((error) => {
+    // A cached rejection would pin the failure for the life of the tab.
+    loading = null;
+    throw error;
+  });
 
   return loading;
 }

--- a/js/ratings.js
+++ b/js/ratings.js
@@ -77,7 +77,11 @@ export async function loadRatings(baseUrl = "data/ratings.json") {
     }
     index = { byKey, bySurname };
     return index;
-  })();
+  })().catch((error) => {
+    // A cached rejection would pin the failure for the life of the tab.
+    loading = null;
+    throw error;
+  });
 
   return loading;
 }

--- a/tests/courses.test.js
+++ b/tests/courses.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { stubFetch } from "./helpers.js";
+import { stubFetch, stubFetchFailingOnce } from "./helpers.js";
 
 const INDEX = {
   built: "2026-08-18",
@@ -34,6 +34,21 @@ test("isLoaded flips once the index is in", async () => {
   const fresh = await import("../js/courses.js?unloaded");
   assert.equal(fresh.isLoaded(), false);
   assert.equal(courses.isLoaded(), true);
+});
+
+test("regression #79: a failed loadCourses is not cached, so the next call retries", async () => {
+  const fresh = await import("../js/courses.js?blip");
+  const restore = stubFetchFailingOnce({ "courses.json": INDEX });
+  try {
+    await assert.rejects(() => fresh.loadCourses("courses.json"), TypeError);
+    assert.equal(fresh.isLoaded(), false);
+    await fresh.loadCourses("courses.json");
+    assert.equal(fresh.isLoaded(), true);
+    // Recovering must not cost the caching: the stub throws on any other route.
+    await fresh.loadCourses("never-fetched.json");
+  } finally {
+    restore();
+  }
 });
 
 test("subjectsFor sorts by code and is scoped to one term", () => {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -19,6 +19,22 @@ export function stubFetch(routes) {
 }
 
 /**
+ * Like stubFetch, but the first call rejects the way a dropped connection
+ * does. For checking that a loader retries instead of caching the failure.
+ */
+export function stubFetchFailingOnce(routes) {
+  const restore = stubFetch(routes);
+  const serving = globalThis.fetch;
+  let failed = false;
+  globalThis.fetch = async (url) => {
+    if (failed) return serving(url);
+    failed = true;
+    throw new TypeError("Failed to fetch");
+  };
+  return restore;
+}
+
+/**
  * Load a snapshot into a module instance.
  *
  * `suffix` picks the instance. Both modules cache after the first load, so a

--- a/tests/ratings.test.js
+++ b/tests/ratings.test.js
@@ -2,7 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { nameKey, surnameKey, searchUrl, profileUrl } from "../js/ratings.js";
-import { withRatings } from "./helpers.js";
+import { withRatings, stubFetchFailingOnce } from "./helpers.js";
+import { RATINGS } from "./fixtures.js";
 
 const ratings = await withRatings();
 const { ratingFor } = ratings;
@@ -91,6 +92,20 @@ test("loadRatings caches, so a second call does not fetch again", async () => {
   const again = await ratings.loadRatings("never-fetched.json");
   assert.equal(again.byKey.get("diana kline").length, 1);
   assert.equal(again.bySurname.get("reed").length, 2);
+});
+
+test("regression #79: a failed loadRatings is not cached, so the next call retries", async () => {
+  const fresh = await import("../js/ratings.js?blip");
+  const restore = stubFetchFailingOnce({ "ratings.json": RATINGS });
+  try {
+    await assert.rejects(() => fresh.loadRatings("ratings.json"), TypeError);
+    const again = await fresh.loadRatings("ratings.json");
+    assert.equal(again.byKey.get("diana kline").length, 1);
+    // Recovering must not cost the caching: the stub throws on any other route.
+    await fresh.loadRatings("never-fetched.json");
+  } finally {
+    restore();
+  }
 });
 
 test("the RateMyProfessors links point at Ohio State", () => {


### PR DESCRIPTION
Closes #79

`loadRatings` and `loadCourses` kept the in-flight promise in a module-level `loading` and never cleared it when the fetch rejected. A rejected promise stayed there for the life of the tab, so every later caller hit `if (loading) return loading` and got the first failure replayed without a second request ever going out. `index` is only assigned on success, so the `if (index)` fast path never rescued it either. `js/seats.js:48` already clears its cached promise in a `.catch`, which is why seats recovered from the same blip and the other two did not. Both loaders now do the same thing.

## One dropped connection, then the network is fine

Three loads of each snapshot, first fetch throwing, everything after it served normally, run against the loaders from `main` and from this branch:

```
main    ratings.json hits 1  rating chip none   courses.json hits 1  subjects 0  isLoaded false
branch  ratings.json hits 2  rating chip 4.6    courses.json hits 2  subjects 1  isLoaded true
```

On `main` the second and third calls never reach the network, so the instructor stays unrated and the subject picker stays empty for the rest of the session. On this branch the second call refetches and both recover.

## What it costs, because the issue understates this

The issue says the only behaviour that changes is that the next call tries again. That holds for the focus listener at `js/app.js:513`. It does not hold for the `input` listener at `js/app.js:517`, which calls `ensureCourses()` on every keystroke. I drove the real `loadCourses` through a verbatim copy of `ensureCourses` with `courses.json` permanently returning 404, typing a 16 character subject at 120ms per keystroke:

```
                        fetches    hint sat on "Loading the course list..."
main     60ms failure         1                                      68ms
branch   60ms failure        16                                    1118ms
main    500ms failure         1                                     520ms
branch  500ms failure         4                                    2049ms
```

With a fast failure the hint now visibly flips between "Loading the course list..." and "Could not load the course list." on nearly every keystroke, where before the loading state came and went too fast to paint.

The 500ms row is what decided me against adding a backoff. Overlapping callers still share one in-flight promise, because `loading` is only nulled inside the rejection handler and that runs after the fetch has settled. So 16 keystrokes cost 4 fetches, not 16, and the retry rate is bounded by how fast the failure comes back rather than by typing speed. There is no window where two requests are in flight at once.

Ratings pays the same trade on the search path at `js/app.js:363`. Five searches with `ratings.json` returning 404 cost 1 fetch on `main` and 5 here, each search waiting about 46ms for the failure instead of getting the cached rejection back instantly. A request that hangs instead of rejecting behaves identically on both versions, since the `.catch` never fires and every caller waits on the same pending promise.

## Tests

140 pass, up from 138. One test per loader, both driving the real module through a fetch that rejects once and then serves.

I confirmed they fail without the fix. In a copy outside the worktree, with only `js/ratings.js` and `js/courses.js` restored to `main`:

```
not ok 30 - regression \#79: a failed loadCourses is not cached, so the next call retries
not ok 115 - regression \#79: a failed loadRatings is not cached, so the next call retries
# tests 140
# pass 138
# fail 2
```

Both tests also call the loader once more with `never-fetched.json` while the stub is still installed, so recovering does not quietly cost the caching. I checked that assertion bites rather than passing for free: on a cached instance the call resolves with no fetch, on an uncached one the stub throws `unexpected fetch: never-fetched.json`.

## Not done on purpose

No backoff and no failure counter. The retry is the point of the issue, and the obvious guard, a sticky "courses failed" flag in `js/app.js`, would put the same cached-failure bug back one layer up.

The DevTools request-blocking walkthrough in the issue was not rerun in a browser. The whole mechanism is module-level promise state, and the tests drive the real loaders directly, so I did not think a browser probe would tell me anything the node tests do not.

Rebased onto `main` at 394e499.
