### PR TITLE
Retry a 429 instead of treating it as fatal

### DIFF
--- a/scripts/fetch-courses.mjs
+++ b/scripts/fetch-courses.mjs
@@ -26,6 +26,11 @@ const OUT_PATH = join(ROOT, 'data', 'courses.json');
 const CONCURRENCY = 5;
 const DELAY_MS = 120;
 const RETRIES = 3;
+// 408 and 425 ask for the request again and a 429 clears on its own. The rest
+// of 4xx will not fix itself. A 5xx or a timeout might.
+const RETRY_STATUS = new Set([408, 425, 429]);
+// Retry-After can name an hour, longer than the run will spend on one request.
+const MAX_RETRY_AFTER_MS = 30000;
 const USER_AGENT =
   'Finder-courses/1.0 (+https://github.com/EnesYilmazcode/Finder) weekly course index';
 
@@ -61,23 +66,46 @@ const MIN_COURSES = 1200;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Retry-After is either a count of seconds or an HTTP date. Anything else, or a
+// date already past, leaves the ordinary backoff in charge.
+function retryAfterMs(header) {
+  if (!header) return 0;
+  const seconds = /^\s*\d+\s*$/.test(header) ? Number(header) : NaN;
+  const ms = Number.isFinite(seconds) ? seconds * 1000 : Date.parse(header) - Date.now();
+  if (!(ms > 0)) return 0;
+  return Math.min(ms, MAX_RETRY_AFTER_MS);
+}
+
 async function fetchWith(url, parse, { allow404 = false } = {}) {
   let lastError;
+  let wait = 0;
+  let retriedForbidden = false;
   for (let attempt = 0; attempt <= RETRIES; attempt++) {
-    if (attempt > 0) await sleep(500 * 2 ** (attempt - 1));
+    if (attempt > 0) await sleep(wait || 500 * 2 ** (attempt - 1));
+    wait = 0;
     try {
       const res = await fetch(url, {
         headers: { 'user-agent': USER_AGENT, accept: 'application/json,text/html' },
         signal: AbortSignal.timeout(30000),
       });
       if (res.status === 404 && allow404) return null;
-      // A 4xx will not fix itself, so stop. A 5xx or a timeout might.
       if (res.status >= 400 && res.status < 500) {
-        const err = new Error(`${res.status} ${res.statusText}`);
-        err.fatal = true;
-        throw err;
+        let retryable = RETRY_STATUS.has(res.status);
+        // A 403 is often a WAF being twitchy, so give it one more go.
+        if (res.status === 403 && !retriedForbidden) {
+          retriedForbidden = true;
+          retryable = true;
+        }
+        if (!retryable) {
+          const err = new Error(`${res.status} ${res.statusText}`);
+          err.fatal = true;
+          throw err;
+        }
       }
       if (!res.ok) {
+        // A response with no headers still has to be reported by status rather
+        // than throw over the Retry-After that is not there.
+        wait = retryAfterMs(res.headers?.get?.('retry-after'));
         lastError = new Error(`${res.status} ${res.statusText}`);
         continue;
       }
@@ -397,8 +425,9 @@ async function main() {
   console.log(`wrote ${OUT_PATH} (${bytes} bytes, ${(bytes / 1024).toFixed(1)} KiB)`);
 }
 
-// Exported so a checker can reuse the walk without rerunning the whole index.
-export { reconcileSubject, searchableTerms };
+// Exported so a checker can reuse the walk without rerunning the whole index,
+// and so the retry policy can be exercised without a network.
+export { fetchJson, reconcileSubject, searchableTerms };
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
   main().catch((err) => {

--- a/scripts/fetch-seats.mjs
+++ b/scripts/fetch-seats.mjs
@@ -34,6 +34,11 @@ const TERM_FILE_RE = /^seats-\d{4}\.json$/;
 const CONCURRENCY = 5;
 const DELAY_MS = 120;
 const RETRIES = 3;
+// 408 and 425 ask for the request again and a 429 clears on its own. The rest
+// of 4xx will not fix itself. A 5xx or a timeout might.
+const RETRY_STATUS = new Set([408, 425, 429]);
+// Retry-After can name an hour, longer than the run will spend on one request.
+const MAX_RETRY_AFTER_MS = 30000;
 const USER_AGENT =
   'Finder-seats/1.0 (+https://github.com/EnesYilmazcode/Finder) daily snapshot';
 
@@ -74,23 +79,46 @@ const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', '
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Retry-After is either a count of seconds or an HTTP date. Anything else, or a
+// date already past, leaves the ordinary backoff in charge.
+function retryAfterMs(header) {
+  if (!header) return 0;
+  const seconds = /^\s*\d+\s*$/.test(header) ? Number(header) : NaN;
+  const ms = Number.isFinite(seconds) ? seconds * 1000 : Date.parse(header) - Date.now();
+  if (!(ms > 0)) return 0;
+  return Math.min(ms, MAX_RETRY_AFTER_MS);
+}
+
 async function fetchText(url, { allow404 = false, accept = 'text/plain,text/html' } = {}) {
   let lastError;
+  let wait = 0;
+  let retriedForbidden = false;
   for (let attempt = 0; attempt <= RETRIES; attempt++) {
-    if (attempt > 0) await sleep(500 * 2 ** (attempt - 1));
+    if (attempt > 0) await sleep(wait || 500 * 2 ** (attempt - 1));
+    wait = 0;
     try {
       const res = await fetch(url, {
         headers: { 'user-agent': USER_AGENT, accept },
         signal: AbortSignal.timeout(30000),
       });
       if (res.status === 404 && allow404) return null;
-      // A 4xx will not fix itself, so stop. A 5xx or a timeout might.
       if (res.status >= 400 && res.status < 500) {
-        const err = new Error(`${res.status} ${res.statusText}`);
-        err.fatal = true;
-        throw err;
+        let retryable = RETRY_STATUS.has(res.status);
+        // A 403 is often a WAF being twitchy, so give it one more go.
+        if (res.status === 403 && !retriedForbidden) {
+          retriedForbidden = true;
+          retryable = true;
+        }
+        if (!retryable) {
+          const err = new Error(`${res.status} ${res.statusText}`);
+          err.fatal = true;
+          throw err;
+        }
       }
       if (!res.ok) {
+        // A response with no headers still has to be reported by status rather
+        // than throw over the Retry-After that is not there.
+        wait = retryAfterMs(res.headers?.get?.('retry-after'));
         lastError = new Error(`${res.status} ${res.statusText}`);
         continue;
       }
@@ -423,8 +451,9 @@ async function main() {
   }
 }
 
-// Exported so a checker can reuse the parser without refetching.
-export { parseSubjectFile };
+// Exported so a checker can reuse the parser without refetching, and so the
+// retry policy can be exercised without a network.
+export { fetchText, parseSubjectFile };
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
   main().catch((err) => {

--- a/tests/fetch-retry.test.js
+++ b/tests/fetch-retry.test.js
@@ -1,0 +1,185 @@
+// The retry policy the two nightly snapshot scripts share. fetch and setTimeout
+// are both replaced, so nothing here touches the network or actually waits.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { fetchText } from "../scripts/fetch-seats.mjs";
+import { fetchJson } from "../scripts/fetch-courses.mjs";
+
+const URL_UNDER_TEST = "https://example.invalid/thing.txt";
+
+// The two scripts hold a hand-copied loop each, so every case runs against both
+// and the copies cannot drift apart quietly.
+const CLIENTS = [
+  ["seats", fetchText, "ok"],
+  ["courses", fetchJson, { body: "ok" }],
+];
+
+const realFetch = globalThis.fetch;
+const realSetTimeout = globalThis.setTimeout;
+
+/** Answer in order, repeating the last. A reply is a status or [status, retryAfter]. */
+function replyWith(replies) {
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    const reply = replies[Math.min(calls.length, replies.length - 1)];
+    const [status, retryAfter = null] = Array.isArray(reply) ? reply : [reply];
+    calls.push(String(url));
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: "",
+      headers: { get: (name) => (name.toLowerCase() === "retry-after" ? retryAfter : null) },
+      text: async () => "ok",
+      json: async () => ({ body: "ok" }),
+    };
+  };
+  return calls;
+}
+
+/** Fire every backoff immediately and record the wait it asked for. */
+function recordDelays() {
+  const delays = [];
+  globalThis.setTimeout = (fn, ms) => {
+    delays.push(ms);
+    return realSetTimeout(fn, 0);
+  };
+  return delays;
+}
+
+test.afterEach(() => {
+  globalThis.fetch = realFetch;
+  globalThis.setTimeout = realSetTimeout;
+});
+
+for (const [client, get, ok] of CLIENTS) {
+  // Regression, #90. The whole 4xx range was fatal, so the one status that means
+  // wait and try again skipped the backoff written for it and ended the run.
+  test(`regression #90: ${client} retries a 429 instead of ending the run`, async () => {
+    const delays = recordDelays();
+    const calls = replyWith([429, 200]);
+    assert.deepEqual(await get(URL_UNDER_TEST), ok);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(delays, [500]);
+  });
+
+  test(`${client}: 408 and 425 are retried too`, async () => {
+    for (const status of [408, 425]) {
+      recordDelays();
+      const calls = replyWith([status, 200]);
+      assert.deepEqual(await get(URL_UNDER_TEST), ok, `${status} should be retried`);
+      assert.equal(calls.length, 2, `${status} should be retried`);
+    }
+  });
+
+  test(`${client}: a rate limit that never clears still gives up`, async () => {
+    const delays = recordDelays();
+    const calls = replyWith([429]);
+    await assert.rejects(() => get(URL_UNDER_TEST), /429/);
+    assert.equal(calls.length, 4, "the first try plus RETRIES");
+    assert.deepEqual(delays, [500, 1000, 2000]);
+  });
+
+  test(`${client}: Retry-After sets the wait when the header is there`, async () => {
+    const delays = recordDelays();
+    replyWith([[429, "2"], 200]);
+    await get(URL_UNDER_TEST);
+    assert.deepEqual(delays, [2000]);
+  });
+
+  test(`${client}: Retry-After is read as a date as well as a count of seconds`, async () => {
+    const delays = recordDelays();
+    replyWith([[429, new Date(Date.now() + 5000).toUTCString()], 200]);
+    await get(URL_UNDER_TEST);
+    assert.ok(delays[0] > 3000 && delays[0] <= 5000, `waited ${delays[0]}ms`);
+  });
+
+  test(`${client}: a Retry-After longer than the cap does not stall one request`, async () => {
+    const delays = recordDelays();
+    replyWith([[429, "3600"], 200]);
+    await get(URL_UNDER_TEST);
+    assert.deepEqual(delays, [30000]);
+  });
+
+  // A wait is digits or a date. Number() would take the rest of these as well,
+  // which is how a Retry-After of 0x10 turns into sixteen seconds.
+  test(`${client}: a Retry-After that is not a wait falls back to the backoff`, async () => {
+    const notWaits = ["soon", "-5", "0", "", "Thu, 01 Jan 1970 00:00:00 GMT"];
+    const numberWouldTake = ["0x10", "1e3", "1.5", "+2"];
+    for (const header of [...notWaits, ...numberWouldTake]) {
+      const delays = recordDelays();
+      replyWith([[429, header], 200]);
+      await get(URL_UNDER_TEST);
+      assert.deepEqual(delays, [500], `Retry-After: ${header}`);
+    }
+  });
+
+  // A rate limiter in front of the origin answers 503 as readily as 429.
+  test(`${client}: a 503 carrying Retry-After is waited out too`, async () => {
+    const delays = recordDelays();
+    replyWith([[503, "7"], 200]);
+    await get(URL_UNDER_TEST);
+    assert.deepEqual(delays, [7000]);
+  });
+
+  // A dropped connection never reaches a header, so without the per-attempt
+  // reset a capped Retry-After would be spent again on every attempt left.
+  test(`${client}: a Retry-After does not carry into the next attempt`, async () => {
+    const delays = recordDelays();
+    let sent = 0;
+    globalThis.fetch = async () => {
+      if (sent++ > 0) throw new Error("socket hang up");
+      return { ok: false, status: 429, statusText: "", headers: { get: () => "3600" } };
+    };
+    await assert.rejects(() => get(URL_UNDER_TEST), /socket hang up/);
+    assert.deepEqual(delays, [30000, 1000, 2000]);
+  });
+
+  test(`${client}: a 403 is retried once and then gives up`, async () => {
+    const delays = recordDelays();
+    const calls = replyWith([403]);
+    await assert.rejects(() => get(URL_UNDER_TEST), /403/);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(delays, [500]);
+  });
+
+  test(`${client}: the rest of 4xx is still fatal on the first response`, async () => {
+    for (const status of [400, 401, 404, 410, 451]) {
+      const delays = recordDelays();
+      const calls = replyWith([status]);
+      await assert.rejects(() => get(URL_UNDER_TEST), new RegExp(String(status)));
+      assert.equal(calls.length, 1, `${status} should not be retried`);
+      assert.deepEqual(delays, [], `${status} should not be retried`);
+    }
+  });
+
+  // Not every fetch stand-in is a full Response, and a missing header must not
+  // turn a status that says what went wrong into one that does not.
+  test(`${client}: a response with no headers still reports its status`, async () => {
+    recordDelays();
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: async () => "",
+      json: async () => ({}),
+    });
+    await assert.rejects(() => get(URL_UNDER_TEST), /failed: 500 Internal Server Error/);
+  });
+
+  test(`${client}: a 5xx still retries`, async () => {
+    const delays = recordDelays();
+    const calls = replyWith([503, 200]);
+    assert.deepEqual(await get(URL_UNDER_TEST), ok);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(delays, [500]);
+  });
+}
+
+// fetchJson takes no options, so only the seats client can be asked this one.
+test("an expected 404 is still not an error", async () => {
+  const calls = replyWith([404]);
+  assert.equal(await fetchText(URL_UNDER_TEST, { allow404: true }), null);
+  assert.equal(calls.length, 1);
+});


### PR DESCRIPTION
Closes #90

`if (res.status >= 400 && res.status < 500) { err.fatal = true; throw err; }` sat above the `if (!res.ok) continue` line that feeds the backoff, so the one status that means wait and try again was the one status guaranteed never to reach it. The catch breaks the attempt loop on `err.fatal`, and neither script writes anything until every term is in, so a single 429 anywhere in a run leaves yesterday's seats or last week's course index frozen on the page.

Both scripts now treat 408, 425 and 429 as retryable and give a 403 one retry. The rest of 4xx still stops on the first response.

Below is the real `fetchText` exported from `scripts/fetch-seats.mjs`, called with `fetch` and `setTimeout` replaced so the waits are recorded rather than slept. Same scenarios against `origin/main` and against this branch:

```
origin/main
429 then 200                      1 request(s), waits []  -> RUN DIES: GET https://www.asc.ohio-state.edu/barrett.3/schedule/ failed: 429
429 Retry-After: 30, then 200     1 request(s), waits []  -> RUN DIES: GET https://www.asc.ohio-state.edu/barrett.3/schedule/ failed: 429
503 Retry-After: 7, then 200      2 request(s), waits [500]  -> page fetched
429 Retry-After: 0x10, then 200   1 request(s), waits []  -> RUN DIES: GET https://www.asc.ohio-state.edu/barrett.3/schedule/ failed: 429
400 (must stay fatal)             1 request(s), waits []  -> RUN DIES: GET https://www.asc.ohio-state.edu/barrett.3/schedule/ failed: 400

fix/issue-90
429 then 200                      2 request(s), waits [500]  -> page fetched
429 Retry-After: 30, then 200     2 request(s), waits [30000]  -> page fetched
503 Retry-After: 7, then 200      2 request(s), waits [7000]  -> page fetched
429 Retry-After: 0x10, then 200   2 request(s), waits [500]  -> page fetched
400 (must stay fatal)             1 request(s), waits []  -> RUN DIES: GET https://www.asc.ohio-state.edu/barrett.3/schedule/ failed: 400
```

Three details in that table worth naming.

`Retry-After` is capped at 30s. A server can name an hour, and `mapLimit` rejects on the first exhausted request, so an uncapped header parks the whole run on one URL.

`Retry-After` is parsed as digits or an HTTP date, not through `Number()`. `Number("0x10")` is 16, `Number("1e3")` is 1000, `Number("1.5")` is 1.5 and `Number("+2")` is 2, none of which RFC 9110 defines as a wait. Without the gate those turn into 16s, a capped 30s, 1.5s and 2s.

The header is read on any response that reaches the backoff, not only 4xx. A rate limiter in front of an origin answers 503 as readily as 429, and the third line above is that case.

`scripts/fetch-courses.mjs` gets the same change. The issue only names `fetch-seats.mjs:83`, but the two files carried a byte-identical copy of the loop and the courses run makes about 2,500 requests a week against `content.osu.edu`, so fixing one and leaving the other seemed worse than the extra file.

Tests: `tests/fetch-retry.test.js`, 25 cases, every one of them run against both clients except the `allow404` case, which `fetchJson` takes no options for. `fetch` and `setTimeout` are both replaced, so the file asserts the delays the loop asked for instead of sleeping them. Suite goes from 138 to 163, all passing, in 920ms.

```
$ node --test $(ls tests/*.test.js | grep -v fetch-retry)
# tests 138
# pass 138
# fail 0

$ node --test
# tests 163
# pass 163
# fail 0
# duration_ms 920.703
```

Confirmed the tests fail without the fix. Rebuilt both scripts from `origin/main` with nothing added but the two `export` lines so the file could still import them, and got 20 of 25 failing. The 5 survivors are the guardrails: the rest of 4xx still fatal, a 5xx still retried, an expected 404 still not an error.

Then mutated the fixed code 13 ways and checked each one turns the suite red, since the point of running the table against both clients is that the two copies cannot drift apart quietly:

```
CAUGHT  (1 failing)  courses: 408/425 back to fatal
CAUGHT  (2 failing)  courses: cap removed
CAUGHT  (1 failing)  courses: 403 never retried
CAUGHT  (5 failing)  courses: Retry-After ignored
CAUGHT  (5 failing)  seats: Retry-After ignored
CAUGHT  (1 failing)  seats: delta-seconds ungated
CAUGHT  (1 failing)  courses: delta-seconds ungated
CAUGHT  (1 failing)  seats: Retry-After back inside the 4xx block
CAUGHT  (1 failing)  courses: Retry-After back inside the 4xx block
CAUGHT  (8 failing)  seats: all 4xx fatal again (the original bug)
CAUGHT  (8 failing)  courses: all 4xx fatal again (the original bug)
CAUGHT  (1 failing)  seats: per-attempt `wait = 0` reset deleted
CAUGHT  (1 failing)  courses: per-attempt `wait = 0` reset deleted
```

What this does not do. It is not verified against a live 429, same honest scope the issue states: neither service was observed rate-limiting and I did not hammer either one to find out. Every test stubs `fetch`, so this is verified as policy, not as behaviour against real OSU infrastructure.

There is no shared throttle either. `mapLimit` runs 5 workers and each backs off on its own, so a sustained rate limit still costs the run, just more slowly. A global gate across the pool is a bigger change than the issue asked for.

`scripts/fetch-ratings.mjs` is left alone. Its loop already retries every failure including a 429, so it has no version of this bug. It ignores `Retry-After`, which is a separate and much smaller thing.
