### PR TITLE
Stop Barrett's DRAFT banner from poisoning the residue check

### DIFF
--- a/docs/barrett-schedule.md
+++ b/docs/barrett-schedule.md
@@ -35,8 +35,8 @@ time is about 06:50 Eastern. Treat the numbers as a daily figure.
 
 ## File shape
 
-Three header lines, then blank-line-separated groups of sections, then up to two
-trailer tables that use completely different layouts.
+Three header lines, five in a draft term, then blank-line-separated groups of
+sections, then up to two trailer tables that use completely different layouts.
 
 ```
 CSE         1268 (Autumn 2026)         updated: 18-Aug-2026
@@ -45,6 +45,25 @@ CSE         1268 (Autumn 2026)         updated: 18-Aug-2026
 <blank>
      CSE 1110             4817 L                                      ONLINE      26/40       M.Mallon
 ```
+
+A term Barrett has not published yet carries a DRAFT banner between the title
+and the column header, so its header is five lines rather than three. All 239
+subject files offered for 1272 on 2026-08-21 carried it, and none of the 241
+offered for 1268 did:
+
+```
+CSE         1272 (Spring 2027)         updated: 20-Aug-2026
+<blank>
+#####  DRAFT: pre-publication information; classes shown here are subject to change #####
+<blank>
+                       class#    (autoenrolls)                                enrld/limit/+wait
+<blank>
+     CSE 1110            35982 L                                      ONLINE       0/40
+```
+
+So the parser finds the body from the `class#` line instead of counting header
+lines, and a file with no `class#` line near the top is an error rather than a
+guess.
 
 The trailers start with `INDependent study classes` and `waitlist report:`.
 Parsing has to stop at whichever comes first, because rows in the independent

--- a/scripts/fetch-seats.mjs
+++ b/scripts/fetch-seats.mjs
@@ -65,6 +65,11 @@ const DAY_COLUMNS = { 49: 'M', 50: 'T', 51: 'W', 52: 'R', 53: 'F', 54: 'Sa', 55:
 const TAIL_RE = /^\s*(?:(\S+)\s+)?(\d+)\/(\d+)(?:\s*\+(\d+))?\s*$/;
 
 const HEADER_RE = /^(\S+)\s+(\d{4}) \((.+?)\)\s+updated: (\S+)\s*$/;
+// A pre-publication term carries a DRAFT banner above the column header, so its
+// header is five lines instead of three. Only the top of the file is searched,
+// so a trailer row cannot stand in for the header.
+const COLUMNS_RE = /class#.*enrld\/limit\/\+wait/;
+const COLUMNS_SEARCH_LINES = 10;
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -141,18 +146,30 @@ function parseDays(line) {
   return out;
 }
 
+// A file whose shape is not the one the column map describes is a layout
+// change, not a stray line, so a caller that tolerates a few bad subjects has
+// to rethrow this rather than count it as one of them.
+function layoutError(message) {
+  const err = new Error(message);
+  err.layout = true;
+  return err;
+}
+
 function parseSubjectFile(subject, term, text) {
   const lines = text.split('\n');
   const header = HEADER_RE.exec(lines[0] ?? '');
-  if (!header) throw new Error(`${subject}: unrecognised header ${JSON.stringify(lines[0])}`);
-  if (header[2] !== term) throw new Error(`${subject}: header term ${header[2]} is not ${term}`);
+  if (!header) throw layoutError(`${subject}: unrecognised header ${JSON.stringify(lines[0])}`);
+  if (header[2] !== term) throw layoutError(`${subject}: header term ${header[2]} is not ${term}`);
+
+  const columnsAt = lines.slice(0, COLUMNS_SEARCH_LINES).findIndex((line) => COLUMNS_RE.test(line));
+  if (columnsAt < 0) throw layoutError(`${subject}: no column header near the top of the file`);
 
   const sections = [];
   const failures = [];
   let continuations = 0;
 
   // Two trailer tables follow the section list and use different layouts.
-  for (const line of lines.slice(3)) {
+  for (const line of lines.slice(columnsAt + 1)) {
     if (line.startsWith('INDependent study classes') || line.startsWith('waitlist report')) break;
     if (!line.trim()) continue;
 

--- a/tests/fetch-seats.test.js
+++ b/tests/fetch-seats.test.js
@@ -1,0 +1,91 @@
+// The snapshotter's pure half. Nothing here fetches: the files are built to
+// Barrett's real column map, so the parser has to accept them.
+
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseSubjectFile } from "../scripts/fetch-seats.mjs";
+import { BARRETT_COLUMNS, barrettFile, barrettLine } from "./fixtures.js";
+
+// Two sections and the continuation row that carries the second one's other
+// meeting time, which is the shape every subject file repeats.
+const BODY = [
+  { catalog: "1110", classNumber: "4817", room: "ONLINE", enrolled: 25, limit: 40, instructor: "M.Mallon" },
+  "",
+  { catalog: "1111", classNumber: "4818", days: "TR", time: "0350P", room: "BE0120", enrolled: 44, limit: 80, instructor: "D.Kline" },
+  "                                            and   T       0220P-0340  BE0470",
+  "",
+  "waitlist report:",
+];
+
+// Lines lifted out of a live CSE file. The builder is only worth anything if it
+// puts every field on the column a real file puts it on, so it is checked
+// against those lines rather than against itself.
+test("the fixture is built to the columns a live file uses", () => {
+  assert.equal(
+    barrettLine(BODY[0]),
+    "     CSE 1110             4817 L                                      ONLINE      25/40       M.Mallon"
+  );
+  assert.equal(
+    barrettLine(BODY[2]),
+    "     CSE 1111             4818 L                  T R     0350P       BE0120      44/80       D.Kline"
+  );
+});
+
+describe("where the column header is", () => {
+  const parsed = (out) => out.sections.map((s) => [s.classNumber, s.enrolled, s.limit]);
+
+  test("a published term parses every section with nothing left over", () => {
+    const out = parseSubjectFile("CSE", "1268", barrettFile("CSE", "1268", BODY));
+    assert.deepEqual(out.failures, []);
+    assert.deepEqual(parsed(out), [["4817", 25, 40], ["4818", 44, 80]]);
+    assert.equal(out.continuations, 1);
+  });
+
+  // Regression, #91. The banner adds two lines, so counting three header lines
+  // started the body on the column header and booked it as a residue failure.
+  test("regression #91: the DRAFT banner does not become a residue failure", () => {
+    const out = parseSubjectFile("CSE", "1268", barrettFile("CSE", "1268", BODY, { draft: true }));
+    assert.deepEqual(out.failures, []);
+    assert.deepEqual(parsed(out), [["4817", 25, 40], ["4818", 44, 80]]);
+    assert.equal(out.continuations, 1);
+  });
+
+  // Without the column header the body position is a guess, and the wording can
+  // turn up again in a trailer, so only the top of the file counts.
+  test("an unrecognised column header stops the run", () => {
+    const missing = barrettFile("CSE", "1268", BODY, { columns: null });
+    assert.throws(() => parseSubjectFile("CSE", "1268", missing), /no column header/);
+
+    const renamed = barrettFile(
+      "CSE",
+      "1268",
+      [...BODY, "", "     CSE 1224               3", "     CSE 2111               4", BARRETT_COLUMNS],
+      { columns: BARRETT_COLUMNS.replace("class#", "class no.") }
+    );
+    assert.throws(() => parseSubjectFile("CSE", "1268", renamed), /no column header/);
+  });
+
+  // A caller is allowed to write off a subject whose file did not load, so the
+  // layout errors have to say they are something else: one renamed column is
+  // every file at once, not one bad subject.
+  test("a layout failure is tagged as one", () => {
+    const cases = {
+      "an unrecognised title": "not a Barrett file",
+      "the wrong term": barrettFile("CSE", "1264", BODY),
+      "no column header": barrettFile("CSE", "1268", BODY, { columns: null }),
+    };
+    for (const [what, text] of Object.entries(cases)) {
+      assert.throws(() => parseSubjectFile("CSE", "1268", text), (err) => err.layout === true, what);
+    }
+  });
+
+  // Counting two lines past the column header would silently drop this section,
+  // and a dropped line leaves no residue, so nothing would report it.
+  test("a section directly under the column header is still parsed", () => {
+    const tight = barrettFile("CSE", "1268", BODY, { draft: true, gap: false });
+    const out = parseSubjectFile("CSE", "1268", tight);
+    assert.deepEqual(out.failures, []);
+    assert.equal(out.sections.length, 2);
+  });
+});

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -117,3 +117,73 @@ function prof(legacyId, firstName, lastName, avgRating, numRatings) {
     wouldTakeAgainPercent: null,
   };
 }
+
+// Barrett's plain text schedule, for the tests that exercise
+// scripts/fetch-seats.mjs. The parser reads fixed columns, so a section line is
+// built at the positions docs/barrett-schedule.md records rather than retyped,
+// and tests/fetch-seats.test.js pins the builder against lines from a live file.
+
+export const BARRETT_COLUMNS =
+  "                       class#    (autoenrolls)                                enrld/limit/+wait";
+
+// A term Barrett has not published yet carries this between the title and the
+// column header, which is two more header lines than a published term has.
+export const BARRETT_BANNER =
+  "#####  DRAFT: pre-publication information; classes shown here are subject to change #####";
+
+const BARRETT_DAY_COLUMNS = { M: 49, T: 50, W: 51, R: 52, F: 53, S: 54, s: 55 };
+
+/** One section line. Anything left out stays blank, as it does in a real file. */
+export function barrettLine({
+  subject = "CSE",
+  catalog = "1110",
+  campus = "",
+  classNumber = "4817",
+  component = "L",
+  autoEnroll = "",
+  days = "",
+  time = "",
+  room = "",
+  enrolled = 25,
+  limit = 40,
+  waitlist = 0,
+  instructor = "",
+} = {}) {
+  const columns = new Array(94).fill(" ");
+  const put = (start, text) => { for (let i = 0; i < text.length; i++) columns[start + i] = text[i]; };
+  put(8 - subject.length, subject); // right aligned
+  put(9, catalog);
+  put(19, campus);
+  put(30 - String(classNumber).length, String(classNumber)); // right aligned
+  put(31, component);
+  put(34, autoEnroll);
+  for (const day of days) put(BARRETT_DAY_COLUMNS[day], day);
+  put(58, time);
+  put(70, room);
+  // Enrollment is right aligned on the slash, and the waitlist hangs off the end.
+  put(84 - String(enrolled).length, `${enrolled}/${limit}${waitlist ? `+${waitlist}` : ""}`);
+  return (columns.join("") + instructor).trimEnd();
+}
+
+/**
+ * One subject file. A row is either fields for barrettLine or a literal line,
+ * which is how a continuation or a trailer heading goes in.
+ *
+ * `columns` set to null drops the column header and a string replaces it, since
+ * both are layout changes the parser has to refuse rather than guess through.
+ * `gap` is the blank line every real file has under the column header.
+ */
+export function barrettFile(subject, term, rows = [], {
+  draft = false,
+  gap = true,
+  columns = BARRETT_COLUMNS,
+  termName = "Autumn 2026",
+  updated = "18-Aug-2026",
+} = {}) {
+  const lines = [`${subject.padEnd(12)}${term} (${termName})         updated: ${updated}`, ""];
+  if (draft) lines.push(BARRETT_BANNER, "");
+  if (columns) lines.push(columns);
+  if (gap) lines.push("");
+  for (const row of rows) lines.push(typeof row === "string" ? row : barrettLine({ subject, ...row }));
+  return lines.join("\n");
+}


### PR DESCRIPTION
Closes #91

`parseSubjectFile` started the body at `lines.slice(3)`, a hard coded three line header. Barrett puts a DRAFT banner and a blank line above the column header of a term it has not published yet, so on those files the loop started on the column header itself, failed the residue check on it, and booked one failure per subject file.

No sections are lost either way. What it costs is the residue budget, which is the one signal that means the fixed-width layout moved and the run should refuse to write. Both parsers over every subject file Barrett offers, pulled live today:

```
term  files   sections before   residue before   sections after   residue after
1262    241            17483                0            17483               0
1264    198             4866                0             4866               0
1268    241            17692                0            17692               0
1272    239            16562              239            16562               0
total   919 subject files pulled live today

residue rate the run computes once 1272 is searchable, budget 0.500%:
  before 239 failures / 56842 lines = 0.420%
  after  0 failures / 56603 lines = 0.000%
```

Section counts are identical in all 919 files, so nothing is gained or lost, only the false failures go away. This has not fired yet because `searchableTermsV2` returns 1262, 1264 and 1268 today, so the draft term is never fetched. The day Spring 2027 becomes searchable the run does still write, but on 0.08 points of headroom, and it does not survive Spring 2026 rolling off the searchable list after it:

```
1262,1264,1268,1272      0.420% under
1264,1268,1272           0.607% OVER budget, refuses to write
```

The body now starts one line after the column header. The issue suggested two, which is the same thing on every real file since the loop skips blanks anyway, but it would silently drop a section if Barrett ever dropped that blank, and a dropped line leaves no residue so nothing would report it. Patching the slice to `columnsAt + 2` turns the fourth test red on its own.

Two things about the search for that header. It reads only the first ten lines, so a trailer table that repeated the wording cannot stand in for the real header and start the body below every section. And a file with no column header up there throws, like the two header checks directly above it, rather than falling back to the old count of three and quietly restoring this bug. Over the same 919 files every one has exactly one matching line, at index 2 published and index 4 draft, none has zero, and the smallest offered file in the set (CSTW in 1262, five lines, one section) still carries it.

`node --test` is 142 pass 0 fail, against 138 on main. The four new tests run the real exported parser over lines lifted out of live CSE files. Three of them fail with main's `scripts/fetch-seats.mjs` swapped in:

```
ok 1 - a published term parses every section with nothing left over
not ok 2 - regression #91: the DRAFT banner does not become a residue failure
not ok 3 - an unrecognised column header stops the run
not ok 4 - a section directly under the column header is still parsed
# tests 4
# pass 1
# fail 3
```

Test 1 is the published-term baseline and is meant to stay green.

Two things I left alone. Renaming the column header at Barrett's end now breaks the run loudly rather than quietly, which is the trade I wanted, but it does mean the regex is the single thing that recognises a header. And the 0.5% budget itself is untouched, since with the false failures gone there is nothing pressing on it.
