### PR TITLE
Stop first paint waiting on the term's seat snapshot

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -613,10 +613,13 @@ async function init() {
     runSearch(initialQuery, els.term.value);
   }
   else {
-    // Ratings and seats are already in flight; fill the landing screen once
-    // they land rather than showing an empty frame in the meantime.
+    // Ratings and the seats index are already in flight; fill the landing
+    // screen once they land rather than showing an empty frame. The term's own
+    // seats are another 69 KB and nothing on this screen shows a seat count, so
+    // they are started here but not waited on.
     setStatus("");
-    Promise.allSettled([loadRatings(), loadSeats(els.term.value)]).then(() => showWelcome(els.term.value));
+    loadSeats(els.term.value).catch((error) => console.warn("seats unavailable", error));
+    Promise.allSettled([loadRatings(), loadSeats()]).then(() => showWelcome(els.term.value));
   }
 }
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { RATINGS, SEATS_INDEX, SEATS_TERMS } from "./fixtures.js";
+
+// app.js runs init() the moment it is imported, so the only way to check what
+// startup waits on is to give it a DOM to start against. Everything stubbed
+// below exists because init touches it on a first visit with no query.
+
+const TERMS_URL = "https://content.osu.edu/v2/classes/searchableTermsV2";
+
+function makeEl() {
+  return {
+    dataset: {},
+    children: [],
+    value: "",
+    checked: false,
+    disabled: false,
+    hidden: true,
+    textContent: "",
+    addEventListener() {},
+    setAttribute() {},
+    append(...nodes) { this.children.push(...nodes); },
+    replaceChildren(...nodes) { this.children = nodes; },
+    querySelectorAll() { return []; },
+  };
+}
+
+function makeDom() {
+  const selectors = [
+    ".app", "#search", "#rail", "#rail-toggle", "#detail", "#detail-body", "#detail-back",
+    "#filters", "#f-days", "#p-subject", "#p-number", "#subject-list", "#number-list",
+    "#p-hint", "#welcome", "#w-stats", "#w-sub", "#w-list", "#view-list", "#view-cal",
+    "#f-clear", "#q", "#term", "#go", "#status", "#results",
+  ];
+  const nodes = new Map(selectors.map((sel) => [sel, makeEl()]));
+  // writeFilters reaches the controls by name off the form.
+  const filters = nodes.get("#filters");
+  for (const name of ["from", "to", "rating", "hideFull", "hideOnline", "ratedOnly"]) {
+    filters[name] = makeEl();
+  }
+  return {
+    querySelector: (sel) => nodes.get(sel) ?? null,
+    createElement: () => makeEl(),
+    node: (sel) => nodes.get(sel),
+  };
+}
+
+/** Poll rather than sleep a fixed time, so a passing run costs a tick. */
+async function waitFor(check, ms = 2000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (check()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return false;
+}
+
+// Restored so a second test added here starts from a real environment. It will
+// still need a fresh js/app.js too, since init only runs on first import.
+const saved = Object.fromEntries(
+  ["document", "window", "location", "history", "fetch"].map((key) => [key, globalThis[key]])
+);
+test.after(() => { Object.assign(globalThis, saved); });
+
+test("the welcome screen paints without waiting for the term's seats", async () => {
+  const dom = makeDom();
+  globalThis.document = dom;
+  globalThis.window = { matchMedia: () => ({ matches: false, addEventListener() {} }) };
+  globalThis.location = { search: "", href: "https://example.com/" };
+  globalThis.history = { replaceState() {} };
+
+  const requested = [];
+  let releaseTermSeats;
+  const termSeats = new Promise((resolve) => { releaseTermSeats = resolve; });
+
+  globalThis.fetch = async (url) => {
+    const key = String(url);
+    requested.push(key);
+    const body =
+      key.startsWith(TERMS_URL) ? { data: { data: [{ strm: "1268", descr: "Autumn 2026" }] } } :
+      key === "data/ratings.json" ? RATINGS :
+      key === "data/seats.json" ? SEATS_INDEX :
+      key === "data/seats-1268.json" ? await termSeats.then(() => SEATS_TERMS["1268"]) :
+      null;
+    if (!body) throw new Error(`unexpected fetch: ${key}`);
+    return { ok: true, status: 200, json: async () => body };
+  };
+
+  await import("../js/app.js");
+
+  const stats = dom.node("#w-stats");
+  const painted = await waitFor(() => stats.textContent !== "");
+  assert.ok(painted, `welcome never painted; fetched ${requested.join(", ")}`);
+
+  // The stats line comes from the index, so the section count is still there.
+  // The date after it is locale-formatted, so it is left unpinned.
+  assert.ok(stats.textContent.startsWith("Autumn 2026 · 7 sections · seats as of "),
+    `stats line degraded to: ${stats.textContent}`);
+  assert.equal(dom.node("#welcome").hidden, false);
+  assert.ok(dom.node("#w-list").children.length > 0);
+
+  // The term's seats still get fetched, so the first search does not pay for them.
+  assert.ok(await waitFor(() => requested.includes("data/seats-1268.json")),
+    `term seats never fetched; fetched ${requested.join(", ")}`);
+  releaseTermSeats();
+});


### PR DESCRIPTION
Closes #58

`init` awaited `Promise.allSettled([loadRatings(), loadSeats(els.term.value)])` before calling `showWelcome`, and `loadSeats(term)` pulls that term's whole Barrett snapshot. The welcome screen never reads a seat count out of it. It was also the worst thing on the page to block on: `els.term.value` is empty until `fetchTerms()` comes back, so the download could not even start until a cross-origin round trip finished, and only then did the paint get to queue behind it.

Sizes on this branch, `gzip -9 -c <file> | wc -c`:

```
data/seats.json           640 raw     364 gz
data/seats-1268.json  305,253 raw  71,188 gz
data/ratings.json   1,858,613 raw 180,238 gz
```

The real page in headless Chrome, served over http out of the committed `data/`, with `searchableTermsV2` canned and `data/seats-1268.json` held for 4s so the dependency shows up. The probe polls `#w-stats` and writes what it finds into `data-probe`:

```
before  {"paintedAt":4100,"stats":"Autumn 2026 · 17,692 sections · seats as of Aug 20",
         "sub":"From 7,367 rated instructors, ...","names":8,
         "order":["data/ratings.json@57","data/seats.json@58","terms@59","data/seats-1268.json@76"]}

after   {"paintedAt":159, "stats":"Autumn 2026 · 17,692 sections · seats as of Aug 20",
         "sub":"From 7,367 rated instructors, ...","names":8,
         "order":["data/ratings.json@52","data/seats.json@52","terms@53","data/seats-1268.json@73"]}
```

Same stats line, same sub line, same eight names, drawn at 159ms instead of 4100ms. The 4s hold is artificial, so that gap measures the dependency, not throughput.

The seats index is still awaited, and it has to be. `showWelcome` builds "17,692 sections · seats as of Aug 20" from `seatsSectionCount(term)` and `seatsUpdated(term)`, and both answer out of the 364-byte index, not the term file. Dropping seats from the `allSettled` the way the issue suggests leaves that line reading "Autumn 2026" alone whenever ratings wins the race home, with nothing to repaint it. So the awaited call became `loadSeats()` with no term, which fetches the index and stops.

The term's file still starts as early as it did before. It is an unawaited call one line up rather than a member of the `allSettled`, which keeps it off the paint without pushing it behind the 180 KB ratings download. Measured with a node harness that runs the real modules and stamps every request, ratings held 1500ms:

```
before  terms requested @34ms, data/seats-1268.json @141ms, welcome painted @1593ms
after   terms requested @33ms, data/seats-1268.json @142ms, welcome painted @1580ms
```

Ratings is the bottleneck in that scenario, so the paint is the same on both sides. The point of it is the middle number: the prefetch still goes out the moment terms resolves.

Tests are 139 passing, up from 138. The new `tests/app.test.js` gives `app.js` a DOM to start against, stubs fetch, and holds `data/seats-1268.json` open on a gate that never resolves during the assertions, so a paint that waits on that file cannot finish. Confirmed failing without the change, against `js/app.js` from main:

```
$ node --test tests/app.test.js
not ok 1 - the welcome screen paints without waiting for the term's seats
  error: 'welcome never painted; fetched data/ratings.json, data/seats.json,
           https://content.osu.edu/v2/classes/searchableTermsV2, data/seats-1268.json'
# pass 0 / # fail 1
```

That fetch order is the issue's claim on its own: ratings and the index go out first, terms resolves, then the term file starts, and the paint sits behind it. The test also fails against the issue's literal suggested fix, at the last assertion, since that version never fetches the term file at all.

What I did not do. The issue says to leave the unawaited `loadSeats(els.term.value)` at the top of `init` alone because it already prefetches the term file. It does not. `index.html:28` ships `<select id="term" name="term" disabled></select>` with no options, so `els.term.value` is `""` there, and `entryFor` returns null on a falsy term, so that call fetches the index and nothing else. The one-line deletion would have moved the whole 71 KB onto the first search instead of off the critical path, which is why this diff is bigger than the issue's.

I also did not re-run the issue's own throttled A/B (2815ms to 2421ms at 1.5 Mbit). Every number above is one I measured on this branch.
