### PR TITLE
Count only what the calendar draws in the hidden note

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4,7 +4,7 @@ import { renderResults } from "./render.js";
 import { loadRatings, topRated, ratedCount, profileUrl } from "./ratings.js";
 import { loadSeats, seatsTerm, seatsUpdated, seatsSectionCount } from "./seats.js";
 import { renderDetail } from "./detail.js";
-import { applyFilters, isActive, DEFAULTS } from "./filters.js";
+import { applyFilters, hiddenFor, isActive, DEFAULTS } from "./filters.js";
 import { renderCalendar } from "./calendar.js";
 import { loadCourses, subjectsFor, subjectLabel, coursesFor, codeFromInput, isLoaded } from "./courses.js";
 
@@ -390,10 +390,7 @@ function paint(term = els.term.value) {
 
   const primary = p.entries;
   const related = r.entries;
-  // Count what the filters removed from everything on the page, not just from
-  // the primary results, or the note understates its own effect.
-  const hiddenSections = p.hiddenSections + r.hiddenSections;
-  const hiddenCourses = p.hiddenCourses + r.hiddenCourses;
+  const { hiddenSections, hiddenCourses } = hiddenFor(view, p, r);
 
     currentEntries = [...primary, ...related];
     sectionIndex = new Map();

--- a/js/filters.js
+++ b/js/filters.js
@@ -116,3 +116,19 @@ export function applyFilters(entries, filters) {
 
   return { entries: kept, hiddenSections, hiddenCourses };
 }
+
+/**
+ * What the filters removed from the piles a view actually draws.
+ *
+ * The calendar plots the primary pile only, so counting the related one there
+ * offers back sections the grid will never draw.
+ */
+export function hiddenFor(view, primary, related) {
+  if (view === "calendar") {
+    return { hiddenSections: primary.hiddenSections, hiddenCourses: primary.hiddenCourses };
+  }
+  return {
+    hiddenSections: primary.hiddenSections + related.hiddenSections,
+    hiddenCourses: primary.hiddenCourses + related.hiddenCourses,
+  };
+}

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -1,7 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { DEFAULTS, toMinutes, isActive, applyFilters } from "../js/filters.js";
+import { DEFAULTS, toMinutes, isActive, applyFilters, hiddenFor } from "../js/filters.js";
+import { buildSlots } from "../js/calendar.js";
 import { entry, section, taught } from "./fixtures.js";
 import { withRatings, withSeats } from "./helpers.js";
 
@@ -24,6 +25,19 @@ const online = section(5003, {
 const arranged = section(5004, { meetings: [] });
 
 const course = () => entry("CSE", "2221", "Software I", [morning, evening, online, arranged]);
+
+// The pile the calendar plots and the pile it does not. hideOnline costs the
+// plotted pile one section of Software I and the whole of Software II, and the
+// other pile its only section.
+const plotted = () => [
+  course(),
+  entry("CSE", "2231", "Software II", [
+    section(5005, { instructionMode: "Distance Learning - Online", meetings: [] }),
+  ]),
+];
+const setAside = () => [entry("CSE", "5911", "Capstone", [
+  section(5006, { instructionMode: "Distance Learning - Online", meetings: [] }),
+])];
 
 test("toMinutes reads a twelve hour clock", () => {
   assert.equal(toMinutes("8:00 am"), 480);
@@ -187,4 +201,36 @@ test("applyFilters does not mutate the entries it was given", () => {
   const entries = [course()];
   applyFilters(entries, filters({ days: ["monday"] }));
   assert.equal(entries[0].sections.length, 4);
+});
+
+test("regression #77: the calendar note counts only the pile the grid plots", () => {
+  const f = filters({ hideOnline: true });
+  assert.deepEqual(
+    hiddenFor("calendar", applyFilters(plotted(), f), applyFilters(setAside(), f)),
+    { hiddenSections: 2, hiddenCourses: 1 }
+  );
+});
+
+test("regression #77: the calendar note matches what the grid gains", () => {
+  const f = filters({ hideOnline: true });
+  const all = plotted();
+  const p = applyFilters(all, f);
+  // renderCalendar draws buildSlots and nothing else, so what buildSlots
+  // accounts for is the most the note can honestly promise back.
+  const drawn = (entries) => {
+    const { slots, unscheduled } = buildSlots(entries, TERM);
+    return slots.reduce((n, s) => n + s.items.length, 0) + unscheduled.length;
+  };
+  assert.equal(
+    hiddenFor("calendar", p, applyFilters(setAside(), f)).hiddenSections,
+    drawn(all) - drawn(p.entries)
+  );
+});
+
+test("the list note counts both piles, since the list shows both", () => {
+  const f = filters({ hideOnline: true });
+  assert.deepEqual(
+    hiddenFor("list", applyFilters(plotted(), f), applyFilters(setAside(), f)),
+    { hiddenSections: 3, hiddenCourses: 2 }
+  );
 });


### PR DESCRIPTION
Closes #77

`paint()` added both piles' hidden counts together, and then fifteen lines later the calendar branch handed `renderCalendar` the primary pile alone. Every section the filters took out of the related pile was counted in a note attached to a grid that never draws it, so "Show them anyway" kept promising more than it could deliver.

Measured in headless Chrome against the real `app.js`, once from `main` and once from this branch, same page and same stubbed search. The fixture is 30 CSE courses, each with one online section, every fifth of them online only so `hideOnline` removes whole courses as well as sections. The grid row is counted out of the DOM: one `.cal-item` per slot in the week, plus the number the unscheduled list prints for itself, since that list caps its rows at 12.

```
                    main                        this branch
calendar note   30 sections and 6 courses   25 sections and 1 course
status before   24 courses, 24 sections     24 courses, 24 sections
status after    25 courses, 49 sections     25 courses, 49 sections
grid sections   24 -> 49  (+25)             24 -> 49  (+25)
list note       30 sections and 6 courses   30 sections and 6 courses
```

On `main` the calendar offered 30 sections and 6 courses back and 25 sections and 1 course arrived. On this branch the note says exactly what shows up. The list note is unchanged, because `renderResults` really does draw both piles.

The suite goes from 138 tests on `main` to 141. The three new ones are in `tests/filters.test.js` and cover `hiddenFor`, the small helper the count now goes through. Putting `hiddenFor` back to summing both piles turns two of them red:

```
# tests 141
# pass 139
# fail 2
not ok 58 - regression #77: the calendar note counts only the pile the grid plots
not ok 59 - regression #77: the calendar note matches what the grid gains
```

The second one asks `buildSlots` how many sections the calendar actually accounts for, rather than restating the arithmetic, so it fails if the note and the grid ever disagree again.

Worth saying plainly: those tests guard the helper, not the call in `paint()`. `js/app.js` queries the DOM at module scope and calls `init()` on import, so `node --test` cannot reach `paint()` at all. I checked what that costs by putting `js/app.js:393` back to the old inline sum with the helper and all three tests left in place, and the suite still reports 141 pass, 0 fail. The call site is what the browser numbers above cover. `tests/render.test.js` already draws the same line for DOM-building code.

The issue suggested reading `p.hiddenSections` and `p.hiddenCourses` straight into the calendar branch. I put the choice in `filters.js` instead, which does mean one `"calendar"` string now lives in a module that had no view vocabulary before. That is the trade I took to get any node test at all: with the decision sitting in `paint()`, reverting it leaves the suite green, which is the measurement above.

Two things I left alone. In calendar view, a filter that only touches the related pile now shows no note rather than a wrong one, and the real number is in list view with the "See them in list view" button right above it. And "Show them anyway" still unhides both piles, so the related-courses line grows with it, which is what the button says it does.
