### PR TITLE
Move focus to the results when a button removes itself

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -260,6 +260,14 @@ function closeDetail() {
   (selected ?? els.results).focus();
 }
 
+// Focus collapses to the body when a control removes itself, which drops a
+// keyboard user past the whole rail. Collapsed, an open detail pane hides the
+// results, so fall back to whichever region is on screen. Not called from
+// paint(), since an ordinary filter change should leave focus where it is.
+function focusResults() {
+  (els.results.getClientRects().length ? els.results : els.detail).focus();
+}
+
 // The status element is never removed or hidden, only its text changes. A live
 // region that was hidden when content arrived usually goes unannounced.
 function setStatus(message, kind = "info") {
@@ -415,7 +423,7 @@ function paint(term = els.term.value) {
       const button = document.createElement("button");
       button.type = "button";
       button.textContent = "See them in list view";
-      button.addEventListener("click", () => setView("list"));
+      button.addEventListener("click", () => { setView("list"); focusResults(); });
       note.append(button);
       els.results.append(note);
     }
@@ -435,7 +443,7 @@ function paint(term = els.term.value) {
     const button = document.createElement("button");
     button.type = "button";
     button.textContent = "Show them anyway";
-    button.addEventListener("click", () => { showHidden = true; paint(term); });
+    button.addEventListener("click", () => { showHidden = true; paint(term); focusResults(); });
     note.append(button);
     els.results.append(note);
   }
@@ -551,6 +559,7 @@ async function init() {
     showHidden = false;
     syncUrl(els.query.value, els.term.value);
     paint();
+    focusResults();
   });
 
   els.railToggle.addEventListener("click", () => {
@@ -604,6 +613,7 @@ async function init() {
     reflectQuery(button.dataset.q);
     syncUrl(button.dataset.q, els.term.value);
     runSearch(button.dataset.q, els.term.value);
+    focusResults();
   });
 
   const initialQuery = params.get("q") ?? "";


### PR DESCRIPTION
Closes #74

Four handlers destroy the element that has focus and put nothing in its place. `paint()` sets `els.clear.hidden = !active`, so "Clear filters" hides itself. `paint()` also rebuilds `#results`, so the "Show them anyway" and "See them in list view" notes are replaced by the repaint their own click triggers. `runSearch()` sets `els.welcome.hidden = true`, which hides the section the example buttons sit in. Chrome drops focus to `<body>` on the next lifecycle update in all four cases.

Each of those handlers now hands focus to `#results`, which was already `tabindex="-1"` and unused.

## Measured

A probe page next to `index.html` so the relative module paths resolve, with `fetch` stubbed inline for the terms and search endpoints and the two snapshots, three courses and four sections. The driver focuses a control, clicks it, which is what Enter on a focused button does, waits four macrotasks, and reads `document.activeElement`. Same page, same command, once against `git show main:js/app.js` and once against this branch.

```
"C:/Program Files/Google/Chrome/Application/chrome.exe" --headless=new --disable-gpu \
  --no-sandbox --allow-file-access-from-files --virtual-time-budget=30000 \
  --window-size=1500,1000 --dump-dom "file:///.../probe.html"
```

`--allow-file-access-from-files` is not optional. Without it the ES module at `js/app.js` is blocked by CORS over `file://` and the page never runs.

```
innerWidth 1484                          main         this branch

welcome example        BUTTON.w-example  -> BODY      -> #results
show them anyway       BUTTON            -> BODY      -> #results
see them in list view  BUTTON            -> BODY      -> #results
clear filters          #f-clear          -> BODY      -> #results
```

Controls that survive their own handler keep focus, measured in the same run with the fix in place, so an ordinary filter change still does not steal focus from the rail:

```
view toggle to calendar  #view-cal   -> #view-cal
view toggle to list      #view-list  -> #view-list
hide full checkbox       #f-full     -> #f-full
tuesday day chip         BUTTON      -> BUTTON     (same element, it has no id)
```

## The collapsed layout needs a fallback

`#results` lives inside `.centre`, and under the 64rem breakpoint `css/finder.css:339` hides it whenever the detail pane is open:

```css
.app[data-view="detail"] .centre { display: none; }
```

Focusing an element that is not rendered does nothing, so `els.results.focus()` on its own would have left "Clear filters" collapsing to the body there anyway. That is the phone layout, and 64rem is 1024px, so a zoomed-in desktop window lands in it too. The repro is all taps: search CSE 2221, tap a section row, tap Filters, tick "Hide online sections", tap "Clear filters".

Same probe, same command without `--window-size`, which is the 764px headless default:

```
view=detail  rail=open  centreDisplay=none  resultsRendered=false  detailRendered=true

                              main       this branch
clear filters in detail view  -> BODY    -> #detail
```

So `focusResults()` takes whichever of the two regions is rendered. `#detail` is already `tabindex="-1"` and it is the thing actually on screen in that state.

## Tests

`node --test` from the repo root: **138 pass, 0 fail**, unchanged.

No test added, and that is a real gap rather than an oversight. `tests/` is node:test with no DOM and no dependencies, and nothing imports `js/app.js`, which has no exports and calls `init()` at module scope against a real `document`. Covering this would mean adding a headless-Chrome harness as the only browser test in the repo, which is more new infrastructure than the fix. The fail-then-pass above is the same probe run against `main`'s `app.js` instead. Nothing in CI will catch a regression on these four handlers.

## Two things worth knowing

The welcome handler is delegated on `[data-q]`, and `showWelcome()` puts that attribute on the top-rated instructor names as well, so those buttons get the same treatment as the "CSE 2221" example. They disappear with the section too, so it is the right outcome, but it is more than the issue's wording implies.

Mouse users now also get focus moved on these four controls. Every focus rule in `css/finder.css` is `:focus-visible`, so no ring is drawn for a click.

The issue's note about where the next Tab lands is its own measurement and is not repeated here. What this change measures is the focus collapse that causes it.
