### PR TITLE
Stop attaching a same-surname stranger's rating to an instructor

### DIFF
--- a/js/ratings.js
+++ b/js/ratings.js
@@ -42,15 +42,15 @@ function firstName(full) {
  * Do two first names plausibly belong to the same person?
  *
  * OSU uses legal names, RMP uses whatever students typed, so "Timothy" appears
- * as "Tim" and "Steve" as "Stephen". A prefix covers the first case. The second
- * needs a shared initial, which is only safe when the surname is unique, so the
- * caller enforces that.
+ * as "Tim". Only a real abbreviation counts. Two letters would let Ji Wang
+ * answer for Jiangmeng Wang, and a shared initial would let Amy Gregg answer
+ * for Anne Gregg.
  */
 function compatibleFirstNames(a, b) {
   if (!a || !b) return false;
   if (a === b) return true;
-  if (a.startsWith(b) || b.startsWith(a)) return true;
-  return a[0] === b[0];
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  return shorter.length >= 3 && longer.startsWith(shorter);
 }
 
 export async function loadRatings(baseUrl = "data/ratings.json") {
@@ -100,14 +100,13 @@ export function ratingFor(name, idx = index) {
   const candidates = idx.bySurname.get(surnameKey(name)) ?? [];
   if (!candidates.length) return null;
   const first = firstName(name);
-  const viable = candidates.filter((p) => {
-    const theirs = firstName(`${p.firstName} ${p.lastName}`);
-    if (theirs === first || theirs.startsWith(first) || first.startsWith(theirs)) return true;
-    // A shared initial is weak evidence, so only trust it when nobody else
-    // could be meant.
-    return candidates.length === 1 && compatibleFirstNames(first, theirs);
-  });
-  return viable.length === 1 ? viable[0] : null;
+  const theirs = candidates.map((p) => firstName(`${p.firstName} ${p.lastName}`));
+  const viable = candidates.filter((_, i) => compatibleFirstNames(first, theirs[i]));
+  // Ruling a name out is not the same as it not being there. "Ji" cannot answer
+  // for "Jiangmeng", but it is still a second Wang, so it has to block the guess
+  // instead of clearing the way for Jin Wang.
+  const related = theirs.filter((t) => t.startsWith(first) || first.startsWith(t));
+  return viable.length === 1 && related.length === 1 ? viable[0] : null;
 }
 
 export function searchUrl(name) {

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -82,14 +82,15 @@ export const SEATS_TERMS = {
 // Ratings snapshot. Every professor here exists to exercise one join case.
 export const RATINGS = {
   school: { id: "U2Nob29sLTcyNA==", legacyId: 724, name: "Ohio State University" },
-  count: 9,
+  count: 12,
   professors: [
     // Plain unique match, and the middle-name case: OSU says "Diana Ikenberry
     // Kline", RMP says "Diana Kline".
     prof(1, "Diana", "Kline", 4.2, 31),
     // Nickname the query is a prefix of: OSU "Timothy Long", RMP "Tim Long".
     prof(2, "Tim", "Long", 3.4, 12),
-    // Shared initial only, and the sole Gomori, so the weak rule is allowed.
+    // Shared initial only, and the sole Gomori. Being the only one is not
+    // evidence, so "Steve Gomori" must not land here.
     prof(3, "Stephen", "Gomori", 4.8, 60),
     // Two real people with the same name. Never guess between them.
     prof(4, "Alan", "Reed", 2.1, 40),
@@ -102,6 +103,10 @@ export const RATINGS = {
     prof(9, "Jonas", "Park", 4.0, 11),
     // Suffix case: the OSU name is "Ivan C. Smith III".
     prof(10, "Ivan", "Smith", 3.7, 8),
+    // A real two letter first name. A longer name must not claim it, and
+    // ruling it out must not hand the query to the other Wang either.
+    prof(11, "Ji", "Wang", 4.5, 9),
+    prof(12, "Jin", "Wang", 3.7, 7),
   ],
 };
 

--- a/tests/ratings.test.js
+++ b/tests/ratings.test.js
@@ -52,13 +52,29 @@ test("ratingFor matches through a generational suffix", () => {
 });
 
 test("ratingFor expands a nickname the query is a prefix of", () => {
-  // OSU says Timothy Long, RateMyProfessors says Tim Long.
+  // OSU says Timothy Long, RateMyProfessors says Tim Long. Tim is three
+  // letters, which is where the floor sits.
   assert.equal(ratingFor("Timothy Long").legacyId, 2);
 });
 
-test("ratingFor accepts a shared initial only when the surname is unique", () => {
-  // Steve against Stephen, and Gomori is the only one.
-  assert.equal(ratingFor("Steve Gomori").legacyId, 3);
+// Regression, #88. Anne Gregg was being shown Amy Gregg's 3.3 and Amy's
+// profile link, because Gregg was the only Gregg in the snapshot.
+test("regression #88: a shared initial is not a match even when the surname is unique", () => {
+  assert.equal(ratingFor("Steve Gomori"), null);
+});
+
+// Regression, #88. "jiangmeng".startsWith("ji") handed Jiangmeng Wang the real
+// Ji Wang's 4.5, which Ji still keeps.
+test("regression #88: a two letter name does not expand into a longer one", () => {
+  assert.equal(ratingFor("Jiangmeng Wang"), null);
+  assert.equal(ratingFor("Ji Wang").legacyId, 11);
+});
+
+// Regression, #88. Ji and Jin were both in the running for Jing, so refusing Ji
+// on length must not leave Jin standing there alone.
+test("regression #88: a name ruled out on length still blocks the guess", () => {
+  assert.equal(ratingFor("Jing Wang"), null);
+  assert.equal(ratingFor("Jin Wang").legacyId, 12);
 });
 
 test("ratingFor refuses to guess between two people with the same name", () => {


### PR DESCRIPTION
Closes #88

The surname fallback collected candidates by surname alone and then asked two questions that were not about identity. A prefix of any length in either direction is why `"jiangmeng".startsWith("ji")` handed Jiangmeng Wang the real Ji Wang's profile. A bare shared first initial was accepted whenever the surname held exactly one person, and 4,428 of the 5,298 surnames in the snapshot hold exactly one person (83.6%), so on most surnames the weakest test was also the easiest one to pass. A unique surname is a small candidate pool, not corroboration.

Both branches now collapse into `compatibleFirstNames`: the names are the same, or the shorter one is at least three letters and the longer one continues it.

The second half of the fix is less obvious. Ruling a candidate out is not the same as it not being there, so a name too short to be an abbreviation still has to block the guess. My first cut only narrowed the filter, and `Jing Wang` went from correctly showing nothing to showing Jin Wang's 3.7. "Ji" used to sit in the viable list and stop the code from choosing, and evicting it left Jin standing there alone. That is the reported bug wearing a different name, so the loose prefix test stays on as a blocker even though it is no longer an acceptance test.

Measured against the shipped `data/ratings.json` (7,367 professors) driven through the real `loadRatings`, and against every instructor teaching Autumn 2026, pulled subject by subject from `content.osu.edu/v2/classes/search`:

```
The three cases named in the issue, plus the one the review caught:

  Anne Gregg      before Amy Gregg 3.3/17 profile 1262854           after null
  Tithi Lai       before Ten-Hwang Lai 3.2/22 profile 602137        after null
  Jiangmeng Wang  before Ji Wang 4.5/51 profile 2485791             after null
  Jing Wang       before null                                       after null

Every instructor teaching Autumn 2026 (term 1268, all 243 subjects, 6264 distinct names):
  lost a rating   108
  gained one      0
  matched someone else 0

The ten losses with the most ratings behind them:
  Ty Shepfer                   was showing Tyler Shepfer 2.7/148 profile 1094085
  Mike Lisa                    was showing Michael Lisa 4.2/64 profile 126159
  Tom Magliery                 was showing Thomas Magliery 3.4/57 profile 820451
  Jiangmeng Wang               was showing Ji Wang 4.5/51 profile 2485791
  Nate Broaddus                was showing Nathan Broaddus 1.7/47 profile 1338907
  W C Benton                   was showing W.C. Benton 1.8/44 profile 277876
  Nicholas Breyfogle           was showing Nick Breyfogle 4.3/43 profile 2104282
  Galey Modan                  was showing Gabriel Modan 2.1/41 profile 38528
  Christin Christin Ray        was showing Christopher Ray 3.7/35 profile 2486624
  Steve Gomori                 was showing Stephen Gomori 3.7/35 profile 223245
```

Nobody gains a rating and nobody swaps identity, so this is strictly a narrowing. It is not free, though. Of the 108, 93 were matched on the shared initial alone, which is what the issue asked to delete, and 15 had a real prefix relation and lose it to the three letter floor. A good number of the 108 are the same person under an everyday name, and that list above is mostly those. The trade is the one the function's own docstring already made: a wrong rating is worse than no rating. None of them go dark either. With no rating, `render.js` and `detail.js` already point the name at a RateMyProfessors search for that exact name instead of at a profile, so the score disappears and the link still works.

I also built and measured the version where the three letter floor applies only to the RMP side, so initials-style OSU names survive. It recovers 10 of the 108, including `C K Shum`, `W C Benton` and `Ty Shepfer`, and it still gains nothing over main. But two of the 10 are `Ju Yeon Park` picking up Julia Park and `Xi Chen` picking up Xiaoyi Chen, which is this bug with the sides swapped: a real short given name swallowed by a longer one. That is why the floor stayed symmetric, and it is what the issue asked for.

Nickname pairs that are not prefixes (Ty/Tyler, Mike/Michael, Bob/Robert) would need a lookup table to come back. That is the obvious follow-up and it is a bigger change than this one, since every row in a table like that is a new chance to be wrong.

Tests: 140 pass, 0 fail, against 138 on main. Three new ones and one rewritten. The rewritten one asserted that `Steve Gomori` finds Stephen Gomori, which is precisely the behaviour the issue removes. I confirmed the new tests gate the change by dropping main's `js/ratings.js` back under them: the shared initial case and the two letter case both fail, 16 of 18 pass in `tests/ratings.test.js`. The `Jing Wang` test passes on main, since main got that case right, and fails against my first cut, which is where it came from.

One line in the diff is not strictly the fix. `tests/fixtures.js` carried `count: 9` over a list of 10 professors, and this change adds two more, so I set it to 12 rather than leave a fixture lying about its own size in the commit that changed that size. Nothing reads the field.

Heads up: Sa7yaC said on the issue that they had implemented the suggested fix and were waiting on confirmation before opening a PR. Close this one in favour of theirs if you would rather take that.
