### PR TITLE
Leave the detail view when the results are replaced

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -343,6 +343,9 @@ function showWelcome(term) {
 }
 
 async function runSearch(q, term) {
+  // Collapsed, the detail pane hides the results and the status line, and the
+  // empty-query and error paths below never reach paint().
+  els.app.dataset.view = "results";
   if (!q.trim()) {
     els.results.replaceChildren();
     showWelcome(term);
@@ -423,6 +426,7 @@ function paint(term = els.term.value) {
     renderResults(els.results, { primary, related }, term);
   }
   resetDetail();
+  els.app.dataset.view = "results";
 
   if (hiddenSections || hiddenCourses) {
     // Never hide silently. Say what was removed and offer it back.


### PR DESCRIPTION
Closes #86

`showDetail()` sets `els.app.dataset.view = "detail"` on a collapsed layout, and `css/finder.css:338-339` uses that attribute to swap `.centre` out for `.detail`. Only two things ever set it back: the Back button and the breakpoint listener. Neither one runs on a search, so every path that replaces the results while a section is open writes them into a column CSS still has at `display: none`.

Two lines, both setting `data-view` back to `results`. One next to the `resetDetail()` call in `paint()`, which is where the issue put it. One at the top of `runSearch()`, because the empty-query return and the `catch` both bail out before `paint()` and strand the user the same way.

## What it looks like from the DOM

Probe page next to `index.html` so `js/` and `css/` resolve, real `app.js` and real `finder.css`, `fetch` stubbed with one term, a CSE 2221 course and a MATH 1151 course. Chrome would not lay out narrower than 500px, which is still under the 64rem breakpoint, and `matchMedia("(max-width: 64rem)")` matched in both runs.

```
"C:/Program Files/Google/Chrome/Application/chrome.exe" --headless=new --disable-gpu \
  --no-sandbox --allow-file-access-from-files --window-size=390,844 \
  --virtual-time-budget=20000 --dump-dom "file:///.../probe-86.html"
```

`--allow-file-access-from-files` is not optional. Without it the ES modules never execute over `file://` and `app.js` sits there doing nothing.

```
## main
layout width=500 collapsed=true
1 first search        view=null    centre=block resultsRects=1 statusRects=1 firstRow=1002
2 opened a section    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=1002
3 searched again      view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=2002
4 opened a section    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=2002
5 changed a filter    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=2002
6 opened a section    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=2002
7 empty query         view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=-
8 opened a section    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=1002
9 search got a 429    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=-
10 opened a section   view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=1002
11 fetch rejected     view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=-
12 opened a section   view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=1002
13 pressed Back       view=results centre=block resultsRects=1 statusRects=1 firstRow=1002

## this branch
layout width=500 collapsed=true
1 first search        view=results centre=block resultsRects=1 statusRects=1 firstRow=1002
2 opened a section    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=1002
3 searched again      view=results centre=block resultsRects=1 statusRects=1 firstRow=2002
4 opened a section    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=2002
5 changed a filter    view=results centre=block resultsRects=1 statusRects=1 firstRow=2002
6 opened a section    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=2002
7 empty query         view=results centre=block resultsRects=1 statusRects=1 firstRow=-
8 opened a section    view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=1002
9 search got a 429    view=results centre=block resultsRects=1 statusRects=1 firstRow=-
10 opened a section   view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=1002
11 fetch rejected     view=results centre=block resultsRects=1 statusRects=1 firstRow=-
12 opened a section   view=detail  centre=none  resultsRects=0 statusRects=0 firstRow=1002
13 pressed Back       view=results centre=block resultsRects=1 statusRects=1 firstRow=1002
```

Row 3 is the issue as filed. The MATH rows are in the DOM either way, `firstRow` flips 1002 to 2002 in both runs, and on main `#centre` still computes to `display: none` with `#results` and `#status` returning zero client rects. Rows 2, 4, 6, 8, 10 and 12 are unchanged, so opening a section still takes over the screen.

## Three paths, not one

Row 5 is the same bug reached from the rail. The Filters button stays in the topbar in detail view, so a phone user can get there, and on main changing a filter also left them on the idle text.

Rows 7, 9 and 11 are the ones `paint()` alone does not reach, which is why the second line is in `runSearch()`:

- Row 7, empty query. `#results` is emptied and `showWelcome()` un-hides `#welcome`, all inside the hidden column, so nothing on screen changes at all.
- Row 9, the API answers 429. `#status` reads `Ohio State's course service returned an error (429). Try again in a moment.` and `statusRects=0`, so the user is never told.
- Row 11, `fetch` rejects. Same, `Could not reach Ohio State's course service...` invisible.

Setting the view before the await also means the "Searching..." status is on screen for the round trip instead of a stale section.

## Desktop

Same probe at `--window-size=1400,900`, laid out at 1384px with `collapsed=false`. All 13 rows are identical between main and this branch once the `data-view` value itself is removed from the comparison. Nothing reads `data-view` outside the `@media (max-width: 64rem)` block, `grep -rn data-view css/ js/ stats/ index.html` finds exactly three rules and all three are `[data-view="detail"]` at `css/finder.css:338-341`, inside a block that spans lines 296-356. No rule matches `"results"`, so the value the first paint now writes is inert.

## Tests

`node --test` is 138 pass, 0 fail, unchanged from main. Nothing was added, and there is no way to add it here without a refactor the issue did not ask for. `node -e "import('./js/app.js')"` fails with `document is not defined`, `tests/helpers.js` stubs `fetch` and nothing else, `tests/render.test.js` already says DOM-building code is out of scope for the suite, and `.github/workflows/test.yml` runs bare `node --test` on ubuntu-latest, so a Chrome-spawning test would not gate anything. The probe recipe above is the artifact instead. It reproduces both tables in one paste.

## What I left alone

Focus does not move. `closeDetail()` owns that, and stealing focus on every filter toggle would be worse than the bug. The probe measured `document.activeElement` on all 13 steps in both runs and it is on a visible element every time: the Search button after a search, `#f-from` after a filter change, the selected row after Back. The pane does hold a focusable RateMyProfessors link per instructor, but a link that opens a new tab cannot reach `paint()`, and every path that does start from the search form, the term select or the rail, all of which stay visible.

The unconditional write matches `closeDetail()`, which is also not guarded on `collapsed.matches`, since above the breakpoint the attribute does nothing.
