### PR TITLE
Give the mobile filter sheet a row to open into

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -296,12 +296,18 @@ body {
 @media (max-width: 64rem) {
   .app {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto minmax(0, 1fr);
+    /* Each pane names its row: under auto placement the row a pane lands in
+       shifts with whichever pane is hidden. */
+    grid-template-rows: auto auto minmax(0, 1fr);
+    /* The pane behind the open sheet keeps its padding in a zero height row.
+       That scrolled the page 32px and a scrollbar reflowed it 15px narrower. */
+    overflow: hidden;
   }
 
   .rail {
     display: none;
     grid-column: 1;
+    grid-row: 2;
     border-right: 0;
     border-bottom: 1px solid var(--rule);
   }
@@ -326,11 +332,12 @@ body {
     color: var(--paper);
   }
 
-  .centre { grid-column: 1; }
+  .centre { grid-column: 1; grid-row: 3; }
 
   .detail {
     display: none;
     grid-column: 1;
+    grid-row: 3;
     border-left: 0;
   }
 

--- a/tests/layout.test.js
+++ b/tests/layout.test.js
@@ -1,0 +1,39 @@
+// The collapsed layout is CSS, so this reads the stylesheet rather than
+// rendering it: it guards what #87 got wrong, the row list, not the heights
+// that follow from it.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const css = readFileSync(new URL("../css/finder.css", import.meta.url), "utf8");
+const collapsed = css.slice(css.search(/@media \(\s*max-width:\s*64rem\s*\)/));
+const rowList = collapsed.match(/grid-template-rows:([^;]+);/)[1].trim();
+// The space inside minmax() is not a track boundary.
+const rows = rowList.replace(/\([^)]*\)/g, (fn) => fn.replace(/\s+/g, "")).split(/\s+/);
+
+/** The row a pane is placed in. */
+function rowOf(selector) {
+  const at = collapsed.indexOf(selector + " {");
+  assert.notEqual(at, -1, `no ${selector} rule in the collapsed layout`);
+  const row = collapsed.slice(at, collapsed.indexOf("}", at)).match(/grid-row:\s*(\d+)/);
+  assert.ok(row, `${selector} names no row in the collapsed layout`);
+  return Number(row[1]);
+}
+
+test("the collapsed layout declares a row for every pane it stacks", () => {
+  assert.ok(rows.length >= 3, `a header and three panes do not fit in ${rowList}`);
+  for (const selector of [".rail", ".centre", ".detail"]) {
+    const row = rowOf(selector);
+    assert.ok(row <= rows.length, `${selector} names row ${row} of ${rows.length}`);
+  }
+});
+
+test("the results keep the flexible row and the rail sits above it", () => {
+  assert.match(rows[rowOf(".centre") - 1], /1fr/);
+  assert.ok(rowOf(".rail") < rowOf(".centre"), "the sheet has to open above the results");
+});
+
+test("the detail pane names the same row as the results it replaces", () => {
+  assert.equal(rowOf(".detail"), rowOf(".centre"));
+});


### PR DESCRIPTION
Closes #87

Below 1024px four panes stack in one column but `.app` declared two grid rows. The rail is the third of those panes, so opening Filters put it in the `minmax(0, 1fr)` row after `.centre` had already taken the free space in an implicit auto row, and the sheet opened to 33px of padding holding 764px of filters.

Measured against a probe of the real index.html shell at the sizes the issue names, with a fixed height block standing in for the results list since the search needs content.osu.edu:

```
                    grid-template-rows           #rail       client/scroll   controls in view
main    390x844     253.922px 0px 590.078px      390x33      32 / 764        0 of 13
branch  390x844     253.922px 590.078px 0px      390x590     589 / 764       9 of 13
main    360x780     253.922px 0px 526.078px      360x33      32 / 764        0 of 13
branch  360x780     253.922px 526.078px 0px      360x526     525 / 764       9 of 13
main   1024x900     148.547px 0px 751.453px      1024x52     51 / 766        0 of 13
branch 1024x900     148.547px 751.453px 0px      1024x751    750 / 766       13 of 13
```

Hit testing the Monday chip at its centre returns `DIV` on main, a results row painted in front of the sheet, and `SPAN`, the chip itself, on the branch. The count is 13 rather than the issue's 14 because `#f-clear` carries `hidden` until a filter is set. At 390x844 nine controls fit the window and the rest sit behind the rail's own `overflow-y: auto`, the same scroll the desktop rail has always had.

Two declarations go past the row list the issue suggested, both because I measured what happens without them.

`.centre` and `.detail` name row 3 instead of auto placing. With the row list alone, a pane shorter than the viewport sizes its auto row to its content: the welcome screen measured `centre 390x76` with 514px of dead space under it, and the idle detail pane measured `390x105`. Naming the row holds both at 390x590, which is what main renders.

`overflow: hidden` on `.app`. With the sheet open the results row is 0px but `.centre` still paints its padding, so the document outgrew the window, `844/844` to `876/844`, and the scrollbar that appeared reflowed the app from 390px wide to 375px on the same tap. Clipping the shell puts both back. Hiding `.centre` outright would do it too, but that takes `#status` out of the tree and it is the `aria-live` region.

The closed, detail and welcome states measure identical to main at every size above.

tests/layout.test.js is new, three tests, and the suite goes from 138 to 141 passing. It reads css/finder.css rather than rendering it, since there is no document in this suite, and its header says so. All three fail against main's stylesheet. They also survive rewrites that change nothing: rerun with the media prelude respaced, both `grid-row` values written as spans, and the middle track written as `minmax(0, auto)`, all three still pass.

One thing I did not do: with the sheet open, the pane behind it is now clipped rather than scrolled to. That is what a sheet does and closing Filters brings it back, but it is a change from main, where the pane behind the broken 33px strip stayed readable.
