### PR TITLE
Split overlapping calendar blocks into side-by-side columns

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -709,7 +709,10 @@ body {
 
 .cal {
   display: grid;
-  grid-template-columns: 3rem repeat(var(--cal-days), minmax(9rem, 1fr));
+  /* The floor comes from each column's own --cal-split, so one crowded
+     Wednesday does not widen Monday with it. A split that divides a column's
+     width is #38's squeezed name, so the floor rises with the split. */
+  grid-template-columns: 3rem repeat(var(--cal-days), minmax(auto, 1fr));
   /* fit-content, not auto: with a floor under the columns the grid is wider
      than a phone, and it has to say so or overflow:hidden eats the difference
      instead of handing it to .cal-scroll. */
@@ -732,7 +735,7 @@ body {
   border-bottom: 1px solid var(--rule);
 }
 
-.cal-col { border-left: 1px solid var(--rule); min-width: 0; }
+.cal-col { border-left: 1px solid var(--rule); min-width: calc(9rem * var(--cal-split, 1)); }
 .cal-body { position: relative; }
 .cal-line { border-bottom: 1px solid var(--sunk); }
 
@@ -765,6 +768,14 @@ body {
 
 .cal-slot.is-full { border-left-color: var(--scarlet); }
 .cal-slot.is-part { border-left-color: var(--wait); }
+
+/* One line each, at any block width: the heights renderSlot budgets for the
+   chrome are single-line, so a wrap here silently clips an instructor. */
+.cal-time, .cal-count, .cal-more {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 .cal-time, .cal-count {
   margin: 0;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -28,6 +28,14 @@ const CHROME_H = 15;       // .cal-time
 const COUNT_H = 15;        // .cal-count, only when there is more than one section
 const PAD_H = 7;           // .cal-slot vertical padding
 
+// Past three, widening the track costs more sideways scrolling than the names
+// it saves, so a fourth column shares the room rather than adding to it.
+const MAX_SPLIT = 3;
+
+// The heights above are single-line, so .cal-time, .cal-count and .cal-more are
+// pinned to one line in the CSS: a wrapped label would eat an instructor line
+// out of the budget below without anything here knowing it had.
+
 function el(tag, className, text) {
   const node = document.createElement(tag);
   if (className) node.className = className;
@@ -74,6 +82,69 @@ export function buildSlots(entries, term) {
   return { slots: [...slots.values()], unscheduled };
 }
 
+// A block is never painted shorter than MIN_SLOT, so a very short class covers
+// more of its column than its end time claims.
+function paintedEnd(slot) {
+  return slot.start + Math.max(slot.end - slot.start, MIN_SLOT / PX_PER_MIN);
+}
+
+/**
+ * Split a day's slots into side-by-side columns.
+ *
+ * Blocks are placed absolutely, so two classes at overlapping times want the
+ * same pixels and whichever draws last takes them, along with the clicks: on
+ * ENGLISH 1110.01 six instructor buttons could not be reached at all, and one
+ * button's own centre opened a different section.
+ */
+export function layOutDay(slots) {
+  // The id breaks ties, since two slots can share a time and paged search does
+  // not return sections in a stable order. See docs/osu-api.md.
+  const order = [...slots].sort((a, b) =>
+    a.start - b.start || a.end - b.end || String(a.id).localeCompare(String(b.id)));
+
+  const laid = [];
+  let run = [];
+  let runEnd = -Infinity;
+
+  // A run is a stretch of the day with no gap in it. Nothing in one run can
+  // touch anything in the next, so each is packed on its own.
+  for (const slot of order) {
+    if (slot.start >= runEnd) { laid.push(...pack(run)); run = []; }
+    run.push(slot);
+    runEnd = Math.max(runEnd, paintedEnd(slot));
+  }
+  return [...laid, ...pack(run)];
+}
+
+/** Greedy leftmost free column, which is the usual week-view packing. */
+function pack(run) {
+  const ends = []; // when each column is free again
+  const blocks = run.map((slot) => {
+    let column = ends.findIndex((end) => end <= slot.start);
+    if (column < 0) column = ends.length;
+    ends[column] = paintedEnd(slot);
+    return { slot, column };
+  });
+  for (const block of blocks) block.columns = ends.length;
+  return blocks;
+}
+
+/**
+ * Left and right insets for one block of a split run, or null when the block
+ * has its run to itself and the CSS inset already has it right.
+ *
+ * The 2px matches the inset the CSS uses; the extra 2px on the right is the
+ * gutter between neighbours.
+ */
+export function slotInsets(column, columns) {
+  if (columns < 2) return null;
+  const share = `(100% - 4px) / ${columns}`;
+  return {
+    left: `calc(2px + ${column} * ${share})`,
+    right: `calc(4px + ${columns - 1 - column} * ${share})`,
+  };
+}
+
 /** Worst-case tone for a slot: red if every section in it is full. */
 function slotTone(items) {
   const known = items.filter((i) => i.seats);
@@ -98,6 +169,13 @@ export function renderCalendar(entries, term) {
   const last = Math.ceil(Math.max(...slots.map((s) => s.end)) / 60) * 60;
   const usedDays = DAYS.filter(([key]) => slots.some((s) => s.days.includes(key)));
 
+  // Laid out before the grid is sized, since each column's floor depends on how
+  // many columns that day needs.
+  const days = usedDays.map(([key, label, fullDay]) => {
+    const blocks = layOutDay(slots.filter((s) => s.days.includes(key)));
+    return { label, fullDay, blocks, split: Math.max(1, ...blocks.map((b) => b.columns)) };
+  });
+
   const grid = el("div", "cal");
   grid.style.setProperty("--cal-days", usedDays.length);
   grid.style.setProperty("--cal-height", `${(last - first) * PX_PER_MIN}px`);
@@ -112,8 +190,11 @@ export function renderCalendar(entries, term) {
   }
   grid.append(gutter);
 
-  for (const [key, label, fullDay] of usedDays) {
+  for (const { label, fullDay, blocks, split } of days) {
     const column = el("div", "cal-col");
+    // Sizes this day's track and no other, so a Wednesday that splits three
+    // ways does not widen a Monday holding one class into sideways scrolling.
+    column.style.setProperty("--cal-split", Math.min(split, MAX_SPLIT));
     column.append(el("div", "cal-head", label));
 
     const body = el("div", "cal-body");
@@ -124,8 +205,8 @@ export function renderCalendar(entries, term) {
       body.append(line);
     }
 
-    for (const slot of slots.filter((s) => s.days.includes(key))) {
-      body.append(renderSlot(slot, first, fullDay));
+    for (const block of blocks) {
+      body.append(renderSlot(block, first, fullDay));
     }
     column.append(body);
     grid.append(column);
@@ -144,11 +225,17 @@ export function renderCalendar(entries, term) {
   return wrap;
 }
 
-function renderSlot(slot, first, fullDay) {
+function renderSlot({ slot, column, columns }, first, fullDay) {
   const box = el("div", `cal-slot ${slotTone(slot.items)}`);
   const height = Math.max((slot.end - slot.start) * PX_PER_MIN, MIN_SLOT);
   box.style.top = `${(slot.start - first) * PX_PER_MIN}px`;
   box.style.height = `${height}px`;
+
+  const insets = slotInsets(column, columns);
+  if (insets) {
+    box.style.left = insets.left;
+    box.style.right = insets.right;
+  }
 
   box.append(el("p", "cal-time", `${clock(slot.start)}–${clock(slot.end)}`));
 

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { buildSlots } from "../js/calendar.js";
+import { buildSlots, layOutDay, slotInsets } from "../js/calendar.js";
 import { entry, meeting, person, section, taught } from "./fixtures.js";
 import { withSeats } from "./helpers.js";
 
@@ -135,4 +135,99 @@ test("seats stay absent when the term does not match the snapshot", () => {
 test("buildSlots handles an empty result set", () => {
   assert.deepEqual(buildSlots([], TERM), { slots: [], unscheduled: [] });
   assert.deepEqual(buildSlots([entry("CSE", "2321", "Foundations 1", [])], TERM), { slots: [], unscheduled: [] });
+});
+
+// layOutDay reads nothing but the times, so a bare slot stands in for one out
+// of buildSlots.
+const at = (start, end) => ({ id: `${start}|${end}`, days: ["wednesday"], start, end, items: [] });
+
+// Regression, #83. Both blocks were drawn full width, so the later one covered
+// the earlier one and took its clicks.
+test("regression #83: overlapping slots go into separate columns", () => {
+  const laid = layOutDay([at(760, 815), at(765, 845)]);
+  assert.deepEqual(laid.map((p) => [p.slot.start, p.column, p.columns]), [[760, 0, 2], [765, 1, 2]]);
+});
+
+test("regression #83: the ENGLISH 1110.01 overlap splits only on the days it happens", () => {
+  const WF = ["wednesday", "friday"];
+  const entries = [
+    entry("ENGLISH", "1110.01", "Writing and Information Literacy", [
+      taught(17458, WF, "12:40 PM", "1:35 PM", ["Cathy Lynne Ryan"]),
+      taught(17463, WF, "12:45 PM", "2:05 PM", ["Scott L DeWitt"]),
+      taught(17480, ["monday"], "12:40 PM", "1:35 PM", ["Nan Johnson"]),
+    ]),
+  ];
+  const { slots } = buildSlots(entries, TERM);
+
+  const wednesday = layOutDay(slots.filter((s) => s.days.includes("wednesday")));
+  assert.deepEqual(wednesday.map((p) => [p.column, p.columns]), [[0, 2], [1, 2]]);
+
+  // Monday holds one class, so nothing there gets narrowed.
+  const monday = layOutDay(slots.filter((s) => s.days.includes("monday")));
+  assert.deepEqual(monday.map((p) => [p.column, p.columns]), [[0, 1]]);
+});
+
+test("a day with no overlap keeps every block full width", () => {
+  const laid = layOutDay([at(540, 595), at(600, 655), at(700, 755)]);
+  assert.deepEqual(laid.map((p) => [p.column, p.columns]), [[0, 1], [0, 1], [0, 1]]);
+});
+
+test("a block ending exactly when the next starts does not split the column", () => {
+  const laid = layOutDay([at(540, 600), at(600, 660)]);
+  assert.deepEqual(laid.map((p) => p.columns), [1, 1]);
+});
+
+test("a column is free again once its block has ended", () => {
+  // The middle block overlaps both of its neighbours, but the outer two never
+  // touch each other, so they share the first column.
+  const laid = layOutDay([at(540, 600), at(570, 630), at(600, 660)]);
+  assert.deepEqual(laid.map((p) => [p.column, p.columns]), [[0, 2], [1, 2], [0, 2]]);
+});
+
+// MIN_SLOT holds a very short block at 44px, which is 23 minutes of grid, so
+// the times alone would put a block on top of it.
+test("a block painted taller than its end time still holds its column", () => {
+  assert.deepEqual(layOutDay([at(700, 710), at(715, 775)]).map((p) => [p.column, p.columns]),
+    [[0, 2], [1, 2]]);
+  assert.deepEqual(layOutDay([at(700, 710), at(730, 790)]).map((p) => [p.column, p.columns]),
+    [[0, 1], [0, 1]]);
+});
+
+// Two slots can share a time and still be two slots, since the id keys on the
+// day list too, and a paged search does not return sections in a stable order.
+test("the order buildSlots happened to emit slots in does not change the layout", () => {
+  const early = { ...at(760, 815), id: "a" };
+  const late = { ...at(760, 815), id: "b" };
+  const shape = (laid) => laid.map((p) => [p.slot.id, p.column, p.columns]);
+  assert.deepEqual(shape(layOutDay([early, late])), [["a", 0, 2], ["b", 1, 2]]);
+  assert.deepEqual(shape(layOutDay([late, early])), [["a", 0, 2], ["b", 1, 2]]);
+});
+
+test("no two blocks ever share a column and a moment", () => {
+  const input = [at(540, 600), at(545, 700), at(570, 630), at(600, 660), at(800, 900), at(850, 870)];
+  const laid = layOutDay(input);
+  assert.equal(laid.length, input.length);
+  for (const a of laid) {
+    for (const b of laid) {
+      if (a === b || a.column !== b.column) continue;
+      assert.ok(a.slot.end <= b.slot.start || b.slot.end <= a.slot.start,
+        `${a.slot.id} and ${b.slot.id} both sit in column ${a.column}`);
+    }
+  }
+});
+
+test("layOutDay handles a day with nothing on it", () => {
+  assert.deepEqual(layOutDay([]), []);
+});
+
+// The insets are what the reader actually sees, and they are easy to get
+// backwards: reversing the right-hand term still passes every test above.
+test("regression #83: a split block is inset to its own column", () => {
+  assert.equal(slotInsets(0, 1), null);
+  assert.deepEqual(slotInsets(0, 2),
+    { left: "calc(2px + 0 * (100% - 4px) / 2)", right: "calc(4px + 1 * (100% - 4px) / 2)" });
+  assert.deepEqual(slotInsets(1, 2),
+    { left: "calc(2px + 1 * (100% - 4px) / 2)", right: "calc(4px + 0 * (100% - 4px) / 2)" });
+  assert.deepEqual(slotInsets(1, 3),
+    { left: "calc(2px + 1 * (100% - 4px) / 3)", right: "calc(4px + 1 * (100% - 4px) / 3)" });
 });


### PR DESCRIPTION
Closes #83

`renderSlot` placed every block with `top` and `height` only, and `.cal-slot` pins `left: 2px; right: 2px`, so two classes at overlapping times want exactly the same pixels. Paint order picks the winner: the later block covers the earlier one and takes its hit testing with it. `buildSlots` already merges sections that share an exact day pattern and time, so the collision only appears at *different* but overlapping times, which is why ENGLISH 1110.01 breaks and the CSE 2321 case that merge was written for does not.

`layOutDay` now groups a day's slots into runs of overlap and hands each one a column index and a column count, and `slotInsets` turns those into the `left`/`right` insets `renderSlot` applies.

## What the browser measures

Probe page next to `index.html`, real `js/calendar.js` and `css/finder.css`, headless Chrome `--dump-dom`. The fixture is the pattern from the issue: a Wed/Fri 12:40p-1:35p block carrying the 17458 / 17471 / 17473 instructor buttons, with the Wed/Fri 12:45p-2:05p block on top of it. Every `.cal-item` is scrolled into view, then `document.elementFromPoint` is called at its own rect centre, which is where a real click resolves.

```
main   880px pane
  buttons 9   buried 6   Wed slot widths [272, 272]
    click at 17458 centre lands on: 17463
    click at 17471 centre lands on: cal-slot is-open
    click at 17473 centre lands on: cal-slot is-open
    click at 17458 centre lands on: 17463
    click at 17471 centre lands on: cal-slot is-open
    click at 17473 centre lands on: cal-slot is-open

branch 880px pane
  buttons 9   buried 0   Wed slot widths [140, 140]
```

Both halves of the issue reproduce: 17458's own centre opens Scott L DeWitt's 17463, and 17471 and 17473 land on the covering `.cal-slot`, which carries no `data-class-number`, so `closest(".section, .cal-item")` in app.js finds nothing and the click does nothing at all. Six buried buttons on main, none on the branch.

## The CSS floor is not optional

Splitting costs width, and a 9rem day column halved is #38's squeezed instructor name coming back. Measured at a 375px pane, same probe:

```
main   375px pane
  buried 6   Wed slot widths [139, 139]
    "Cathy Lynne Ryan" rendered at 93px, ellipsised: False

branch 375px pane, without the CSS floor change
  buried 0   Wed slot widths [68, 68]
    "Cathy Lynne Ryan" rendered at 55px, ellipsised: True

branch 375px pane
  buried 0   Wed slot widths [140, 140]
    "Cathy Lynne Ryan" rendered at 93px, ellipsised: False
```

So the track floor scales with the busiest day's column count, which is `--cal-split`. A split block keeps a whole column's width instead of halving it, and the grid says it is wider so `.cal-scroll` hands over the difference, the same way #38 decided a week scrolls sideways rather than crushing its columns.

That is not free. For this three-day course at an 880px pane the grid goes from 880px to 914px, so it now scrolls sideways by 34px where it did not before. A grid using six weekdays with one two-way split goes from 914px to 1778px. `MAX_SPLIT` caps the widening at three columns, so a fourth shares the room instead of adding to it: a four-way overlap measures 105px slots and still zero buried buttons.

## Tests

148 pass, up from 138 on main. Reverting the fix in a scratch copy (`layOutDay` stubbed back to `slots.map((slot) => ({ slot, column: 0, columns: 1 }))` and `slotInsets` to `null`) gives 141 pass, 7 fail. The seven that fail are the real regression coverage; the other three added tests guard the cases that must *not* split (a day with no overlap, a block ending exactly when the next starts, an empty day) and cannot fail against a stub that never splits.

`slotInsets` is exported and tested on its own because nothing else catches its arithmetic. Flipping `columns - 1 - column` to `columns - column` and dropping that one test leaves the suite at 147 pass, 0 fail, while the same build measures 13px wide blocks in the browser and buries all 8 buttons, which is worse than the bug being fixed. With the test in place that flip fails on its own and nothing else does.

## Deliberately not done

`.cal-slot`'s own rule is untouched. The insets are only written when a block shares its run, so a day with no overlap renders byte-identical to main.

`--cal-split` has no unit test. `renderCalendar` builds DOM and this suite has no document, which `tests/render.test.js:1` already states as the convention, so it is verified by the measurements above instead. Getting it wrong makes blocks narrow, not buried.

Two smaller behaviour changes worth naming rather than leaving to be discovered in the diff. Blocks now render in start-time order instead of the order `buildSlots` emitted them, so tab order follows the clock. And packing uses the painted extent, not the recorded end time, because `MIN_SLOT` holds a block at 44px whether or not its times fill that, which is 23 minutes of grid at `PX_PER_MIN`; packing on the times alone would still bury a very short class under its neighbour.
