### PR TITLE
Put the selected section in the URL and copy its class number

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ the page says how many sections it removed and offers a button that shows
 them anyway. There is no saved schedule and no conflict detection. Finder
 searches, it does not plan.
 
+Every search is in the address bar, and so is the section you picked, so a
+link opens on the section you meant rather than on the search. The right
+pane copies the class number BuckeyeLink asks for, and offers Share on the
+browsers that have it.
+
 ## Where the data comes from
 
 ```
@@ -164,7 +169,7 @@ The snapshot scripts are Node 22:
 node scripts/fetch-seats.mjs 1268
 ```
 
-`npm test` runs 138 tests through `node --test`, with nothing installed.
+`npm test` runs 149 tests through `node --test`, with nothing installed.
 
 ## Repo layout
 
@@ -179,6 +184,7 @@ js/
   calendar.js         week grid
   detail.js           right pane
   filters.js          client-side filtering
+  deeplink.js         the section a link points at
   ratings.js          RMP snapshot and name matching
   seats.js            Barrett snapshot and the term guard
   courses.js          lazily loaded course index
@@ -187,7 +193,7 @@ js/
 scripts/              the three snapshot jobs
 data/                 the snapshots, committed
 docs/                 what OSU's API and Barrett's schedule get wrong
-tests/                138 tests, zero dependencies
+tests/                149 tests, zero dependencies
 wireframes/           three layouts considered first
 analytics/            the page-view counter, a Cloudflare Worker
 stats/                the page that reads the counter
@@ -197,7 +203,9 @@ stats/                the page that reads the counter
 
 - Seats are a morning snapshot, so a section can fill before you search.
 - Barrett covers fewer sections than the API, so some rows never show seats.
-- The Back button does nothing, and a shared calendar link opens as a list.
+- Back closes the section pane and puts back the filters it opened with, but
+  it does not undo a search.
+- A shared calendar link opens as a list.
 - Changing a filter clears whichever section you had selected.
 - Columbus only, and only the three terms OSU's API exposes at a time.
 - A section with several meeting patterns shows the first one.

--- a/css/finder.css
+++ b/css/finder.css
@@ -507,6 +507,25 @@ body {
   margin: 0 0 0.4rem;
 }
 
+/* The buttons sit on the eyebrow's baseline, so they carry its bottom margin
+   as well, or the instructor name rides up under them. */
+.d-head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
+
+.d-act {
+  font: inherit;
+  font-family: var(--data);
+  font-size: 0.72rem;
+  padding: 0.25rem 0.5rem;
+  margin-bottom: 0.4rem;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--mute);
+  cursor: pointer;
+}
+
+.d-act:hover { color: var(--ink); border-color: var(--ink); }
+
 .d-name {
   font-family: var(--display);
   font-weight: 700;

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,7 @@ import { renderDetail } from "./detail.js";
 import { applyFilters, isActive, DEFAULTS } from "./filters.js";
 import { renderCalendar } from "./calendar.js";
 import { loadCourses, subjectsFor, subjectLabel, coursesFor, codeFromInput, isLoaded } from "./courses.js";
+import { classFromParams, setClassParam, sameSearch, hasSection, missOutcome } from "./deeplink.js";
 
 const els = {
   app: document.querySelector(".app"),
@@ -49,6 +50,9 @@ let currentEntries = [];
 let lastResult = null;
 let showHidden = false;
 let view = "list";
+// A section named by the URL. Applied on the next paint and then forgotten, so
+// changing a filter later does not drag the pane back to it.
+let pendingClass = "";
 
 function dayStates() {
   const required = [];
@@ -237,23 +241,57 @@ function setView(next) {
   paint();
 }
 
-function selectSection(row) {
-  const found = sectionIndex.get(row.dataset.classNumber);
-  if (!found) return;
+function sectionLink(classNumber) {
+  return setClassParam(new URL(location.href), classNumber).href;
+}
 
-  for (const other of els.results.querySelectorAll(".is-selected")) {
-    other.classList.remove("is-selected");
-    other.removeAttribute("aria-current");
+function deselectRows() {
+  for (const row of els.results.querySelectorAll(".is-selected")) {
+    row.classList.remove("is-selected");
+    row.removeAttribute("aria-current");
   }
+}
+
+/** Show a row's section and name it in the URL. */
+function applySelection(row) {
+  const found = sectionIndex.get(row.dataset.classNumber);
+  if (!found) return false;
+
+  deselectRows();
+  // Any note about a link that missed was about some other section.
+  els.results.querySelector(".link-note")?.remove();
   row.classList.add("is-selected");
   // Selection is state, not just colour, so it is exposed rather than implied.
   row.setAttribute("aria-current", "true");
 
-  showDetail(renderDetail({ ...found, term: els.term.value, entries: currentEntries, formatDate }));
+  const link = sectionLink(row.dataset.classNumber);
+  showDetail(renderDetail({
+    ...found, term: els.term.value, entries: currentEntries, formatDate, shareUrl: link,
+  }));
+  history.replaceState(null, "", link);
+  return true;
+}
+
+function clearSelection() {
+  deselectRows();
+  resetDetail();
+  if (collapsed.matches) els.app.dataset.view = "results";
+}
+
+function selectSection(row) {
+  if (!sectionIndex.has(row.dataset.classNumber)) return;
+  // One history entry for the pane rather than one per section looked at: push
+  // as it opens, replace while it is open, so Back closes it instead of walking
+  // back through the whole visit. Either way applySelection writes the URL.
+  if (!els.results.querySelector(".is-selected")) history.pushState(null, "", location.href);
+  applySelection(row);
 }
 
 function closeDetail() {
   els.app.dataset.view = "results";
+  // The pane is shut, so the link stops naming a section. The row keeps its
+  // selection because focus is about to go back to it.
+  history.replaceState(null, "", setClassParam(new URL(location.href), ""));
   // Back to the row that opened the pane where possible, so a keyboard user
   // resumes where they left off instead of at the top of the results.
   const selected = els.results.querySelector(".is-selected");
@@ -276,6 +314,9 @@ function setBusy(busy) {
 
 function syncUrl(q, term) {
   const url = new URL(location.href);
+  // A link's section belongs to the search it arrived with, so retrying that
+  // search after a 429 keeps it and searching for anything else drops it.
+  if (!sameSearch(url, q, term)) pendingClass = "";
   if (q) url.searchParams.set("q", q); else url.searchParams.delete("q");
   if (term) url.searchParams.set("term", term);
 
@@ -291,6 +332,9 @@ function syncUrl(q, term) {
   for (const key of ["hideFull", "hideOnline", "ratedOnly"]) {
     if (f[key]) url.searchParams.set(key, "1"); else url.searchParams.delete(key);
   }
+  // Every caller of this has just changed the result set, and the repaint that
+  // follows clears the pane, so whichever section was named is gone.
+  setClassParam(url, "");
   history.replaceState(null, "", url);
 }
 
@@ -394,6 +438,8 @@ function paint(term = els.term.value) {
   // the primary results, or the note understates its own effect.
   const hiddenSections = p.hiddenSections + r.hiddenSections;
   const hiddenCourses = p.hiddenCourses + r.hiddenCourses;
+  const wanted = pendingClass;
+  pendingClass = "";
 
     currentEntries = [...primary, ...related];
     sectionIndex = new Map();
@@ -420,9 +466,14 @@ function paint(term = els.term.value) {
       els.results.append(note);
     }
   } else {
-    renderResults(els.results, { primary, related }, term);
+    // A related course stays folded away until it is asked for, so a link into
+    // one has to ask for it here rather than after the render.
+    const openRelated = Boolean(wanted) && hasSection(related, wanted);
+    renderResults(els.results, { primary, related, openRelated }, term);
   }
   resetDetail();
+
+  const missed = wanted ? openLinked(wanted, term) : "";
 
   if (hiddenSections || hiddenCourses) {
     // Never hide silently. Say what was removed and offer it back.
@@ -443,11 +494,10 @@ function paint(term = els.term.value) {
   if (!primary.length) {
     // Careful not to claim everything went when related courses may still be
     // on screen underneath this message.
-    setStatus(
-      isActive(filters)
-        ? `No sections match your filters in ${termName(term)}. Loosen one, or clear them.`
-        : `Nothing matched in ${termName(term)}. Try a subject and number, like CSE 2221.`
-    );
+    const nothing = isActive(filters)
+      ? `No sections match your filters in ${termName(term)}. Loosen one, or clear them.`
+      : `Nothing matched in ${termName(term)}. Try a subject and number, like CSE 2221.`;
+    setStatus(`${nothing}${missed ? ` ${missed}` : ""}`);
     return;
   }
 
@@ -456,7 +506,41 @@ function paint(term = els.term.value) {
   // Barrett refreshes once a day, so the numbers are dated, and during a
   // registration window that distinction matters.
   const dated = seatsTerm(term) && seatsUpdated(term) ? ` Seats as of ${formatDate(seatsUpdated(term))}.` : "";
-  setStatus(`${primary.length} ${noun}, ${sections} sections in ${termName(term)}.${dated}`);
+  setStatus(`${primary.length} ${noun}, ${sections} sections in ${termName(term)}.${dated}${missed ? ` ${missed}` : ""}`);
+}
+
+/**
+ * Land a shared link on its section, or say why it is not on screen and give
+ * that back to paint, since the note is not in a live region and the status is.
+ * Returns "" when the link landed.
+ */
+function openLinked(classNumber, term) {
+  const row = els.results.querySelector(`[data-class-number="${classNumber}"]`);
+  if (row) { applySelection(row); return ""; }
+
+  // The results, not the DOM. A section can be in them and still have no row:
+  // the calendar plots primary courses only.
+  const { message, offer } = missOutcome(classNumber, {
+    inResults: sectionIndex.has(classNumber),
+    inSearch: hasSection([...lastResult.primary, ...lastResult.related], classNumber),
+  });
+
+  const note = document.createElement("p");
+  note.className = "hidden-note link-note";
+  note.append(document.createTextNode(`${message} `));
+  if (offer) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = offer === "list" ? "See it in list view" : "Show it anyway";
+    button.addEventListener("click", () => {
+      pendingClass = classNumber;
+      if (offer === "list") setView("list");
+      else { showHidden = true; paint(term); }
+    });
+    note.append(button);
+  }
+  els.results.append(note);
+  return message;
 }
 
 function formatDate(iso) {
@@ -579,6 +663,19 @@ async function init() {
     selectSection(row);
   });
 
+  // An entry is the whole URL, so the filters it was written with come back
+  // with the section rather than leaving the address bar describing a page that
+  // is no longer on screen. The query and the term are not: nothing pushes a
+  // search.
+  window.addEventListener("popstate", () => {
+    const params = new URLSearchParams(location.search);
+    writeFilters(params);
+    showHidden = false;
+    clearSelection();
+    pendingClass = classFromParams(params);
+    paint();
+  });
+
   els.form.addEventListener("submit", (event) => {
     event.preventDefault();
     if (els.submit.getAttribute("aria-disabled") === "true") return;
@@ -609,6 +706,7 @@ async function init() {
   const initialQuery = params.get("q") ?? "";
   els.query.value = initialQuery;
   if (initialQuery.trim()) {
+    pendingClass = classFromParams(params);
     reflectQuery(initialQuery);
     runSearch(initialQuery, els.term.value);
   }

--- a/js/deeplink.js
+++ b/js/deeplink.js
@@ -1,0 +1,54 @@
+// The one section a link can point at.
+//
+// Lives outside app.js so the rules a shared link depends on can be tested
+// without a document.
+
+// A class number and nothing else. Anything else came from a mangled link and
+// must not be quoted back into the page.
+const CLASS_NUMBER = /^\d{1,6}$/;
+
+/** The section a link asks for, or "" when it does not ask for one. */
+export function classFromParams(params) {
+  const raw = (params.get("class") ?? "").trim();
+  return CLASS_NUMBER.test(raw) ? raw : "";
+}
+
+/** Point a URL at one section, or at none. Mutates and returns the URL. */
+export function setClassParam(url, classNumber) {
+  const wanted = String(classNumber ?? "").trim();
+  if (CLASS_NUMBER.test(wanted)) url.searchParams.set("class", wanted);
+  else url.searchParams.delete("class");
+  return url;
+}
+
+/**
+ * Does this URL still describe the search being run? The section a link names
+ * belongs to the search it arrived with, so a retry after an error keeps it and
+ * a search for anything else drops it. A link that names no term rides on
+ * whichever term the page picked.
+ */
+export function sameSearch(url, q, term) {
+  const was = url.searchParams.get("term");
+  return (url.searchParams.get("q") ?? "") === q && (was === null || was === term);
+}
+
+/** Is this class number anywhere in these entries? */
+export function hasSection(entries, classNumber) {
+  return (entries ?? []).some((entry) =>
+    (entry.sections ?? []).some((section) => String(section.classNumber) === String(classNumber)));
+}
+
+/**
+ * Why a link did not land, and what would fix it. Three different answers: the
+ * section is in the results but the calendar does not plot it, the filters
+ * removed it, or it is not in the search at all. Only the first two are one
+ * click from being fixed, and only the third is worth a guess at why.
+ */
+export function missOutcome(classNumber, { inResults, inSearch }) {
+  if (inResults) return { message: `Section ${classNumber} is not on the grid.`, offer: "list" };
+  if (inSearch) return { message: `Section ${classNumber} is hidden by your filters.`, offer: "filters" };
+  return {
+    message: `Section ${classNumber} is not in these results. It may belong to another term, or the search may not have returned it.`,
+    offer: "",
+  };
+}

--- a/js/detail.js
+++ b/js/detail.js
@@ -35,6 +35,48 @@ function figure(value, label, tone) {
   return wrap;
 }
 
+/**
+ * The class number and the two things students do with it: type it into
+ * BuckeyeLink, and send the section to a friend.
+ */
+function sectionHead(section, course, shareUrl) {
+  const head = el("div", "d-head");
+  head.append(el("p", "eyebrow", `Section ${section.classNumber}`));
+
+  // navigator.clipboard is undefined on plain http, so the button is only
+  // drawn where it can do something.
+  if (navigator.clipboard) {
+    const label = "Copy number";
+    const copy = el("button", "d-act", label);
+    copy.type = "button";
+    // The label is the only feedback there is, so it has to be spoken too.
+    copy.setAttribute("aria-live", "polite");
+    let timer = 0;
+    copy.addEventListener("click", async () => {
+      const done = await navigator.clipboard.writeText(String(section.classNumber)).then(() => true, () => false);
+      copy.textContent = done ? "Copied" : "Copy failed";
+      // Restart the flash rather than let the last click's timer cut it short.
+      clearTimeout(timer);
+      timer = setTimeout(() => { copy.textContent = label; }, 1200);
+    });
+    head.append(copy);
+  }
+
+  if (shareUrl && navigator.share) {
+    const share = el("button", "d-act", "Share");
+    share.type = "button";
+    share.addEventListener("click", () => {
+      // Dismissing the sheet rejects, and that is not a failure.
+      navigator.share({
+        title: `${course.subject} ${course.catalogNumber} section ${section.classNumber}`,
+        url: shareUrl,
+      }).catch(() => {});
+    });
+    head.append(share);
+  }
+  return head;
+}
+
 function instructorHeading(people) {
   const heading = el("h2", "d-name");
   people.forEach((person, i) => {
@@ -83,11 +125,11 @@ function alsoTeaches(people, current, entries, term) {
   return wrap;
 }
 
-export function renderDetail({ section, course, term, entries, formatDate }) {
+export function renderDetail({ section, course, term, entries, formatDate, shareUrl }) {
   const wrap = document.createDocumentFragment();
   const people = instructorsOf(section);
 
-  wrap.append(el("p", "eyebrow", `Section ${section.classNumber}`));
+  wrap.append(sectionHead(section, course, shareUrl));
   wrap.append(people.length ? instructorHeading(people) : el("h2", "d-name is-none", "Instructor not listed"));
 
   const units = formatUnits(course);

--- a/js/render.js
+++ b/js/render.js
@@ -169,7 +169,7 @@ export function renderCourse({ course, sections }, term) {
   return article;
 }
 
-export function renderResults(container, { primary, related }, term) {
+export function renderResults(container, { primary, related, openRelated }, term) {
   const nodes = primary.map((entry) => renderCourse(entry, term));
 
   if (related?.length) {
@@ -180,11 +180,15 @@ export function renderResults(container, { primary, related }, term) {
     // these up front costs thousands of nodes to display none of them, so they
     // are built on first open instead.
     let built = false;
-    details.addEventListener("toggle", () => {
-      if (built || !details.open) return;
+    const build = () => {
+      if (built) return;
       built = true;
       details.append(...related.map((entry) => renderCourse(entry, term)));
-    });
+    };
+    details.addEventListener("toggle", () => { if (details.open) build(); });
+    // A link into a related course has to land on a row that exists. The toggle
+    // event is queued rather than fired, so opening alone is not enough.
+    if (openRelated) { details.open = true; build(); }
 
     nodes.push(details);
   }

--- a/tests/deeplink.test.js
+++ b/tests/deeplink.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { classFromParams, setClassParam, sameSearch, hasSection, missOutcome } from "../js/deeplink.js";
+import { entry, section } from "./fixtures.js";
+
+const params = (search) => new URLSearchParams(search);
+const url = (search) => new URL(`https://enesyilmazcode.github.io/Finder/${search}`);
+
+test("a link naming a section gives up its class number", () => {
+  assert.equal(classFromParams(params("?q=CSE+2221&term=1268&class=5168")), "5168");
+});
+
+test("a link naming no section gives up nothing", () => {
+  assert.equal(classFromParams(params("?q=CSE+2221&term=1268")), "");
+  assert.equal(classFromParams(params("?class=")), "");
+});
+
+// The number is quoted back into the page when it is not on screen, so anything
+// that is not a class number has to stop here.
+test("anything that is not a class number is ignored", () => {
+  for (const junk of ["<script>alert(1)</script>", "abc", "51 68", "5168x", "-5168"]) {
+    assert.equal(classFromParams(params(`?class=${encodeURIComponent(junk)}`)), "", junk);
+  }
+});
+
+test("writing a section puts it on the URL", () => {
+  assert.equal(
+    setClassParam(url("?q=CSE+2221&term=1268"), "5168").search,
+    "?q=CSE+2221&term=1268&class=5168"
+  );
+});
+
+test("the number survives a round trip through the URL", () => {
+  const written = setClassParam(url("?q=CSE+2221"), 5168);
+  assert.equal(classFromParams(written.searchParams), "5168");
+});
+
+test("no section means the param goes away rather than sitting there empty", () => {
+  assert.equal(setClassParam(url("?q=CSE+2221&class=5168"), "").search, "?q=CSE+2221");
+  assert.equal(setClassParam(url("?q=CSE+2221&class=5168"), null).search, "?q=CSE+2221");
+});
+
+// The filters are in the URL too, and two of them are repeated keys. Every new
+// search clears the section through here, so clearing has to leave them alone.
+test("writing or clearing the section leaves the rest of the link alone", () => {
+  const search = "?q=CSE+2221&term=1268&day=monday&day=friday&noday=tuesday&rating=4";
+  for (const [wanted, expected] of [["5168", "5168"], ["", null]]) {
+    const written = setClassParam(url(`${search}&class=5169`), wanted);
+    assert.deepEqual(written.searchParams.getAll("day"), ["monday", "friday"]);
+    assert.deepEqual(written.searchParams.getAll("noday"), ["tuesday"]);
+    assert.equal(written.searchParams.get("rating"), "4");
+    assert.equal(written.searchParams.get("class"), expected);
+  }
+});
+
+// The API 429s and times out, so a shared link has to survive the retry that
+// follows. Anything else the student searches for is a different question and
+// the section they were sent goes with the old answer.
+test("a retry is the same search, another query is not", () => {
+  const here = url("?q=CSE+2221&term=1268&class=5168");
+  assert.equal(sameSearch(here, "CSE 2221", "1268"), true);
+  assert.equal(sameSearch(here, "CSE 2231", "1268"), false);
+  assert.equal(sameSearch(here, "CSE 2221", "1264"), false);
+});
+
+test("a link with no term rides on the term the page picked", () => {
+  assert.equal(sameSearch(url("?q=CSE+2221&class=5168"), "CSE 2221", "1268"), true);
+});
+
+const results = () => [
+  entry("CSE", "2221", "Software I", [section(5168), section(5169)]),
+  entry("CSE", "2231", "Software II", [section(5170)]),
+];
+
+test("a class number is found wherever it sits in the results", () => {
+  assert.equal(hasSection(results(), "5168"), true);
+  assert.equal(hasSection(results(), 5170), true);
+  assert.equal(hasSection(results(), "9999"), false);
+  assert.equal(hasSection([], "5168"), false);
+});
+
+// Three different problems, and the fix for a section the grid leaves out is
+// not the fix for one the filters removed. Telling them apart is the whole
+// reason the DOM is not asked whether the section is there.
+test("the three ways a link can miss are told apart", () => {
+  const grid = missOutcome("5168", { inResults: true, inSearch: true });
+  const filtered = missOutcome("5168", { inResults: false, inSearch: true });
+  const gone = missOutcome("5168", { inResults: false, inSearch: false });
+
+  assert.equal(grid.offer, "list");
+  assert.equal(filtered.offer, "filters");
+  assert.equal(gone.offer, "");
+  for (const { message } of [grid, filtered, gone]) assert.match(message, /5168/);
+  assert.match(filtered.message, /filters/);
+});


### PR DESCRIPTION
Closes #64

`syncUrl` wrote ten things into the address bar and the selected section was not one of them, and the whole repo held one history call, a `replaceState`. So a student could share the search but never the section, and the five digit number BuckeyeLink asks for was text you had to drag a mouse over. This adds a `class` param, a `popstate` listener, and a copy button on the detail pane's eyebrow.

Measured in headless Chrome over the DevTools protocol against the real `index.html`, served from this branch, with `content.osu.edu` replaced by a fixed three course answer so the numbers repeat. The DOM is measured, not screenshotted.

```
main, ?q=CSE+2221&term=1268&class=5168
  detail pane          "Pick a section to see the instructor, seats and room."
  selected rows        []
  buttons on the pane  []
  url after clicking section 5168    ?q=CSE+2221&term=1268
  history entries two clicks add     0

this branch, the same link
  detail pane          "Section 5168 Copy number Share Paolo Bucci CSE 2221 ..."
  selected rows        ["5168"]
  buttons on the pane  ["Copy number","Share"]
  url after clicking section 5169    ?q=CSE+2221&term=1268&class=5169
  history entries two clicks add     1
  clipboard after one click on Copy number   "5168"
  the button reads     "Copied", then "Copy number" 1.5s later
```

Back closes the pane rather than leaving the site, and it brings the whole URL back with it, not just the section:

```
after Back      url ?q=CSE+2221&term=1268   pane "Pick a section to see ..."   selected []
after Forward   pane "Section 5169 Copy number Share Paolo Bucci ..."

select 5168, tick "Only rated instructors", press Back
  url                            ?q=CSE+2221&term=1268
  "Only rated" still ticked      false
  hidden by your filters note    []
```

That last one is why `popstate` rewrites the filters instead of only the selection. A pushed entry is a snapshot of the filters that were set when the pane opened, so restoring half of it leaves the address bar advertising an unfiltered view of a filtered screen, and the address bar is the thing students copy.

## Landing needs a row to land on

Documented trap 3 is that ranking is not filtering: any subject and number query returns unrelated courses, and `render.js` parks all of them in a collapsed `<details class="related">` that is not built until someone opens it. So asking the DOM whether the section is on screen answers no for every related course, and the app would blame filters nobody set for a link the app itself hands out through Share. The lookup asks `sectionIndex`, which `paint` builds from the results, and opens the disclosure before the render when the link points inside it.

```
?q=CSE+2221&term=1268&class=5170   (CSE 2231, ranked in as a related course)
  rows in the DOM   ["5168","5169","5170","5171"]
  detail pane       "Section 5170 Copy number Share Tim Long CSE 2231 ..."
  selected rows     ["5170"]
```

## A link that misses says which kind of miss it was

The note goes under the results and the same sentence is appended to the `role="status"` line, so it is announced rather than only drawn:

```
?class=99999
  note    "Section 99999 is not in these results. It may belong to another term,
           or the search may not have returned it."
  status  "1 course, 2 sections in Autumn 2026. Seats as of Aug 20. Section 99999 is
           not in these results. ..."

?class=5168&noday=tuesday
  note    "Section 5168 is hidden by your filters. Show it anyway"
  after the button   pane "Section 5168 ...", selected ["5168"]

calendar view, class=5170
  note    "Section 5170 is not on the grid. See it in list view"
  after the button   pane "Section 5170 ...", selected ["5170"]

?class=%3Cscript%3Ealert(1)%3C/script%3E
  note []   pane unchanged
```

The second sentence of the stale message stops short of naming a cause, because trap 2 says paged search is not repeatable, so the same query that produced the link a minute ago can come back without that section.

Two smaller paths a shared link takes. `docs/osu-api.md` records the 500s and the rate limiting, so the pending section has to outlive one failed search and the retry the student presses, and the phone's Back to results button has to stop the URL naming a pane that is shut:

```
the first search 429s, then the same search runs again
  status  "Ohio State's course service returned an error (429). Try again in a moment."
  after the retry   pane "Section 5168 ...", url ?q=CSE+2221&term=1268&class=5168

phone layout, pane open        view "detail",  url ?q=CSE+2221&term=1268&class=5168
phone layout, Back to results  view "results", url ?q=CSE+2221&term=1268
```

## Tests

149 pass, 0 fail, `node --test` from the repo root. 11 of them are new, in `tests/deeplink.test.js`: reading and writing the param, the digits only guard, leaving the repeated `day` and `noday` keys alone on both a write and a clear, whether a retry counts as the same search, and the three miss outcomes being told apart. Removing `js/deeplink.js` turns that file into 1 fail; making `sameSearch` always agree fails one test, and making `missOutcome` forget the calendar case fails another.

Being straight about the limit: reverting `js/app.js`, `js/detail.js`, `js/render.js` and `css/finder.css` to main leaves the suite at 149 pass. The wiring needs a document and the suite has none, which is the same reason `tests/render.test.js` only covers `groupByInstructor`. Everything above the tests section is browser measurement, not suite coverage.

## Left alone on purpose

- Back does not undo a search or a term switch. Nothing pushes a search, so an entry written before a term change still names the old term. The README limits list says what Back does now.
- Once a link has arrived, clicking a different section replaces rather than pushes, so Back from a friend's link leaves the site instead of returning to their section. Measured: entries added 0. The pane costs one history entry either way, which is the rule that keeps Back from walking back through every section someone looked at.
- `class` is dropped in `syncUrl` rather than only in the term handler the issue named. All seven callers have just changed the result set and the repaint clears the pane, so a surviving `class` would be a lie in the address bar.
- A filtered link shows its own note above the existing "N sections hidden by your filters" note. They count different things, so both stay.
