### PR TITLE
Read every meeting a section holds, not just the first

### DIFF
--- a/css/finder.css
+++ b/css/finder.css
@@ -224,6 +224,7 @@ body {
 .teacher-name,
 .section-when,
 .section-where,
+.section-also,
 .section-who { overflow-wrap: break-word; }
 
 .course-code {
@@ -267,6 +268,7 @@ body {
 .section-when { font-size: 0.95rem; }
 
 .section-where,
+.section-also,
 .section-who {
   grid-column: 2;
   color: var(--mute);
@@ -361,6 +363,7 @@ body {
   .section-number { grid-column: 1; }
   .section-when,
   .section-where,
+  .section-also,
   .section-who { grid-column: 1 / -1; }
   .seats { grid-column: 1 / -1; text-align: left; }
   .course-meta { margin-left: 0; width: 100%; white-space: normal; }

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -44,7 +44,7 @@ function clock(minutes) {
 }
 
 /**
- * Collapse sections into time slots.
+ * Collapse meetings into time slots.
  *
  * Several instructors routinely teach the same course at the same hour. CSE
  * 2321 has three sections at MoWeFr 3:00p. Slicing that column three ways is
@@ -57,17 +57,25 @@ export function buildSlots(entries, term) {
 
   for (const entry of entries) {
     for (const section of entry.sections) {
-      const meeting = (section.meetings ?? []).find((m) => m.startTime && DAYS.some(([k]) => m[k]));
-      if (!meeting) { unscheduled.push({ entry, section }); continue; }
+      // A section can book two rooms for the same hour and must still be named
+      // once. MUSIC 2203.04 meets MoWeFr 4:10p in Weigel 174 and Weigel 100A.
+      const placed = new Set();
 
-      const start = toMinutes(meeting.startTime);
-      const end = toMinutes(meeting.endTime) ?? (start == null ? null : start + 55);
-      if (start == null) { unscheduled.push({ entry, section }); continue; }
+      for (const meeting of section.meetings ?? []) {
+        if (!DAYS.some(([key]) => meeting[key])) continue;
+        const start = toMinutes(meeting.startTime);
+        if (start == null) continue;
+        const end = toMinutes(meeting.endTime) ?? start + 55;
 
-      const days = DAYS.filter(([key]) => meeting[key]).map(([key]) => key);
-      const id = `${days.join(",")}|${start}|${end}`;
-      if (!slots.has(id)) slots.set(id, { id, days, start, end, items: [] });
-      slots.get(id).items.push({ entry, section, seats: seatsFor(section.classNumber, term) });
+        const days = DAYS.filter(([key]) => meeting[key]).map(([key]) => key);
+        const id = `${days.join(",")}|${start}|${end}`;
+        if (placed.has(id)) continue;
+        placed.add(id);
+        if (!slots.has(id)) slots.set(id, { id, days, start, end, items: [] });
+        slots.get(id).items.push({ entry, section, seats: seatsFor(section.classNumber, term) });
+      }
+
+      if (!placed.size) unscheduled.push({ entry, section });
     }
   }
 

--- a/js/detail.js
+++ b/js/detail.js
@@ -1,7 +1,7 @@
 // The right pane. Everything here already exists in memory by the time a
 // section is selected, so nothing fetches.
 
-import { formatWhen, formatUnits, instructorsOf } from "./format.js";
+import { formatWhen, formatUnits, instructorsOf, distinctMeetings } from "./format.js";
 import { ratingFor, searchUrl, profileUrl } from "./ratings.js";
 import { seatsFor, seatsUpdated } from "./seats.js";
 import { isIndividualStudy } from "./rank.js";
@@ -130,11 +130,15 @@ export function renderDetail({ section, course, term, entries, formatDate }) {
   }
   wrap.append(seatBlock);
 
-  const meeting = section.meetings?.[0] ?? null;
   const meets = block("Meets");
-  meets.append(row("When", formatWhen(meeting)));
-  const room = meeting?.buildingDescription || meeting?.facilityDescription;
-  if (room) meets.append(row("Room", room));
+  // The [null] keeps a section with nothing scheduled printing Time to be
+  // announced. See #82.
+  const meetings = distinctMeetings(section);
+  for (const meeting of meetings.length ? meetings : [null]) {
+    meets.append(row("When", formatWhen(meeting)));
+    const room = meeting?.buildingDescription || meeting?.facilityDescription;
+    if (room) meets.append(row("Room", room));
+  }
   if (section.instructionMode) meets.append(row("Mode", section.instructionMode));
   if (section.startDate && section.endDate) meets.append(row("Runs", `${section.startDate} to ${section.endDate}`));
   wrap.append(meets);

--- a/js/filters.js
+++ b/js/filters.js
@@ -74,8 +74,9 @@ function keepSection(section, filters) {
     if (filters.avoid.length && filters.avoid.some((d) => meetsOn.has(d))) return false;
   }
 
-  const meeting = section.meetings?.find((m) => m.startTime) ?? null;
-  if (meeting) {
+  // A lab that meets Tuesday morning and again Thursday afternoon was surviving
+  // "ends no later than noon" on the strength of its Tuesday half. See #82.
+  for (const meeting of section.meetings ?? []) {
     const start = toMinutes(meeting.startTime);
     const end = toMinutes(meeting.endTime) ?? start;
     if (filters.from && start != null && start < Number(filters.from)) return false;

--- a/js/format.js
+++ b/js/format.js
@@ -48,3 +48,24 @@ export function instructorsOf(section) {
   }
   return [...seen.values()];
 }
+
+/**
+ * A section's meetings with the API's repeats dropped.
+ *
+ * Upstream lists the same pattern once per room label it holds for the class.
+ * CSE 2112 class 8823 comes back with ten meetings that describe three, and
+ * CHEM 8893 class 24426 with eight that describe one.
+ */
+export function distinctMeetings(section) {
+  const seen = new Set();
+  return (section?.meetings ?? []).filter((meeting) => {
+    const key = [
+      formatWhen(meeting),
+      meeting?.buildingDescriptionShort, meeting?.facilityDescriptionShort,
+      meeting?.buildingDescription, meeting?.facilityDescription,
+    ].join("|");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/js/render.js
+++ b/js/render.js
@@ -6,7 +6,7 @@
 // enrollment figure per course and repeats it onto every section, so rendering
 // it per section would tell students a full section is open. See #13.
 
-import { formatWhen, formatPlace, formatUnits, instructorsOf } from "./format.js";
+import { formatWhen, formatPlace, formatUnits, instructorsOf, distinctMeetings } from "./format.js";
 import { ratingFor, searchUrl, profileUrl } from "./ratings.js";
 import { seatsFor } from "./seats.js";
 
@@ -108,7 +108,8 @@ export function renderSection(section, term) {
   li.tabIndex = 0;
   li.setAttribute("role", "button");
   li.dataset.classNumber = String(section.classNumber ?? "");
-  const meeting = section.meetings?.[0] ?? null;
+  const meetings = distinctMeetings(section);
+  const meeting = meetings[0] ?? null;
 
   li.append(el("span", "section-number", section.classNumber ?? ""));
 
@@ -118,6 +119,11 @@ export function renderSection(section, term) {
   li.append(when);
 
   li.append(el("span", "section-where", formatPlace(meeting, section)));
+
+  // See #82.
+  for (const extra of meetings.slice(1)) {
+    li.append(el("span", "section-also", `${formatWhen(extra)} · ${formatPlace(extra, section)}`));
+  }
 
   // Absent means unknown, never zero. A section with no snapshot row simply
   // shows nothing rather than implying it is empty.

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -96,7 +96,7 @@ test("a missing end time falls back to a 55 minute class", () => {
   assert.equal(slots[0].end, 955);
 });
 
-test("buildSlots picks the first meeting that has both a day and a time", () => {
+test("a meeting with no day of the week cannot be placed on the grid", () => {
   const entries = [
     entry("CSE", "2321", "Foundations 1", [
       section(1001, {
@@ -107,9 +107,50 @@ test("buildSlots picks the first meeting that has both a day and a time", () => 
       }),
     ]),
   ];
-  const { slots } = buildSlots(entries, TERM);
+  const { slots, unscheduled } = buildSlots(entries, TERM);
   assert.equal(slots.length, 1);
   assert.equal(slots[0].start, 900);
+  assert.equal(unscheduled.length, 0, "the section is on the grid, so it is not also listed as unscheduled");
+});
+
+// Regression, #82. Class 15671 in Autumn 2026 meets Tu 8:00a-10:55a in CE 310
+// and again Th 4:10p-5:05p in MP 1040, and only the Tuesday half was drawn.
+test("regression #82: every meeting of a section gets its own slot", () => {
+  const entries = [
+    entry("CHEM", "1110", "Elementary Chemistry", [
+      section(1001, {
+        meetings: [
+          meeting(["tuesday"], "8:00 AM", "10:55 AM", [person("Mehr Bindra")]),
+          meeting(["thursday"], "4:10 PM", "5:05 PM", [person("Laurenda Lamboni")]),
+        ],
+      }),
+    ]),
+  ];
+  const { slots, unscheduled } = buildSlots(entries, TERM);
+  assert.deepEqual(
+    slots.map((s) => [s.days.join(","), s.start, s.end]),
+    [["tuesday", 480, 655], ["thursday", 970, 1025]]
+  );
+  for (const slot of slots) assert.equal(slot.items.length, 1);
+  assert.equal(unscheduled.length, 0);
+});
+
+// Regression, #82. MUSIC 2203.04 section 19215 meets MoWeFr 4:10p-5:05p in two
+// Weigel rooms at once, which is two meetings for one block on the grid.
+test("regression #82: a section meeting twice in the same hour is listed once", () => {
+  const entries = [
+    entry("MUSIC", "2203.04", "Men's Glee Club", [
+      section(1001, {
+        meetings: [
+          meeting(MWF, "4:10 PM", "5:05 PM", [person("Robert James Ward")], { buildingDescriptionShort: "WG 174" }),
+          meeting(MWF, "4:10 PM", "5:05 PM", [person("Robert James Ward")], { buildingDescriptionShort: "WG 100A" }),
+        ],
+      }),
+    ]),
+  ];
+  const { slots } = buildSlots(entries, TERM);
+  assert.equal(slots.length, 1);
+  assert.equal(slots[0].items.length, 1);
 });
 
 test("each item carries the seats for its own section", () => {

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { DEFAULTS, toMinutes, isActive, applyFilters } from "../js/filters.js";
-import { entry, section, taught } from "./fixtures.js";
+import { entry, meeting, person, section, taught } from "./fixtures.js";
 import { withRatings, withSeats } from "./helpers.js";
 
 // filters.js reads seats and ratings through the shared module state, so the
@@ -181,6 +181,35 @@ test("applyFilters counts what it removed", () => {
   assert.equal(entries.length, 1, "the course with nothing left drops out");
   assert.equal(hiddenCourses, 1);
   assert.equal(hiddenSections, 2, "one TuTh section in each course");
+});
+
+// Regression, #82. Class 15671 in Autumn 2026 meets Tu 8:00a-10:55a in CE 310
+// and again Th 4:10p-5:05p in MP 1040. Reading the Tuesday half alone let it
+// survive an "ends no later than noon" filter by five hours.
+test("regression #82: a later meeting outside the window fails the filter", () => {
+  const split = () => entry("CHEM", "1110", "Elementary Chemistry", [
+    section(6001, {
+      meetings: [
+        meeting(["tuesday"], "8:00 AM", "10:55 AM", [person("Mehr Bindra")]),
+        meeting(["thursday"], "4:10 PM", "5:05 PM", [person("Laurenda Lamboni")]),
+      ],
+    }),
+  ]);
+  assert.equal(applyFilters([split()], filters({ to: "720" })).entries.length, 0, "Thursday runs to 5:05p");
+  assert.equal(applyFilters([split()], filters({ from: "600" })).entries.length, 0, "Tuesday starts at 8:00a");
+  assert.equal(applyFilters([split()], filters({ from: "480", to: "1025" })).entries.length, 1, "both fit");
+});
+
+test("regression #82: a meeting with no time still cannot fail a time filter", () => {
+  const partial = entry("CHEM", "1110", "Elementary Chemistry", [
+    section(6002, {
+      meetings: [
+        meeting(["monday"], null, null, [person("Mehr Bindra")]),
+        meeting(["tuesday"], "8:00 AM", "10:55 AM", [person("Mehr Bindra")]),
+      ],
+    }),
+  ]);
+  assert.equal(applyFilters([partial], filters({ from: "480", to: "720" })).entries.length, 1);
 });
 
 test("applyFilters does not mutate the entries it was given", () => {

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { formatDays, formatTime, formatWhen, formatPlace, formatUnits, instructorsOf } from "../js/format.js";
+import { formatDays, formatTime, formatWhen, formatPlace, formatUnits, instructorsOf, distinctMeetings } from "../js/format.js";
 import { meeting, person, section } from "./fixtures.js";
 
 const DASH = "\u2013";
@@ -109,4 +109,50 @@ test("instructorsOf survives missing meetings and missing instructors", () => {
   assert.deepEqual(instructorsOf({ classNumber: 1005 }), []);
   assert.deepEqual(instructorsOf(null), []);
   assert.deepEqual(instructorsOf({ meetings: [{ startTime: "9:00 AM" }] }), []);
+});
+
+// Regression, #82. CSE 2112 class 8823 comes back with ten meetings for one
+// Tuesday class, alternating the room label between BE 120 and Baker Syst.
+// Printing a line per meeting turned that row into nine repeats.
+test("regression #82: a pattern repeated per room label counts once", () => {
+  const room = (short, full) => ({ buildingDescriptionShort: short, buildingDescription: full });
+  const s = section(8823, {
+    meetings: [
+      meeting(["tuesday"], "2:20 PM", "3:40 PM", [], room("BE 120", "Baker Systems 120")),
+      meeting(["tuesday"], "2:20 PM", "3:40 PM", [], room("Baker Syst", "Baker Systems 470")),
+      meeting(["tuesday"], "2:20 PM", "3:40 PM", [], room("BE 120", "Baker Systems 120")),
+      meeting(["tuesday"], "2:20 PM", "3:20 PM", [], room("Baker Syst", "Baker Systems 470")),
+    ],
+  });
+  assert.deepEqual(
+    distinctMeetings(s).map((m) => `${formatWhen(m)} ${m.buildingDescriptionShort}`),
+    [`Tu 2:20p${DASH}3:40p BE 120`, `Tu 2:20p${DASH}3:40p Baker Syst`, `Tu 2:20p${DASH}3:20p Baker Syst`]
+  );
+});
+
+// Regression, #82. Class 15671 really does meet twice, and MUSIC 2203.04
+// section 19215 really is booked into two Weigel rooms for the same hour.
+// Neither may be collapsed.
+test("regression #82: meetings that differ in time or room are all kept", () => {
+  const split = section(15671, {
+    meetings: [
+      meeting(["tuesday"], "8:00 AM", "10:55 AM", [], { buildingDescriptionShort: "CE 310" }),
+      meeting(["thursday"], "4:10 PM", "5:05 PM", [], { buildingDescriptionShort: "MP 1040" }),
+    ],
+  });
+  assert.equal(distinctMeetings(split).length, 2);
+
+  const twoRooms = section(19215, {
+    meetings: [
+      meeting(["monday", "wednesday", "friday"], "4:10 PM", "5:05 PM", [], { buildingDescriptionShort: "WG 174" }),
+      meeting(["monday", "wednesday", "friday"], "4:10 PM", "5:05 PM", [], { buildingDescriptionShort: "WG 100A" }),
+    ],
+  });
+  assert.equal(distinctMeetings(twoRooms).length, 2);
+});
+
+test("distinctMeetings survives missing meetings", () => {
+  assert.deepEqual(distinctMeetings(section(1001)), []);
+  assert.deepEqual(distinctMeetings({ classNumber: 1002 }), []);
+  assert.deepEqual(distinctMeetings(null), []);
 });


### PR DESCRIPTION
Closes #82

Four places each pulled a single meeting off a section and treated it as the whole schedule: `render.js` and `detail.js` took `meetings[0]`, `calendar.js` took the first with a day and a time, `filters.js` took the first with a start time. Nothing upstream says a section has one meeting, so the second half of a split class was invisible everywhere and was never judged by the time filter.

Walking the array is only half of it. OSU lists the same pattern once per room label it holds, so a naive loop prints the same line up to nine times on one row. `distinctMeetings` in `format.js` drops those repeats before either renderer sees them, which is the job `instructorsOf` two functions above it already does for the names hanging off every meeting.

## What the rows actually render

Measured in headless Chrome against the real `css/finder.css`, reading `getBoundingClientRect` out of the DOM, on live term 1268 data. The middle column is this branch before the dedupe was added, which is what made the dedupe necessary.

```
class 15671, Chemistry 1110, 2 meetings in the API
  main:
    Tu 8:00a-10:55a Laboratory · CE 310
    [row 71px, detail pane 1 When/Room pair]
  walking them raw:
    Tu 8:00a-10:55a Laboratory · CE 310
    Th 4:10p-5:05p · MP 1040
    [row 95px, detail pane 2 When/Room pairs]
  this branch:
    Tu 8:00a-10:55a Laboratory · CE 310
    Th 4:10p-5:05p · MP 1040
    [row 95px, detail pane 2 When/Room pairs]

class 8823, CSE 2112, 10 meetings in the API
  main:
    Tu 2:20p-3:40p Laboratory · BE 120
    [row 71px, detail pane 1 When/Room pair]
  walking them raw:
    Tu 2:20p-3:40p Laboratory · BE 120
    Tu 2:20p-3:40p · Baker Syst
    Tu 2:20p-3:40p · BE 120
    Tu 2:20p-3:40p · Baker Syst
    Tu 2:20p-3:40p · BE 120
    Tu 2:20p-3:40p · Baker Syst
    Tu 2:20p-3:40p · BE 120
    Tu 2:20p-3:40p · Baker Syst
    Tu 2:20p-3:40p · BE 120
    Tu 2:20p-3:20p · Baker Syst
    [row 290px, detail pane 10 When/Room pairs]
  this branch:
    Tu 2:20p-3:40p Laboratory · BE 120
    Tu 2:20p-3:40p · Baker Syst
    Tu 2:20p-3:20p · Baker Syst
    [row 119px, detail pane 3 When/Room pairs]
```

Across 5582 distinct sections pulled live from twelve subjects, the raw loop emits 226 extra lines and 33 of them repeat a line already on the same row, on six sections. The dedupe removes all 33 and loses no distinct line at either site. After it, the most distinct meeting lines any section in that sample carries is 4, so printing them all is fine and the "+N more" the issue offered as an alternative is not needed.

## The filter and the calendar

One live CHEM 1210 pull for Autumn 2026, driven through the repo's own `filterCourses`, `applyFilters` and `buildSlots`, once per source tree. The ground truth is written separately: every meeting with a readable start must sit inside the window.

```
=== main ===
  to=720 (ends no later than noon): 123 sections kept, 13 of them run outside the window
    e.g. class 15616
  from=540 to=1080: 222 sections kept, 11 of them run outside the window
    e.g. class 15613
  calendar: 363 of 493 distinct meetings placed, 130 dropped, 76 slots, 7 unscheduled
=== branch ===
  to=720 (ends no later than noon): 110 sections kept, 0 of them run outside the window
  from=540 to=1080: 211 sections kept, 0 of them run outside the window
  calendar: 493 of 493 distinct meetings placed, 0 dropped, 97 slots, 7 unscheduled
```

The two kept counts fall by exactly the number of wrong survivors, 13 and 11, so nothing correct was filtered out along with them. Unscheduled is unchanged at 7.

## Tests

138 on main, 145 here. Putting main's `calendar.js`, `detail.js`, `filters.js` and `render.js` back over this branch's, keeping the new `format.js` so the suite still links, gives:

```
not ok 26 - regression #82: every meeting of a section gets its own slot
not ok 59 - regression #82: a later meeting outside the window fails the filter
# tests 145
# pass 143
# fail 2
```

Revert `format.js` as well and `format.test.js` stops linking at all, since `distinctMeetings` does not exist on main. The other five new or changed assertions pass on main, which makes them guards rather than fail-then-pass tests, so each was mutation-tested against the one line it covers:

```
key distinctMeetings on the time alone      -> "a pattern repeated per room label counts once" fails
                                            -> "meetings that differ in time or room are all kept" fails
drop the dedupe, keep the export            -> "a pattern repeated per room label counts once" fails
drop `start != null` in keepSection         -> "a meeting with no time still cannot fail a time filter" fails
drop `if (placed.has(id)) continue`         -> "a section meeting twice in the same hour is listed once" fails
push to unscheduled on a dayless meeting    -> "a meeting with no day of the week cannot be placed" fails
```

`render.js` and `detail.js` still have no node:test coverage. `render.test.js` says DOM is out of scope and there is no detail test file, so those two halves were verified only by the browser probe above, which is deleted. The durable regression tests cover `format.js`, `filters.js` and `calendar.js`.

One test was renamed, not removed. "buildSlots picks the first meeting that has both a day and a time" described behaviour this issue deletes. Its fixture is unchanged; it is now "a meeting with no day of the week cannot be placed on the grid" and additionally asserts the section is not double-listed as unscheduled.

## What I did not do

The issue's order note holds. This makes `buildSlots` emit a slot per meeting, which took that CHEM 1210 pull from 76 slots holding 363 items to 97 holding 493, so the burying #83 is about gets measurably worse until #115 lands. Nothing is silently clipped, a slot that overflows still says "+N more, see list view", but if the two are meant to ship together this is the one that should wait.

Three sections in the 5582 now draw two overlapping blocks on the same day, because their own meeting rows disagree with each other about the time: class 8823 ends at both 3:40p and 3:20p, class 23599 at both 5:15p and 5:10p, and class 22786 starts at both 1:50p and 2:20p. Collapsing those would mean picking which time upstream meant, which the data does not settle, so they render as the contradiction they are.

The seat count sits in column 3 with an auto row, so on a multi-line row it lands beside the last meeting rather than beside the class number. That was already true of the two-line rows on main and pinning it is a design call this issue did not ask for.
