### PR TITLE
Filter out the hours a student is already busy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,22 +39,23 @@ equivalent piece to fail. It is a folder of files on GitHub Pages.
 |  Starts after |     5477  TuTh 4:10p   DL 357   40/40 +1  | SEATS           |
 |  Ends before  |     5478  WeFr 4:10p   DL 280   40/40 +1  | [========  ]    |
 |               |   ...                                     | Enrolled 32/40  |
-| INSTRUCTOR    |   Paolo Bucci  3.0 (147)                  | Waitlist none   |
-|  Min rating   |     5168  TuTh 8:00a   DL 357   32/40     | As of  Aug 19   |
-|  Only rated   |     5169  WeFr 8:00a   DL 280   32/40     |                 |
-|               |   ...                                     | MEETS           |
-| AVAILABILITY  |   Naomi Lynn Zweben  4.9 (44)             | TuTh 8:00a      |
-|  Hide full    |     4831  TuTh 11:30a  DL 357   41/40 +2  | Dreese Lab 357  |
-|  Hide online  |     4833  TuTh 12:40p  DL 357   40/40 +1  |                 |
-|               |                                           | ALSO TEACHES    |
-|               | > Show 6 related courses                  | ABOUT           |
+| BUSY TIMES    |   Paolo Bucci  3.0 (147)                  | Waitlist none   |
+|  TuTh 9:35a x |     5168  TuTh 8:00a   DL 357   32/40     | As of  Aug 19   |
+|               |     5169  WeFr 8:00a   DL 280   32/40     |                 |
+| INSTRUCTOR    |   ...                                     | MEETS           |
+|  Min rating   |   Naomi Lynn Zweben  4.9 (44)             | TuTh 8:00a      |
+|  Only rated   |     4831  TuTh 11:30a  DL 357   41/40 +2  | Dreese Lab 357  |
+|               |     4833  TuTh 12:40p  DL 357   40/40 +1  |                 |
+| AVAILABILITY  |                                           | ALSO TEACHES    |
+|  Hide full    | > Show 6 related courses                  | ABOUT           |
+|  Hide online  |                                           |                 |
 +---------------+-------------------------------------------+-----------------+
 ```
 
 On a phone the filters move behind a Filters button and the right pane
 takes over the screen, so you get the same three panes one at a time.
 
-- **Filters.** Days, time window, minimum rating, hide full, hide online.
+- **Filters.** Days, time window, busy times, minimum rating, hide full, hide online.
 - **Middle.** The same sections as a list by instructor, or on a week grid.
 - **Right pane.** Rating, difficulty, take-again, seats, room, description.
 

--- a/css/finder.css
+++ b/css/finder.css
@@ -603,7 +603,8 @@ body {
   color: var(--mute);
 }
 
-.f-day[data-state="require"] span {
+.f-day[data-state="require"] span,
+.f-day[data-state="busy"] span {
   background: var(--scarlet);
   border-color: var(--scarlet);
   color: var(--paper);
@@ -649,7 +650,8 @@ body {
 
 .f-check input { accent-color: var(--scarlet); width: 0.95rem; height: 0.95rem; }
 
-.f-clear {
+.f-clear,
+.f-add {
   font: inherit;
   font-size: 0.8rem;
   width: 100%;
@@ -661,7 +663,32 @@ body {
   cursor: pointer;
 }
 
-.f-clear:hover { color: var(--ink); border-color: var(--ink); }
+.f-clear:hover,
+.f-add:hover { color: var(--ink); border-color: var(--ink); }
+
+.f-add { margin-top: 0.6rem; }
+
+.f-span { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; }
+
+.f-chips { list-style: none; display: flex; flex-wrap: wrap; gap: 0.3rem; margin: 0.6rem 0 0; padding: 0; }
+
+.f-chip {
+  font: inherit;
+  font-family: var(--data);
+  font-size: 0.72rem;
+  padding: 0.3rem 0.45rem;
+  border: 1px solid var(--field);
+  border-radius: var(--radius);
+  background: var(--wash);
+  color: inherit;
+  cursor: pointer;
+}
+
+/* Decoration. The button already carries a label that says it removes. */
+.f-chip::after { content: " ×"; color: var(--mute); }
+
+.f-chip:hover { color: var(--scarlet); border-color: var(--scarlet); }
+.f-chip:focus-visible { outline: 2px solid var(--scarlet); outline-offset: 2px; }
 
 .hidden-note {
   border: 1px dashed var(--rule);

--- a/index.html
+++ b/index.html
@@ -93,6 +93,35 @@
           </select>
         </fieldset>
 
+        <fieldset class="f-set" id="f-busy">
+          <legend class="eyebrow">Busy times</legend>
+          <div class="f-days" id="f-busy-days" role="group" aria-label="Days you are busy">
+            <button type="button" class="f-day" data-day="monday" data-state="any"
+                    aria-pressed="false" aria-label="Monday"><span>Mo</span></button>
+            <button type="button" class="f-day" data-day="tuesday" data-state="any"
+                    aria-pressed="false" aria-label="Tuesday"><span>Tu</span></button>
+            <button type="button" class="f-day" data-day="wednesday" data-state="any"
+                    aria-pressed="false" aria-label="Wednesday"><span>We</span></button>
+            <button type="button" class="f-day" data-day="thursday" data-state="any"
+                    aria-pressed="false" aria-label="Thursday"><span>Th</span></button>
+            <button type="button" class="f-day" data-day="friday" data-state="any"
+                    aria-pressed="false" aria-label="Friday"><span>Fr</span></button>
+          </div>
+          <div class="f-span">
+            <div>
+              <label class="f-label" for="f-busy-start">From</label>
+              <input class="f-ctl" id="f-busy-start" name="busyStart" type="time">
+            </div>
+            <div>
+              <label class="f-label" for="f-busy-end">To</label>
+              <input class="f-ctl" id="f-busy-end" name="busyEnd" type="time">
+            </div>
+          </div>
+          <button class="f-add" id="f-busy-add" type="button" aria-describedby="f-busy-hint">Add busy time</button>
+          <ul class="f-chips" id="f-busy-list"></ul>
+          <p class="f-hint" id="f-busy-hint" aria-live="polite">Block out a class you already have. Sections that overlap it drop out.</p>
+        </fieldset>
+
         <fieldset class="f-set">
           <legend class="eyebrow">Instructor</legend>
           <label class="f-label" for="f-rating">Minimum rating</label>

--- a/js/app.js
+++ b/js/app.js
@@ -4,7 +4,8 @@ import { renderResults } from "./render.js";
 import { loadRatings, topRated, ratedCount, profileUrl } from "./ratings.js";
 import { loadSeats, seatsTerm, seatsUpdated, seatsSectionCount } from "./seats.js";
 import { renderDetail } from "./detail.js";
-import { applyFilters, isActive, DEFAULTS } from "./filters.js";
+import { applyFilters, isActive, parseBusy, formatBusy, DEFAULTS } from "./filters.js";
+import { busyLabel } from "./format.js";
 import { renderCalendar } from "./calendar.js";
 import { loadCourses, subjectsFor, subjectLabel, coursesFor, codeFromInput, isLoaded } from "./courses.js";
 
@@ -18,6 +19,12 @@ const els = {
   detailBack: document.querySelector("#detail-back"),
   filters: document.querySelector("#filters"),
   days: document.querySelector("#f-days"),
+  busyDays: document.querySelector("#f-busy-days"),
+  busyStart: document.querySelector("#f-busy-start"),
+  busyEnd: document.querySelector("#f-busy-end"),
+  busyAdd: document.querySelector("#f-busy-add"),
+  busyList: document.querySelector("#f-busy-list"),
+  busyHint: document.querySelector("#f-busy-hint"),
   subject: document.querySelector("#p-subject"),
   number: document.querySelector("#p-number"),
   subjectList: document.querySelector("#subject-list"),
@@ -78,6 +85,71 @@ function setDayState(button, state) {
   button.setAttribute("aria-label", `${day}: ${said}`);
 }
 
+// Busy blocks are chips in the rail, never clicks on the calendar. A clickable
+// grid reads as an invitation to mark the overlaps too, and marking overlaps is
+// a schedule builder. Finder searches, it does not plan.
+
+const BUSY_HINT = els.busyHint.textContent;
+
+function setBusyDay(button, busy) {
+  button.dataset.state = busy ? "busy" : "any";
+  button.setAttribute("aria-pressed", String(busy));
+}
+
+/** Blocks are read back off their chips, the way day states are read off theirs. */
+function busyBlocks() {
+  return [...els.busyList.querySelectorAll(".f-chip")].map((chip) => parseBusy(chip.dataset.busy)).filter(Boolean);
+}
+
+/** Two ways of writing the same block, "TuTh" and "ThTu", are one chip. */
+function uniqueBlocks(blocks) {
+  return [...new Map(blocks.map((b) => [formatBusy(b), b])).values()];
+}
+
+function renderBusy(blocks) {
+  els.busyList.replaceChildren(...uniqueBlocks(blocks).map((block) => {
+    const label = busyLabel(block);
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = "f-chip";
+    chip.dataset.busy = formatBusy(block);
+    chip.textContent = label;
+    chip.setAttribute("aria-label", `Remove busy time ${label}`);
+    const item = document.createElement("li");
+    item.append(chip);
+    return item;
+  }));
+}
+
+/** "09:35" from a time field to minutes past midnight. */
+function fieldMinutes(value) {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value ?? "");
+  return match ? Number(match[1]) * 60 + Number(match[2]) : null;
+}
+
+function resetBusyFields() {
+  for (const button of els.busyDays.querySelectorAll(".f-day")) setBusyDay(button, false);
+  els.busyStart.value = "";
+  els.busyEnd.value = "";
+  els.busyHint.textContent = BUSY_HINT;
+}
+
+function addBusy() {
+  const days = [...els.busyDays.querySelectorAll('.f-day[data-state="busy"]')].map((b) => b.dataset.day);
+  const start = fieldMinutes(els.busyStart.value);
+  const end = fieldMinutes(els.busyEnd.value);
+  if (!days.length || start == null || end == null || start >= end) {
+    els.busyHint.textContent = "Pick at least one day, and a start before the end.";
+    return;
+  }
+
+  renderBusy([...busyBlocks(), { days, start, end }]);
+  resetBusyFields();
+  showHidden = false;
+  syncUrl(els.query.value, els.term.value);
+  paint();
+}
+
 function readFilters() {
   const data = new FormData(els.filters);
   const { required, avoided } = dayStates();
@@ -85,6 +157,7 @@ function readFilters() {
     ...DEFAULTS,
     days: required,
     avoid: avoided,
+    busy: busyBlocks(),
     from: data.get("from") ?? "",
     to: data.get("to") ?? "",
     rating: data.get("rating") ?? "",
@@ -102,6 +175,7 @@ function writeFilters(params) {
     const day = button.dataset.day;
     setDayState(button, required.includes(day) ? "require" : avoided.includes(day) ? "avoid" : "any");
   }
+  renderBusy(params.getAll("busy").map(parseBusy).filter(Boolean));
   els.filters.from.value = params.get("from") ?? "";
   els.filters.to.value = params.get("to") ?? "";
   els.filters.rating.value = params.get("rating") ?? "";
@@ -285,6 +359,8 @@ function syncUrl(q, term) {
   url.searchParams.delete("noday");
   for (const day of f.days) url.searchParams.append("day", day);
   for (const day of f.avoid) url.searchParams.append("noday", day);
+  url.searchParams.delete("busy");
+  for (const block of f.busy) url.searchParams.append("busy", formatBusy(block));
   for (const [key, value] of [["from", f.from], ["to", f.to], ["rating", f.rating]]) {
     if (value) url.searchParams.set(key, value); else url.searchParams.delete(key);
   }
@@ -530,7 +606,37 @@ async function init() {
   els.viewList.addEventListener("click", () => setView("list"));
   els.viewCal.addEventListener("click", () => setView("calendar"));
 
-  els.filters.addEventListener("change", () => {
+  els.filters.addEventListener("change", (event) => {
+    // The busy fields are not a filter until Add is pressed.
+    if (event.target.closest("#f-busy")) return;
+    showHidden = false;
+    syncUrl(els.query.value, els.term.value);
+    paint();
+  });
+
+  els.busyAdd.addEventListener("click", addBusy);
+
+  // Enter in a busy field adds. Making Add a submit button would do this for
+  // free, but it would also make it the default button for the whole rail.
+  for (const field of [els.busyStart, els.busyEnd]) {
+    field.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter") return;
+      event.preventDefault();
+      addBusy();
+    });
+  }
+
+  els.busyDays.addEventListener("click", (event) => {
+    const button = event.target.closest(".f-day");
+    if (button) setBusyDay(button, button.dataset.state !== "busy");
+  });
+
+  els.busyList.addEventListener("click", (event) => {
+    const chip = event.target.closest(".f-chip");
+    if (!chip) return;
+    const item = chip.closest("li");
+    (item.nextElementSibling?.querySelector(".f-chip") ?? els.busyAdd).focus();
+    item.remove();
     showHidden = false;
     syncUrl(els.query.value, els.term.value);
     paint();
@@ -548,6 +654,8 @@ async function init() {
   els.clear.addEventListener("click", () => {
     els.filters.reset();
     for (const button of els.days.querySelectorAll(".f-day")) setDayState(button, "any");
+    renderBusy([]);
+    resetBusyFields();
     showHidden = false;
     syncUrl(els.query.value, els.term.value);
     paint();

--- a/js/filters.js
+++ b/js/filters.js
@@ -1,7 +1,7 @@
 // Client-side filtering over results already fetched. No filter triggers a
 // network request, so dragging a time slider does not hammer OSU.
 
-import { instructorsOf } from "./format.js";
+import { dayCodes, instructorsOf } from "./format.js";
 import { ratingFor } from "./ratings.js";
 import { seatsFor } from "./seats.js";
 
@@ -10,6 +10,7 @@ const DAY_KEYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "satur
 export const DEFAULTS = {
   days: [],          // days that must be met; empty means no constraint
   avoid: [],         // days that must not be met
+  busy: [],          // {days, start, end} blocks nothing may overlap
   from: "",          // earliest start, as minutes past midnight
   to: "",            // latest end
   rating: "",        // minimum average rating
@@ -25,6 +26,43 @@ export function toMinutes(text) {
   let hour = Number(match[1]) % 12;
   if (match[3].toLowerCase() === "p") hour += 12;
   return hour * 60 + Number(match[2]);
+}
+
+/**
+ * A busy block from its URL form, "TuTh-575-655". Returns null when unparseable.
+ *
+ * Minutes past midnight, the same as `from` and `to`, and dashes rather than
+ * colons so a shared link does not come out full of %3A.
+ */
+export function parseBusy(text) {
+  const match = /^([A-Za-z]+)-(\d{1,4})-(\d{1,4})$/.exec(String(text ?? "").trim());
+  if (!match) return null;
+  if (match[1].length % 2) return null;
+  const codes = match[1].match(/.{2}/g);
+
+  const wanted = new Set();
+  for (const code of codes) {
+    const key = DAY_KEYS.find((k) => dayCodes([k]).toLowerCase() === code.toLowerCase());
+    if (!key) return null;
+    wanted.add(key);
+  }
+  const days = DAY_KEYS.filter((key) => wanted.has(key));
+
+  const start = Number(match[2]);
+  const end = Number(match[3]);
+  if (start >= end || end > 1440) return null;
+  return { days, start, end };
+}
+
+export function formatBusy(block) {
+  return `${dayCodes(block.days)}-${block.start}-${block.end}`;
+}
+
+/** Half open, so a class that ends exactly when a block starts is not a clash. */
+function overlaps(start, end, block) {
+  // No end time means the class is only known to be in progress at its start.
+  const stop = end > start ? end : start + 1;
+  return start < block.end && stop > block.start;
 }
 
 function sectionDays(section) {
@@ -74,12 +112,15 @@ function keepSection(section, filters) {
     if (filters.avoid.length && filters.avoid.some((d) => meetsOn.has(d))) return false;
   }
 
-  const meeting = section.meetings?.find((m) => m.startTime) ?? null;
-  if (meeting) {
+  // A lab and its lecture meet at different hours, so the first meeting listed
+  // is not the section's span.
+  for (const meeting of section.meetings ?? []) {
     const start = toMinutes(meeting.startTime);
+    if (start == null) continue;
     const end = toMinutes(meeting.endTime) ?? start;
-    if (filters.from && start != null && start < Number(filters.from)) return false;
-    if (filters.to && end != null && end > Number(filters.to)) return false;
+    if (filters.from && start < Number(filters.from)) return false;
+    if (filters.to && end > Number(filters.to)) return false;
+    if (filters.busy.some((b) => b.days.some((d) => meeting[d]) && overlaps(start, end, b))) return false;
   }
 
   return true;
@@ -87,7 +128,8 @@ function keepSection(section, filters) {
 
 export function isActive(filters) {
   return Boolean(
-    filters.days.length || filters.avoid.length || filters.from || filters.to || filters.rating ||
+    filters.days.length || filters.avoid.length || filters.busy.length ||
+    filters.from || filters.to || filters.rating ||
     filters.hideFull || filters.hideOnline || filters.ratedOnly
   );
 }

--- a/js/format.js
+++ b/js/format.js
@@ -5,7 +5,12 @@ const DAY_LABELS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
 
 export function formatDays(meeting) {
   if (!meeting) return "";
-  return DAY_KEYS.map((key, i) => (meeting[key] ? DAY_LABELS[i] : null)).filter(Boolean).join("");
+  return dayCodes(DAY_KEYS.filter((key) => meeting[key]));
+}
+
+/** The same abbreviation from plain day keys, for filters that have no meeting. */
+export function dayCodes(days) {
+  return DAY_KEYS.map((key, i) => (days.includes(key) ? DAY_LABELS[i] : null)).filter(Boolean).join("");
 }
 
 export function formatTime(meeting) {
@@ -13,6 +18,18 @@ export function formatTime(meeting) {
   const start = meeting.startTime.replace(/\s?([ap])m/i, "$1").toLowerCase();
   const end = meeting.endTime?.replace(/\s?([ap])m/i, "$1").toLowerCase();
   return end ? `${start}–${end}` : start;
+}
+
+/** Minutes past midnight on a clock face. The inverse of filters.js toMinutes. */
+function fromMinutes(minutes) {
+  const hour = Math.floor(minutes / 60) % 24;
+  const display = hour % 12 === 0 ? 12 : hour % 12;
+  return `${display}:${String(minutes % 60).padStart(2, "0")}${hour < 12 ? "a" : "p"}`;
+}
+
+/** A busy block, "TuTh 9:35a–10:55a", written the way the section rows write a meeting. */
+export function busyLabel(block) {
+  return `${dayCodes(block.days)} ${fromMinutes(block.start)}–${fromMinutes(block.end)}`;
 }
 
 export function formatWhen(meeting) {

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -1,8 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { DEFAULTS, toMinutes, isActive, applyFilters } from "../js/filters.js";
-import { entry, section, taught } from "./fixtures.js";
+import { DEFAULTS, toMinutes, isActive, applyFilters, parseBusy, formatBusy } from "../js/filters.js";
+import { entry, meeting, section, taught } from "./fixtures.js";
 import { withRatings, withSeats } from "./helpers.js";
 
 // filters.js reads seats and ratings through the shared module state, so the
@@ -57,6 +57,7 @@ test("isActive is false for the defaults", () => {
 
 test("isActive notices any one filter", () => {
   assert.equal(isActive(filters({ days: ["monday"] })), true);
+  assert.equal(isActive(filters({ busy: [{ days: ["monday"], start: 540, end: 600 }] })), true);
   assert.equal(isActive(filters({ from: "540" })), true);
   assert.equal(isActive(filters({ to: "1020" })), true);
   assert.equal(isActive(filters({ rating: "4" })), true);
@@ -105,6 +106,126 @@ test("a section with no end time is judged on its start", () => {
   const open = entry("CSE", "1", "T", [taught(7001, ["monday"], "9:00 AM", null, ["Someone"])]);
   assert.equal(applyFilters([open], filters({ to: "600" })).entries.length, 1);
   assert.equal(applyFilters([open], filters({ to: "500" })).entries.length, 0);
+});
+
+// A lecture and its lab, which is what the first-meeting-only rule got wrong.
+const split = section(6001, {
+  meetings: [
+    meeting(["monday", "wednesday"], "9:00 AM", "9:55 AM", []),
+    meeting(["friday"], "6:00 PM", "8:00 PM", []),
+  ],
+});
+const splitCourse = () => entry("BIOLOGY", "2105", "Lab", [split]);
+
+test("regression #62: a time window judges every meeting, not just the first", () => {
+  // The Friday lab runs to 8:00 pm, so this section does not end by noon. The
+  // old rule read the 9:55 am lecture, the first meeting listed, and kept it.
+  assert.equal(applyFilters([splitCourse()], filters({ to: "720" })).entries.length, 0);
+});
+
+test("regression #62: a floor on start reads past the first meeting too", () => {
+  // Mirrored: the API lists the 2:00 pm lecture first, so reading only that hid
+  // an 8:00 am lab from "starts no earlier than noon".
+  const reversed = entry("CHEM", "1110", "Lab", [section(6002, {
+    meetings: [
+      meeting(["monday"], "2:00 PM", "3:00 PM", []),
+      meeting(["friday"], "8:00 AM", "9:00 AM", []),
+    ],
+  })]);
+  assert.equal(applyFilters([reversed], filters({ from: "720" })).entries.length, 0);
+});
+
+test("parseBusy reads the URL form", () => {
+  assert.deepEqual(parseBusy("TuTh-575-655"), { days: ["tuesday", "thursday"], start: 575, end: 655 });
+  assert.deepEqual(parseBusy("mo-480-540"), { days: ["monday"], start: 480, end: 540 });
+  assert.deepEqual(parseBusy("MoWeFr-780-825").days, ["monday", "wednesday", "friday"]);
+});
+
+test("parseBusy returns null rather than guessing", () => {
+  for (const junk of ["", "  ", null, undefined, "TuTh", "Xx-1-2", "Tut-1-2", "TuTh-655-575",
+                      "TuTh-575-575", "TuTh-0-1441", "TuTh:575-655"]) {
+    assert.equal(parseBusy(junk), null, `${junk} should not parse`);
+  }
+});
+
+test("formatBusy writes days in week order", () => {
+  // app.js hands formatBusy the days in whatever order they were clicked.
+  assert.equal(formatBusy({ days: ["thursday", "tuesday"], start: 575, end: 655 }), "TuTh-575-655");
+  assert.deepEqual(parseBusy(formatBusy(parseBusy("ThTu-575-655"))), parseBusy("TuTh-575-655"));
+});
+
+test("a busy block drops the sections that collide with it", () => {
+  // Busy TuTh 6:00 pm to 7:00 pm, which is inside the evening section.
+  const { entries, hiddenSections } = applyFilters(
+    [course()],
+    filters({ busy: [{ days: ["tuesday", "thursday"], start: 1080, end: 1140 }] })
+  );
+  assert.deepEqual(entries[0].sections.map((s) => s.classNumber), [1001, 5003, 5004]);
+  assert.equal(hiddenSections, 1);
+});
+
+test("a busy block only judges the days it covers", () => {
+  // The same hour, but on a day the evening section does not meet.
+  const { entries } = applyFilters(
+    [course()],
+    filters({ busy: [{ days: ["monday"], start: 1080, end: 1140 }] })
+  );
+  assert.deepEqual(entries[0].sections.map((s) => s.classNumber), [1001, 1002, 5003, 5004]);
+});
+
+test("a busy block is half open, so touching edges are not a clash", () => {
+  // The morning section runs 9:10 to 10:05 on MoWeFr.
+  const before = filters({ busy: [{ days: ["monday"], start: 480, end: 550 }] });
+  const after = filters({ busy: [{ days: ["monday"], start: 605, end: 700 }] });
+  assert.ok(applyFilters([course()], before).entries[0].sections.some((s) => s.classNumber === 1001));
+  assert.ok(applyFilters([course()], after).entries[0].sections.some((s) => s.classNumber === 1001));
+
+  const across = filters({ busy: [{ days: ["monday"], start: 549, end: 551 }] });
+  assert.ok(!applyFilters([course()], across).entries[0].sections.some((s) => s.classNumber === 1001));
+});
+
+test("a busy block checks every meeting of a section", () => {
+  // Busy Friday evening, which only the second meeting runs into.
+  const { entries } = applyFilters(
+    [splitCourse()],
+    filters({ busy: [{ days: ["friday"], start: 1140, end: 1200 }] })
+  );
+  assert.equal(entries.length, 0);
+});
+
+test("unknown meeting patterns never fail a busy block", () => {
+  const { entries } = applyFilters(
+    [course()],
+    filters({ busy: [{ days: ["monday", "tuesday", "wednesday", "thursday", "friday"], start: 0, end: 1440 }] })
+  );
+  assert.deepEqual(
+    entries[0].sections.map((s) => s.classNumber),
+    [5003, 5004],
+    "an online and an arranged section have no time to judge"
+  );
+});
+
+test("a section with no end time still clashes with a block it starts inside", () => {
+  const open = entry("CSE", "1", "T", [taught(7002, ["monday"], "9:00 AM", null, ["Someone"])]);
+  const inside = filters({ busy: [{ days: ["monday"], start: 540, end: 600 }] });
+  const outside = filters({ busy: [{ days: ["monday"], start: 600, end: 660 }] });
+  assert.equal(applyFilters([open], inside).entries.length, 0);
+  assert.equal(applyFilters([open], outside).entries.length, 1);
+});
+
+test("a meeting with no time never fails a time filter or a busy block", () => {
+  // A lecture at a known hour plus a "Time to be announced" second meeting.
+  const partial = entry("CSE", "3901", "Lab", [section(6003, {
+    meetings: [
+      meeting(["monday"], "9:00 AM", "10:00 AM", []),
+      meeting(["friday"], null, null, []),
+    ],
+  })]);
+  assert.equal(applyFilters([partial], filters({ from: "540", to: "660" })).entries.length, 1);
+  assert.equal(
+    applyFilters([partial], filters({ busy: [{ days: ["friday"], start: 0, end: 1440 }] })).entries.length,
+    1
+  );
 });
 
 test("hideOnline drops only what the instruction mode says is online", () => {

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { formatDays, formatTime, formatWhen, formatPlace, formatUnits, instructorsOf } from "../js/format.js";
+import { formatDays, dayCodes, busyLabel, formatTime, formatWhen, formatPlace, formatUnits, instructorsOf } from "../js/format.js";
 import { meeting, person, section } from "./fixtures.js";
 
 const DASH = "\u2013";
@@ -20,6 +20,17 @@ test("formatDays is empty for no days and for no meeting", () => {
   assert.equal(formatDays(meeting([])), "");
   assert.equal(formatDays(null), "");
   assert.equal(formatDays(undefined), "");
+});
+
+test("dayCodes abbreviates a plain list of days in week order", () => {
+  assert.equal(dayCodes(["thursday", "tuesday"]), "TuTh");
+  assert.equal(dayCodes([]), "");
+});
+
+test("busyLabel reads like the section rows", () => {
+  assert.equal(busyLabel({ days: ["tuesday", "thursday"], start: 575, end: 655 }), `TuTh 9:35a${DASH}10:55a`);
+  // 1440 is the midnight that ends the day, not the one that starts it.
+  assert.equal(busyLabel({ days: ["monday"], start: 720, end: 1440 }), `Mo 12:00p${DASH}12:00a`);
 });
 
 test("formatTime drops the space and the m", () => {


### PR DESCRIPTION
Closes #62

Two things were wrong. `from` is a floor on start and `to` is a ceiling on end, so together they can only cut one contiguous window and never a hole in the middle of the day: a student busy TuTh 9:35 to 10:55 had to reach for "Starts no earlier than 11:00 am", which also throws away every 8:00 am section. And underneath that, `keepSection` judged time from `section.meetings?.find((m) => m.startTime)`, a single meeting, while `sectionDays` two functions above already scanned every one. A lab and its lecture meet at different hours, so whichever meeting the API happened to list first decided the answer.

The second half had to land first, and it is the part with teeth. CHEM 1110, Autumn 2026, 20 sections pulled live from `content.osu.edu/v2` on 2026-08-21, run through `js/filters.js` before and after:

```
"Starts no earlier than 11:00 am"
  before: 15 sections
  after:  12 sections
  wrongly kept: 15673, 23090, 15674
    #15673 meets 11:10 am-2:05 pm and 10:20 am-11:15 am
    #23090 meets 11:10 am-2:05 pm and 8:00 am-8:55 am
    #15674 meets 11:10 am-2:05 pm and 8:00 am-8:55 am

"Ends no later than 12:00 pm"
  before: 5 sections
  after:  4 sections
  wrongly kept: 15671
    #15671 meets 8:00 am-10:55 am and 4:10 pm-5:05 pm
```

**#23090 was surviving "starts no earlier than 11:00 am" while meeting at 8:00 am on Thursday.** Widening the same measurement to 600 sections across CHEM, BIOLOGY and PHYSICS for that term, 69 of them have a first meeting that misreports the section's real span. That rate is a function of how the pull is scoped, so it is here and dated rather than frozen into a code comment.

## Busy blocks

A block is `{days, start, end}`, serialized as a repeated `busy=TuTh-575-655` param next to `day` and `noday`. Minutes past midnight to match `from` and `to`, dashes rather than colons so a shared link does not come out full of `%3A`. A section drops when any of its meetings overlaps a block on a day they share, half open, so a class that ends exactly when a block starts is not a clash.

Driven in the real page in headless Chrome, against that same live CHEM 1110 data, measured from the DOM:

```
sections on load: 20
busy Th 8:00-9:00: 16 sections, chips ["Th 8:00a-9:00a"], url busy=Th-480-540
hidden note: 4 sections hidden by your filters. Show them anyway
the identical block added again: 1 chip, 16 sections
Add button type: button
busy hint after a submit from the rating select: "Block out a class you already have. Sections that overlap it drop out."
also busy Tu 11:00-12:00: 14 sections, chips ["Th 8:00a-9:00a","Tu 11:00a-12:00p"]
first chip removed: 16 sections, chips ["Tu 11:00a-12:00p"]
focus lands on: f-chip
last chip removed, focus lands on: f-busy-add
back to: 20 sections

shared link, one block spelled four ways plus junk: chips ["TuTh 9:35a-10:55a"], 15 sections
busy params written back after touching another filter: ["TuTh-575-655"]
```

The last two lines are the link round trip. `?busy=TuTh-575-655&busy=TuTh-575-655&busy=tUtH-575-655&busy=ThTu-575-655&busy=junk` paints one chip, not four, and the junk param is dropped rather than guessed at.

Add is a plain button, not a submit button. Making it a submit button gives `#filters` a default button it never had, and then Enter over the rating select lands in the busy handler and writes an error under a section nobody touched. Enter inside a busy time field still adds, through its own keydown handler.

## Tests

152 now, 138 on main, so 14 added. Every one of them was confirmed to fail without the code it covers, not just to pass with it:

```
first timed meeting only          -> fails 3  (both #62 regressions, plus the busy multi-meeting test)
unknown-time guard deleted        -> fails 1
busy blocks not checked           -> fails 5
overlap closed instead of half open -> fails 1
parseBusy loses case insensitivity  -> fails 1
even-length day-code guard deleted  -> fails 1
dayCodes emits the caller's order   -> fails 2
```

## What is deliberately not here

The calendar stays read only. Clicking a cell to mark yourself busy reads as an invitation to mark the overlaps too, and marking overlaps is a schedule builder, which the README already refuses. That refusal is now written down next to the busy code in `js/app.js` so the next person to propose the clickable grid argues with a decision rather than a silence.

`js/calendar.js:60` has the same first-meeting-only habit when it lays sections onto the week grid. It is a different bug with a different fix and it belongs in its own issue.

The display helpers landed in `js/format.js` rather than `js/filters.js`. `dayCodes` was going to be a third copy of the Mo/Tu/We table and a second `clock(minutes)` in a second module, so `formatDays` now delegates to the shared one and `busyLabel` sits next to `formatTime`.
