### PR TITLE
Stop one failed subject request from discarding every term's seats

### DIFF
--- a/.github/workflows/seats.yml
+++ b/.github/workflows/seats.yml
@@ -36,7 +36,11 @@ jobs:
           TERM_INPUT: ${{ inputs.term }}
         run: node scripts/fetch-seats.mjs $TERM_INPUT
 
+      # The fetch exits non-zero when it skipped a term, and the terms it did
+      # snapshot are already on disk by then, so commit before the job goes red.
+      # !cancelled() is success or failure, so this also commits after a crash.
       - name: Commit if changed
+        if: ${{ !cancelled() }}
         run: |
           # One file per term now, so stage by pathspec. -A picks up a term that
           # is new and one that was dropped, and staging a file whose bytes did

--- a/scripts/fetch-seats.mjs
+++ b/scripts/fetch-seats.mjs
@@ -10,7 +10,8 @@
 //         node scripts/fetch-seats.mjs 1268
 // With no argument every term the API reports as searchable is snapshotted,
 // which is what the workflow does. Naming terms refreshes only those: the other
-// searchable terms keep the files and index entries they already have.
+// searchable terms keep the files and index entries they already have. A term
+// that fails its checks keeps what it has too, and the run exits non-zero.
 //
 // Output is one file per term, data/seats-1268.json, plus data/seats.json
 // listing them. Seats load before anything renders, so a browser fetches the
@@ -26,7 +27,8 @@ const BASE = 'https://www.asc.ohio-state.edu/barrett.3/schedule';
 // Only for the term list. Every seat number here comes from Barrett.
 const API = 'https://content.osu.edu/v2/classes';
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const OUT_DIR = join(ROOT, 'data');
+// Overridable so a test can run the script against a temp directory.
+const OUT_DIR = process.env.SEATS_OUT_DIR ?? join(ROOT, 'data');
 const INDEX_NAME = 'seats.json';
 const TERM_PREFIX = 'seats-';
 const TERM_FILE_RE = /^seats-\d{4}\.json$/;
@@ -42,10 +44,16 @@ const MAX_RETRY_AFTER_MS = 30000;
 const USER_AGENT =
   'Finder-seats/1.0 (+https://github.com/EnesYilmazcode/Finder) daily snapshot';
 
-// A subject file that fails the layout check this badly is a format change,
-// not a stray line, so the job should fail loudly instead of shipping junk.
-const MAX_RESIDUE_RATE = 0.005;
+// Residue measured across a whole term. A term that fails the layout check this
+// badly is a format change, not a stray line, so it is held back rather than
+// shipped. Named for its granularity because a per-file gate wants a different
+// number: one bad row in a 25-row subject file is 4%.
+const MAX_TERM_RESIDUE_RATE = 0.005;
 const MIN_SUBJECTS = 50;
+
+// A chosen ceiling, not a measured failure rate. Under it a subject's sections
+// read as unknown for a day. Over it too much of the term is missing to ship.
+const MAX_SUBJECT_FAILURES = 5;
 
 // Fixed-width field slices, measured against every subject file for term 1268
 // on 2026-08-18 (17680 section lines, zero residue). Half-open [start, end).
@@ -263,21 +271,40 @@ async function mapLimit(items, limit, worker) {
 
 async function snapshotTerm(term, subjects) {
   const started = Date.now();
+  // mapLimit runs on Promise.all, so a worker that throws rejects the whole
+  // term. A failed request and a file that will not parse are recorded apart
+  // because only the first of them is worth tolerating.
   const results = await mapLimit(subjects, CONCURRENCY, async (subject) => {
-    const text = await fetchText(`${BASE}/${subject}/${term}.txt`, { allow404: true });
+    let text;
+    try {
+      text = await fetchText(`${BASE}/${subject}/${term}.txt`, { allow404: true });
+    } catch (err) {
+      return { subject, offered: false, fetchError: err.message };
+    }
     if (text === null) return { subject, offered: false };
-    return { subject, offered: true, ...parseSubjectFile(subject, term, text) };
+    try {
+      return { subject, offered: true, ...parseSubjectFile(subject, term, text) };
+    } catch (err) {
+      // The layout errors land here too. They are one renamed column across
+      // every file rather than one bad subject, so they must reach the counter
+      // termProblem gives no tolerance to, never the failed-request one.
+      return { subject, offered: false, parseError: err.message };
+    }
   });
 
   const byClass = new Map();
   const collisions = [];
   const failures = [];
+  const fetchErrors = [];
+  const parseErrors = [];
   let offered = 0;
   let continuations = 0;
   let updated = '';
   let termName = '';
 
   for (const r of results) {
+    if (r.fetchError) fetchErrors.push(r.fetchError);
+    if (r.parseError) parseErrors.push(r.parseError);
     if (!r.offered) continue;
     offered++;
     continuations += r.continuations;
@@ -316,6 +343,8 @@ async function snapshotTerm(term, subjects) {
       term,
       subjectsListed: subjects.length,
       subjectsOffered: offered,
+      subjectsFailed: fetchErrors.length,
+      subjectsUnparsed: parseErrors.length,
       sectionsParsed: parsed,
       continuationRows: continuations,
       residueFailures: failures.length,
@@ -324,7 +353,30 @@ async function snapshotTerm(term, subjects) {
       seconds: (Date.now() - started) / 1000,
     },
     failures,
+    fetchErrors,
+    parseErrors,
   };
+}
+
+// The checks a term clears before its file is rewritten. Returned rather than
+// thrown so a bad term does not take the good ones with it.
+function termProblem(stats) {
+  if (stats.sectionsParsed === 0) return 'no sections parsed';
+  if (stats.subjectsOffered < MIN_SUBJECTS) return `only ${stats.subjectsOffered} subjects returned data`;
+  if (stats.subjectsFailed > MAX_SUBJECT_FAILURES) {
+    return `${stats.subjectsFailed} subject requests failed, more than the ${MAX_SUBJECT_FAILURES} allowed`;
+  }
+  // A file that arrived and would not parse is a layout change, not a flake, so
+  // one is enough to hold the term back. This is the threshold the loud throws
+  // in parseSubjectFile rely on, so it does not get a tolerance.
+  if (stats.subjectsUnparsed > 0) return `${stats.subjectsUnparsed} subject files did not parse`;
+  if (stats.residueRate > MAX_TERM_RESIDUE_RATE) {
+    return (
+      `residue rate ${(stats.residueRate * 100).toFixed(2)}% exceeds ` +
+      `${(MAX_TERM_RESIDUE_RATE * 100).toFixed(2)}%, the fixed-width layout probably changed`
+    );
+  }
+  return null;
 }
 
 async function writeAtomic(path, contents) {
@@ -370,42 +422,46 @@ async function main() {
   const subjects = await fetchSubjects();
   console.log(`${terms.length} searchable terms (${terms.join(', ')}), ${subjects.length} subjects listed`);
 
-  const out = {};
-  let residueSeen = 0;
-  let sectionsSeen = 0;
+  const ready = [];
+  const skipped = [];
 
   for (const term of terms) {
-    const { snapshot, stats, failures } = await snapshotTerm(term, subjects);
-    out[term] = snapshot;
-    residueSeen += stats.residueFailures;
-    sectionsSeen += stats.sectionsParsed;
+    const { snapshot, stats, failures, fetchErrors, parseErrors } = await snapshotTerm(term, subjects);
 
     console.log(
       `term ${term}: ${stats.subjectsOffered} subjects offered, ` +
-        `${stats.sectionsParsed} sections, ${stats.residueFailures} residue failures, ` +
+        `${stats.sectionsParsed} sections, ${stats.subjectsFailed} subjects failed, ` +
+        `${stats.subjectsUnparsed} unparsed, ${stats.residueFailures} residue failures, ` +
         `${stats.continuationRows} continuation rows, ${stats.collisions} collisions, ` +
         `${stats.seconds.toFixed(1)}s`
     );
     for (const f of failures.slice(0, 20)) console.log(`  residue ${f}`);
-    if (stats.sectionsParsed === 0) throw new Error(`term ${term}: no sections parsed`);
-    if (stats.subjectsOffered < MIN_SUBJECTS) {
-      throw new Error(`term ${term}: only ${stats.subjectsOffered} subjects returned data`);
+    for (const e of [...fetchErrors, ...parseErrors].slice(0, 20)) console.error(`  ${e}`);
+
+    const problem = termProblem(stats);
+    if (problem) {
+      skipped.push(term);
+      const had = await exists(join(OUT_DIR, `${TERM_PREFIX}${term}.json`));
+      console.error(`term ${term}: ${problem}, ${had ? 'keeping the file it already has' : 'no file to keep'}`);
+      continue;
     }
+    // Actions shows this on the run summary, so a term that shipped with
+    // subjects missing is visible without opening the log of a green job.
+    if (stats.subjectsFailed) {
+      console.error(
+        `::warning::term ${term}: snapshot is missing ${stats.subjectsFailed} of ${stats.subjectsListed} subjects`
+      );
+    }
+    ready.push([term, snapshot]);
   }
 
-  const rate = sectionsSeen + residueSeen ? residueSeen / (sectionsSeen + residueSeen) : 0;
-  if (rate > MAX_RESIDUE_RATE) {
-    throw new Error(
-      `residue rate ${(rate * 100).toFixed(2)}% exceeds ${(MAX_RESIDUE_RATE * 100).toFixed(2)}%, ` +
-        'the fixed-width layout probably changed, refusing to write'
-    );
-  }
+  if (!ready.length) throw new Error('no term cleared its checks, nothing written');
 
-  // One file per term. Nothing is written until every term has cleared the
-  // checks above, so a bad run cannot leave one term fresh and another stale.
+  // One file per term, written independently. A term that failed its checks
+  // keeps the file it already had, so a run can leave a fresh term next to a
+  // stale one.
   const entries = [];
-  for (const term of terms) {
-    const snapshot = out[term];
+  for (const [term, snapshot] of ready) {
     const file = `${TERM_PREFIX}${term}.json`;
     const bytes = await writeJson(join(OUT_DIR, file), snapshot);
     entries.push({
@@ -449,11 +505,15 @@ async function main() {
     await rm(join(OUT_DIR, name));
     console.log(`removed data/${name}, that term is no longer searchable`);
   }
+
+  // Red, but only after the terms that did parse have been written.
+  if (skipped.length) throw new Error(`did not refresh term ${skipped.join(', ')}`);
 }
 
-// Exported so a checker can reuse the parser without refetching, and so the
-// retry policy can be exercised without a network.
-export { fetchText, parseSubjectFile };
+// Exported so a checker can reuse the parser without refetching, so the retry
+// policy can be exercised without a network, and so the tests can run a term
+// without the writing half.
+export { MAX_SUBJECT_FAILURES, fetchText, parseSubjectFile, snapshotTerm, termProblem };
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
   main().catch((err) => {

--- a/tests/barrett-mock.mjs
+++ b/tests/barrett-mock.mjs
@@ -1,0 +1,71 @@
+// Barrett and the term list served from memory, for the tests that exercise
+// scripts/fetch-seats.mjs. Nothing here touches the network.
+//
+// The subject files come from the shared barrettFile builder, so this only has
+// to say which subjects misbehave and how.
+
+import { stubFetch } from "./helpers.js";
+import { barrettFile } from "./fixtures.js";
+
+const BASE = "https://www.asc.ohio-state.edu/barrett.3/schedule";
+const API = "https://content.osu.edu/v2/classes";
+
+// Class numbers carry the subject, so a snapshot says which subject each
+// section came from: SUBJ07's rows are 10700 up.
+const rows = (subject, count) =>
+  Array.from({ length: count }, (_, i) => ({
+    catalog: `${1110 + i}`,
+    classNumber: `${10000 + Number(subject.slice(4)) * 100 + i}`,
+    days: "MWF",
+    time: "0800A",
+    room: "ONLINE",
+    enrolled: 26 + i,
+    limit: 40,
+    instructor: "M.Mallon",
+  }));
+
+// A real Response always carries headers, and fetchText reads Retry-After off
+// the not-ok path, so leaving them out would test a shape fetch never returns.
+const headers = { get: () => null };
+const ok = (body) => ({ ok: true, status: 200, statusText: "OK", headers, text: async () => body });
+const bad = (status, statusText) => ({ ok: false, status, statusText, headers, text: async () => "" });
+
+/**
+ * Stub globalThis.fetch for one scenario and return a restore function.
+ *
+ * `published` names the terms Barrett actually serves; the rest 404 the way an
+ * unpublished term does. A subject in `failing` 403s, which fetchText treats as
+ * fatal, one in `mislabelled` returns a file stamped with the wrong term, and
+ * one in `layoutBroken` returns a file with no column header.
+ */
+export function install({
+  subjects = [],
+  searchable = [],
+  published = [],
+  failing = [],
+  mislabelled = [],
+  layoutBroken = [],
+  sections = 4,
+} = {}) {
+  return stubFetch((href) => {
+    if (href === `${API}/searchableTermsV2`) {
+      return ok(JSON.stringify({ data: { data: searchable.map((strm) => ({ strm, classSearch: "Y" })) } }));
+    }
+    if (href === `${BASE}/`) return ok(subjects.map((s) => `<a href="${s}">${s}</a>`).join("\n"));
+
+    const [subject, file] = href.slice(BASE.length + 1).split("/");
+    const term = file.replace(".txt", "");
+    if (failing.includes(subject)) return bad(403, "Forbidden");
+    if (!published.includes(term)) return bad(404, "Not Found");
+    return ok(barrettFile(
+      subject,
+      mislabelled.includes(subject) ? "1264" : term,
+      rows(subject, sections),
+      layoutBroken.includes(subject) ? { columns: null } : {}
+    ));
+  });
+}
+
+// Loaded with --import when a test spawns the real script, where the
+// environment is the only channel into the child.
+if (process.env.BARRETT_MOCK) install(JSON.parse(process.env.BARRETT_MOCK));

--- a/tests/fetch-seats-run.test.js
+++ b/tests/fetch-seats-run.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = join(ROOT, "scripts", "fetch-seats.mjs");
+const MOCK = pathToFileURL(join(ROOT, "tests", "barrett-mock.mjs")).href;
+
+// MIN_SUBJECTS is 50, so a term needs at least that many to clear its checks.
+const SUBJECTS = Array.from({ length: 50 }, (_, i) => `SUBJ${String(i).padStart(2, "0")}`);
+
+function run(outDir, scenario) {
+  return spawnSync(process.execPath, ["--import", MOCK, SCRIPT], {
+    encoding: "utf8",
+    env: { ...process.env, SEATS_OUT_DIR: outDir, BARRETT_MOCK: JSON.stringify(scenario) },
+  });
+}
+
+const write = (dir, name, value) => writeFileSync(join(dir, name), `${JSON.stringify(value)}\n`);
+const read = (dir, name) => readFileSync(join(dir, name), "utf8");
+
+// Regression, #93. This is the half the issue is titled after: one term Barrett
+// has not rebuilt yet used to throw before anything was written, so every other
+// term lost its refresh too.
+test("regression #93: a skipped term keeps its file while the rest are written", () => {
+  const dir = mkdtempSync(join(tmpdir(), "finder-seats-"));
+  try {
+    // Yesterday: 1272 snapshotted, and 1260 from back when it was searchable.
+    write(dir, "seats-1272.json", { term: "1272", termName: "Spring 2027", sourceUpdated: "2026-07-29", sections: { 20001: [5, 30, 0] } });
+    write(dir, "seats-1260.json", { term: "1260", termName: "Autumn 2025", sourceUpdated: "2025-12-01", sections: { 30001: [9, 25, 0] } });
+    write(dir, "seats.json", {
+      terms: [
+        { term: "1260", termName: "Autumn 2025", sourceUpdated: "2025-12-01", sections: 1, file: "seats-1260.json" },
+        { term: "1272", termName: "Spring 2027", sourceUpdated: "2026-07-29", sections: 1, file: "seats-1272.json" },
+      ],
+    });
+    const before = read(dir, "seats-1272.json");
+
+    const r = run(dir, { subjects: SUBJECTS, searchable: ["1268", "1272"], published: ["1268"] });
+
+    assert.equal(r.status, 1, `the run still goes red\n${r.stderr}`);
+    assert.match(r.stderr, /term 1272: no sections parsed, keeping the file it already has/);
+    assert.equal(read(dir, "seats-1272.json"), before, "the skipped term's file is untouched");
+    assert.equal(Object.keys(JSON.parse(read(dir, "seats-1268.json")).sections).length, 200);
+
+    const index = JSON.parse(read(dir, "seats.json"));
+    assert.deepEqual(index.terms.map((t) => t.term), ["1268", "1272"]);
+    assert.equal(index.terms[1].sourceUpdated, "2026-07-29", "1272 keeps its own older date");
+    assert.equal(existsSync(join(dir, "seats-1260.json")), false, "a term that really left is still dropped");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/fetch-seats.test.js
+++ b/tests/fetch-seats.test.js
@@ -1,10 +1,17 @@
-// The snapshotter's pure half. Nothing here fetches: the files are built to
-// Barrett's real column map, so the parser has to accept them.
+// The snapshotter without the writing half. The subject files are built to
+// Barrett's real column map, so the parser has to accept them, and the term
+// runs go through a Barrett served from memory rather than the network.
 
 import test, { describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { parseSubjectFile } from "../scripts/fetch-seats.mjs";
+import {
+  MAX_SUBJECT_FAILURES,
+  parseSubjectFile,
+  snapshotTerm,
+  termProblem,
+} from "../scripts/fetch-seats.mjs";
+import { install } from "./barrett-mock.mjs";
 import { BARRETT_COLUMNS, barrettFile, barrettLine } from "./fixtures.js";
 
 // Two sections and the continuation row that carries the second one's other
@@ -87,5 +94,91 @@ describe("where the column header is", () => {
     const out = parseSubjectFile("CSE", "1268", tight);
     assert.deepEqual(out.failures, []);
     assert.equal(out.sections.length, 2);
+  });
+});
+
+describe("what holds a term back", () => {
+  const SUBJECTS = Array.from({ length: 12 }, (_, i) => `SUBJ${String(i).padStart(2, "0")}`);
+
+  const termStats = (extra) => ({
+    subjectsOffered: 241,
+    subjectsFailed: 0,
+    subjectsUnparsed: 0,
+    sectionsParsed: 17680,
+    residueRate: 0,
+    ...extra,
+  });
+
+  // Regression, #93. mapLimit runs on Promise.all, so a subject that threw used
+  // to reject the whole term and take every other subject's sections with it.
+  // A 403 is fatal on the first attempt, so it reaches that catch without
+  // sitting through the retry ladder a 5xx earns.
+  test("regression #93: a subject that never loads does not sink the term", async () => {
+    const restore = install({ subjects: SUBJECTS, published: ["1268"], failing: ["SUBJ07"] });
+    try {
+      const { snapshot, stats, fetchErrors } = await snapshotTerm("1268", SUBJECTS);
+      assert.equal(stats.subjectsFailed, 1);
+      assert.equal(stats.subjectsOffered, 11);
+      assert.equal(stats.sectionsParsed, 44, "the other 11 subjects still parsed");
+      assert.match(fetchErrors[0], /SUBJ07/);
+      assert.match(fetchErrors[0], /403/);
+      assert.deepEqual(snapshot.sections["10000"], [26, 40, 0], "SUBJ00 is in the snapshot");
+      assert.equal(snapshot.sections["10700"], undefined, "SUBJ07 is not, its sections read as unknown");
+    } finally {
+      restore();
+    }
+  });
+
+  // A file that arrived and would not parse is Barrett changing shape, which is
+  // the one thing the new tolerance must not swallow.
+  test("regression #93: a subject file that will not parse holds the term back", async () => {
+    const restore = install({ subjects: SUBJECTS, published: ["1268"], mislabelled: ["SUBJ03"] });
+    try {
+      const { stats, parseErrors } = await snapshotTerm("1268", SUBJECTS);
+      assert.equal(stats.subjectsUnparsed, 1);
+      assert.equal(stats.subjectsFailed, 0, "a header mismatch is not a failed request");
+      assert.match(parseErrors[0], /SUBJ03: header term 1264 is not 1268/);
+      assert.match(termProblem(termStats({ subjectsUnparsed: 1 })), /did not parse/);
+    } finally {
+      restore();
+    }
+  });
+
+  // #91 made a missing column header throw so a Barrett rename is loud. That
+  // throw lands in the catch this branch added, so it has to reach the counter
+  // with no tolerance rather than the one that writes off five bad subjects.
+  test("a layout error counts as unparsed, not as a tolerated failed request", async () => {
+    const restore = install({ subjects: SUBJECTS, published: ["1268"], layoutBroken: ["SUBJ05"] });
+    try {
+      const { stats, parseErrors } = await snapshotTerm("1268", SUBJECTS);
+      assert.equal(stats.subjectsUnparsed, 1);
+      assert.equal(stats.subjectsFailed, 0);
+      assert.match(parseErrors[0], /SUBJ05: no column header/);
+      assert.match(
+        termProblem(termStats({ subjectsUnparsed: stats.subjectsUnparsed })),
+        /did not parse/,
+        "one renamed column is enough to hold the term"
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("regression #93: a term that parsed nothing is reported, not thrown", () => {
+    assert.equal(termProblem(termStats({ subjectsOffered: 0, sectionsParsed: 0 })), "no sections parsed");
+    assert.equal(termProblem(termStats({})), null, "a healthy term has no problem to report");
+  });
+
+  test("regression #93: a few failed subjects pass, a lot do not", () => {
+    assert.equal(termProblem(termStats({ subjectsFailed: MAX_SUBJECT_FAILURES })), null);
+    assert.match(
+      termProblem(termStats({ subjectsFailed: MAX_SUBJECT_FAILURES + 1 })),
+      /subject requests failed/
+    );
+  });
+
+  test("the subject floor and the layout check still stop a term", () => {
+    assert.match(termProblem(termStats({ subjectsOffered: 49 })), /only 49 subjects/);
+    assert.match(termProblem(termStats({ residueRate: 0.01 })), /residue rate .* exceeds/);
   });
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -8,14 +8,22 @@
 
 import { RATINGS, SEATS_INDEX, SEATS_TERMS } from "./fixtures.js";
 
-/** Swap in a fetch that serves fixtures by URL. Returns a restore function. */
+/**
+ * Swap in a fetch that serves fixtures by URL. Returns a restore function.
+ *
+ * `routes` is a URL-keyed map of JSON bodies, or a function returning a whole
+ * Response-like object, which is what the seat snapshotter's tests need: text
+ * bodies and the 403s and 404s Barrett really answers with.
+ */
 export function stubFetch(routes) {
   const original = globalThis.fetch;
-  globalThis.fetch = async (url) => {
-    const key = String(url);
-    if (!(key in routes)) throw new Error(`unexpected fetch: ${key}`);
-    return { ok: true, status: 200, json: async () => routes[key] };
-  };
+  const serve = typeof routes === "function"
+    ? routes
+    : (key) => {
+        if (!(key in routes)) throw new Error(`unexpected fetch: ${key}`);
+        return { ok: true, status: 200, json: async () => routes[key] };
+      };
+  globalThis.fetch = async (url) => serve(String(url));
   return () => { globalThis.fetch = original; };
 }
 


### PR DESCRIPTION
Closes #93

`mapLimit` finishes on `Promise.all`, so one subject that exhausted its attempts rejected the whole term, which tripped the `sectionsParsed === 0` check and threw inside the per-term loop in `main()` before anything was written. Terms that had parsed cleanly went in the bin with it. `snapshotTerm` now records a subject it could not fetch instead of rejecting, and `main()` decides per term: the terms that clear their checks get written, the ones that do not keep the file they already have, and the run still exits non-zero.

## Before and after

Same mock Barrett on both sides. 60 subjects, `SUBJ07` failing every attempt, and term 1272 searchable but not published by Barrett yet. `data/` seeded with yesterday's files, identical hashes going in.

```
seeded         4f778b81 seats.json    e3cb9974 seats-1268.json    44f25159 seats-1272.json

BEFORE, main
  2 searchable terms (1268, 1272), 60 subjects listed
  GET .../SUBJ07/1268.txt failed: 403 Forbidden
  EXIT=1
  4f778b81 seats.json    e3cb9974 seats-1268.json    44f25159 seats-1272.json

AFTER
  2 searchable terms (1268, 1272), 60 subjects listed
  term 1268: 59 subjects offered, 236 sections, 1 subjects failed, 0 unparsed, 0 residue failures, ...
    GET .../SUBJ07/1268.txt failed: 403 Forbidden
  ::warning::term 1268: snapshot is missing 1 of 60 subjects
  term 1272: 0 subjects offered, 0 sections, 1 subjects failed, 0 unparsed, ...
  term 1272: no sections parsed, keeping the file it already has
  wrote data/seats-1268.json (4331 bytes, 4.2 KiB)
  wrote data/seats.json (522 bytes)
  did not refresh term 1272
  EXIT=1
  b9ec7ca5 seats.json    bb6ea7ca seats-1268.json    44f25159 seats-1272.json
```

Autumn went from yesterday's file to 236 sections. Spring's hash never moved and its index entry carried over with its own older `sourceUpdated`. Both runs are still red, so the nightly still tells you something went wrong.

## A file that will not parse is not a flaky request

The tolerance is narrow on purpose. A failed request is counted and forgiven up to five. A subject file that arrived and would not parse is Barrett changing shape, so one of those holds the term back on its own. Three subject files stamped with the previous term's header, same seeded `data/`:

```
main          SUBJ01: header term 1264 is not 1268
              EXIT=1        seats-1268.json e3cb9974

this branch   term 1268: 57 subjects offered, 228 sections, 0 subjects failed, 3 unparsed, ...
                SUBJ01: header term 1264 is not 1268
                SUBJ02: header term 1264 is not 1268
                SUBJ03: header term 1264 is not 1268
              term 1268: 3 subject files did not parse, keeping the file it already has
              no term cleared its checks, nothing written
              EXIT=1        seats-1268.json e3cb9974
```

Byte for byte the same outcome as main. Catching around the parser too would have shipped a green snapshot quietly missing those three subjects.

## Tests

144 pass, 138 of them already on main. `snapshotTerm` and `termProblem` get five unit tests, and `tests/fetch-seats-run.test.js` spawns the real script against a stubbed Barrett with `SEATS_OUT_DIR` pointed at a temp directory, which is the one production line added for it. That test covers the whole loop in one run: 1268 written, 1272 skipped and byte identical with its index entry carried over, a `seats-1260.json` that is no longer searchable deleted, exit code 1.

Each new test was confirmed to fail against the specific code it claims to cover, mutated in a scratch copy:

```
worker try/catch reverted to main's        2 fail   (the fetch test and the parse test)
one wide catch over fetch and parse        1 fail   (the parse test)
term loop throws again, the way main does  1 fail   (the run test)
```

The suite went from 250ms to 2.8s, measured twice each. Nearly all of that is the run test, and nearly all of that is the script's own 120ms politeness delay: 100 stubbed requests at concurrency 5 is 2.4s of deliberate sleeping. I would rather pay it than leave the loop that decides what gets committed untested.

## Two things that changed beyond the literal ask

The residue check moved from a run-wide pool to per term, because a pooled check cannot coexist with per-term writes: one term's layout break would still block every other term, which is the same defect in a different coat. It does tighten the gate on small terms. From the committed `data/seats.json`, Spring 2026 has 17483 sections, Summer 4866 and Autumn 17692, so a 0.5% pooled budget is about 200 residue lines across the run while Summer on its own gets 24. Residue is zero in all three terms today, so nothing changes now.

`.github/workflows/seats.yml` needed `if: ${{ !cancelled() }}` on the commit step or the fix does nothing in production: the partial refresh would be written and then thrown away with the runner. `!cancelled()` means success or failure, so the commit step now also runs after a genuine crash. A run that dies between writing the term files and writing the index would commit a fresh term file with a stale index, where main discarded both. That costs one day of a wrong "Seats as of" date and it needs a filesystem error on the runner, so I left it.

## Not done

No minimum section count before a term is skipped on residue rate alone. That would be a second magic number guarding a case that has never happened in the three committed snapshots, and the honest fix for the concern is the paragraph above rather than more gates.

The script still exits non-zero on a skip rather than exiting 0 and failing the job from a later step. That would keep the commit gated on a crash-free run, but it needs an exit-code protocol between the script and the workflow, and it makes `node scripts/fetch-seats.mjs` return success on a run that did not refresh a term.
