### PR TITLE
Refuse a gutted snapshot instead of committing it

### DIFF
--- a/.github/workflows/courses.yml
+++ b/.github/workflows/courses.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: '40 8 * * 1'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Write even when the run comes back far short of what is committed'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -28,8 +34,12 @@ jobs:
           node-version: '22'
 
       # No term argument: the script indexes every searchable term, and naming
-      # one would drop the others from the file.
+      # one would drop the others from the file. A run that comes back far short
+      # of the committed index refuses and leaves it alone, so shipping a real
+      # shrink means re-running this workflow by hand with force set.
       - name: Build course index
+        env:
+          FORCE_WRITE: ${{ inputs.force && '1' || '' }}
         run: node scripts/fetch-courses.mjs
 
       - name: Commit if changed

--- a/.github/workflows/ratings.yml
+++ b/.github/workflows/ratings.yml
@@ -6,6 +6,12 @@ on:
     # busiest scheduling window and get delayed.
     - cron: "20 7 * * *"
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Write even when the run comes back far short of what is committed"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -25,6 +31,8 @@ jobs:
           node-version: "22"
 
       - name: Fetch ratings
+        env:
+          FORCE_WRITE: ${{ inputs.force && '1' || '' }}
         run: node scripts/fetch-ratings.mjs
 
       - name: Commit if changed

--- a/.github/workflows/seats.yml
+++ b/.github/workflows/seats.yml
@@ -11,6 +11,11 @@ on:
         description: '4-digit term code for a one-off run, blank for every searchable term'
         required: false
         default: ''
+      force:
+        description: 'Write even when the run comes back far short of what is committed'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -34,6 +39,7 @@ jobs:
       - name: Fetch seat counts
         env:
           TERM_INPUT: ${{ inputs.term }}
+          FORCE_WRITE: ${{ inputs.force && '1' || '' }}
         run: node scripts/fetch-seats.mjs $TERM_INPUT
 
       # The fetch exits non-zero when it skipped a term, and the terms it did

--- a/README.md
+++ b/README.md
@@ -164,7 +164,12 @@ The snapshot scripts are Node 22:
 node scripts/fetch-seats.mjs 1268
 ```
 
-`npm test` runs 138 tests through `node --test`, with nothing installed.
+All three refuse to write a snapshot that came back far short of the one already
+committed, and leave the old file in place. `FORCE_WRITE=1`, or the force input
+on the workflow, writes it anyway, which is how a real shrink gets shipped. A
+file that failed to parse is refused either way.
+
+`npm test` runs 218 tests through `node --test`, with nothing installed.
 
 ## Repo layout
 
@@ -187,7 +192,7 @@ js/
 scripts/              the three snapshot jobs
 data/                 the snapshots, committed
 docs/                 what OSU's API and Barrett's schedule get wrong
-tests/                138 tests, zero dependencies
+tests/                218 tests, zero dependencies
 wireframes/           three layouts considered first
 analytics/            the page-view counter, a Cloudflare Worker
 stats/                the page that reads the counter

--- a/docs/barrett-schedule.md
+++ b/docs/barrett-schedule.md
@@ -133,9 +133,17 @@ There were 1080 of them in term 1268. They are counted, not parsed.
 
 After slicing out every known field the parser blanks those columns and asserts
 that nothing but whitespace is left. A line that fails goes into a failure count
-rather than being dropped quietly, and the job exits non-zero if more than 0.5%
-of lines fail. That is what catches a layout change instead of shipping wrong
-seat numbers.
+rather than being dropped quietly. The term is then held back, and the job exits
+non-zero, when those failures are more than 0.5% of the term, when a subject file
+failed every row it had, or when more than one line in one file failed and those
+are over the same 0.5%. That is what catches a layout change instead of shipping
+wrong seat numbers.
+
+The per-file half is there because a small subject can fail every row it has and
+still sit far under 0.5% of a whole term, and its sections then render as no seat
+data at all. It takes two bad lines rather than one because most subject files
+are short: 633 of the 680 offered across the three searchable terms on
+2026-08-21 hold under 200 rows, so one odd line is already over the rate.
 
 Measured on 2026-08-18: 17680 section lines, 0 residue failures.
 

--- a/scripts/fetch-courses.mjs
+++ b/scripts/fetch-courses.mjs
@@ -17,6 +17,8 @@ import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { countRefusal, refusalMessage } from './guards.mjs';
+
 const API = 'https://content.osu.edu/v2/classes';
 const BARRETT = 'https://www.asc.ohio-state.edu/barrett.3/schedule';
 const CAMPUS = 'col';
@@ -59,8 +61,8 @@ const STABLE_PASSES = 2;
 const SINGLE_PAGE_STABLE_PASSES = 1;
 
 // Autumn 2026 measured 243 subjects and 6072 courses, Summer 2026 the smallest
-// at 197 and 1984. The floors sit well under the smallest term: they exist to
-// catch a run that came back gutted, not to police term to term drift.
+// at 197 and 1984. The floors sit well under the smallest term because they only
+// have to cover a first run: after that a term is held to its own last count.
 const MIN_SUBJECTS = 100;
 const MIN_COURSES = 1200;
 
@@ -196,19 +198,45 @@ async function discoverSubjects(term) {
   return found;
 }
 
-// Subject list, part three: whatever the last run wrote. Missing or unreadable
-// means a first run, which is not an error.
-async function previousSubjects() {
-  const codes = new Set();
+// The index the last run wrote. Missing or unreadable means a first run, which
+// is not an error. Read once, since both readers below want a projection of it.
+async function previousIndex(path = OUT_PATH) {
   try {
-    const previous = JSON.parse(await readFile(OUT_PATH, 'utf8'));
-    for (const term of Object.values(previous.terms ?? {})) {
-      for (const subject of term.subjects ?? []) if (subject.code) codes.add(subject.code);
-    }
+    return JSON.parse(await readFile(path, 'utf8'));
   } catch {
-    return codes;
+    return null;
+  }
+}
+
+// Subject list, part three: every code the last run knew about.
+function previousSubjects(previous) {
+  const codes = new Set();
+  for (const term of Object.values(previous?.terms ?? {})) {
+    for (const subject of term.subjects ?? []) if (subject.code) codes.add(subject.code);
   }
   return codes;
+}
+
+// Per-term counts from the same index, for the collapse check below.
+function previousCounts(previous) {
+  const counts = {};
+  for (const [strm, term] of Object.entries(previous?.terms ?? {})) {
+    const subjects = term.subjects ?? [];
+    counts[strm] = {
+      subjects: subjects.length,
+      courses: subjects.reduce((n, s) => n + (s.courses?.length ?? 0), 0),
+    };
+  }
+  return counts;
+}
+
+// Every reason not to write a term. Apart from main so a test can hold it to the
+// counts that are really committed.
+function writeRefusals(strm, offered, courses, before) {
+  return [
+    countRefusal(`term ${strm} subjects`, offered, MIN_SUBJECTS, before?.subjects),
+    countRefusal(`term ${strm} courses`, courses, MIN_COURSES, before?.courses),
+  ];
 }
 
 // One complete walk of one subject. The subject filter takes the code
@@ -357,6 +385,19 @@ async function main() {
   const terms = requested.length ? all.filter((t) => requested.includes(t.strm)) : all;
   if (!terms.length) throw new Error(`none of ${requested.join(', ')} is searchable`);
 
+  const committed = await previousIndex();
+
+  // searchableTermsV2 is one uncached call to the same API that pages
+  // non-deterministically, and a short answer drops whole terms from a file that
+  // is rewritten every run. A named run is exempt: dropping the rest is what
+  // that mode is for.
+  if (!requested.length) {
+    const refusal = refusalMessage([
+      countRefusal('searchable terms', terms.length, 1, Object.keys(committed?.terms ?? {}).length),
+    ]);
+    if (refusal) throw new Error(`Refusing to write ${OUT_PATH}.\n${refusal}`);
+  }
+
   const candidates = new Set();
   const barrett = await barrettSubjects();
   for (const code of barrett) candidates.add(code);
@@ -365,7 +406,7 @@ async function main() {
   // is itself paged, so it is as lossy as anything else here, and without this
   // a subject could drop out of the file for one run and come back the next.
   // A candidate that really is not offered costs one request and is dropped.
-  const previous = await previousSubjects();
+  const previous = previousSubjects(committed);
   for (const code of previous) candidates.add(code);
 
   let swept = 0;
@@ -381,6 +422,8 @@ async function main() {
       `${swept} subject hits across ${terms.length} term sweeps`
   );
 
+  const counts = previousCounts(committed);
+
   const out = {};
   for (const term of terms) {
     const { index, stats } = await indexTerm(term, codes);
@@ -394,16 +437,8 @@ async function main() {
         `${stats.unconverged} unconverged, ${stats.seconds.toFixed(1)}s`
     );
 
-    if (stats.offered < MIN_SUBJECTS) {
-      throw new Error(
-        `term ${term.strm}: only ${stats.offered} subjects offered, expected at least ${MIN_SUBJECTS}, refusing to write`
-      );
-    }
-    if (stats.courses < MIN_COURSES) {
-      throw new Error(
-        `term ${term.strm}: only ${stats.courses} courses, expected at least ${MIN_COURSES}, refusing to write`
-      );
-    }
+    const refusal = refusalMessage(writeRefusals(term.strm, stats.offered, stats.courses, counts[term.strm]));
+    if (refusal) throw new Error(`Refusing to write ${OUT_PATH}.\n${refusal}`);
   }
 
   // Always keyed by term, even for a single term, so the page reads one shape
@@ -425,9 +460,10 @@ async function main() {
   console.log(`wrote ${OUT_PATH} (${bytes} bytes, ${(bytes / 1024).toFixed(1)} KiB)`);
 }
 
-// Exported so a checker can reuse the walk without rerunning the whole index,
-// and so the retry policy can be exercised without a network.
-export { fetchJson, reconcileSubject, searchableTerms };
+// Exported so a checker can reuse the walk without rerunning the whole index, so
+// the retry policy can be exercised without a network, and so a test can drive
+// the write gate against the committed index.
+export { fetchJson, previousCounts, previousIndex, reconcileSubject, searchableTerms, writeRefusals };
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
   main().catch((err) => {

--- a/scripts/fetch-ratings.mjs
+++ b/scripts/fetch-ratings.mjs
@@ -7,9 +7,11 @@
 //
 // Usage: node scripts/fetch-ratings.mjs
 
-import { mkdir, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { countRefusal, refusalMessage } from "./guards.mjs";
 
 const ENDPOINT = "https://www.ratemyprofessors.com/graphql";
 
@@ -33,9 +35,8 @@ const PAGE_DELAY_MS = 300;
 const MAX_ATTEMPTS = 3;
 const MAX_PAGES = 200; // stops a broken cursor from looping forever
 
-// ~7.3k Ohio State professors have at least one rating. Anything far below that means
-// upstream changed shape or started rate limiting, and writing it would silently gut
-// the file the site reads.
+// ~7.3k Ohio State professors have at least one rating. This is only the first-run
+// backstop: what the run is really held to is the count already committed.
 const MIN_EXPECTED = 5000;
 
 const OUT_PATH = join(dirname(dirname(fileURLToPath(import.meta.url))), "data", "ratings.json");
@@ -112,6 +113,21 @@ function normalize(node) {
   };
 }
 
+// What the last run wrote. Missing or unreadable means a first run, not an error.
+async function previousCount(path = OUT_PATH) {
+  try {
+    return JSON.parse(await readFile(path, "utf8")).professors?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Every reason not to write this run. Apart from main so a test can hold it to
+// the file that is really committed.
+async function writeRefusals(count, path = OUT_PATH) {
+  return [countRefusal("rated professors", count, MIN_EXPECTED, await previousCount(path))];
+}
+
 async function main() {
   const professors = new Map(); // keyed by legacyId; paging can repeat an edge
   let after;
@@ -144,10 +160,10 @@ async function main() {
 
   console.log(`fetched ${professors.size} of ${resultCount}, ${fresh.length} of them rated`);
 
-  if (fresh.length < MIN_EXPECTED) {
+  const refusal = refusalMessage(await writeRefusals(fresh.length));
+  if (refusal) {
     console.error(
-      `Refusing to write: got ${fresh.length} rated professors, expected at least ${MIN_EXPECTED}. ` +
-        `Upstream reported resultCount ${resultCount}. Leaving ${OUT_PATH} untouched.`
+      `Refusing to write ${OUT_PATH}. Upstream reported resultCount ${resultCount}.\n${refusal}`
     );
     process.exit(1);
   }
@@ -172,7 +188,12 @@ async function main() {
   console.log(`Wrote ${records.length} professors to ${OUT_PATH} (${json.length} bytes)`);
 }
 
-main().catch((error) => {
-  console.error(`fetch-ratings failed: ${error.message}`);
-  process.exit(1);
-});
+// Exported so a test can drive the write gate without fetching the roster.
+export { previousCount, writeRefusals };
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().catch((error) => {
+    console.error(`fetch-ratings failed: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/fetch-seats.mjs
+++ b/scripts/fetch-seats.mjs
@@ -12,6 +12,8 @@
 // which is what the workflow does. Naming terms refreshes only those: the other
 // searchable terms keep the files and index entries they already have. A term
 // that fails its checks keeps what it has too, and the run exits non-zero.
+// FORCE_WRITE=1 writes a term that came back far short of the one already
+// committed, which is how a real upstream shrink gets shipped.
 //
 // Output is one file per term, data/seats-1268.json, plus data/seats.json
 // listing them. Seats load before anything renders, so a browser fetches the
@@ -22,6 +24,8 @@
 import { mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { countRefusal, fatal, refusalMessage, subjectResidueRefusal } from './guards.mjs';
 
 const BASE = 'https://www.asc.ohio-state.edu/barrett.3/schedule';
 // Only for the term list. Every seat number here comes from Barrett.
@@ -49,7 +53,21 @@ const USER_AGENT =
 // shipped. Named for its granularity because a per-file gate wants a different
 // number: one bad row in a 25-row subject file is 4%.
 const MAX_TERM_RESIDUE_RATE = 0.005;
+
+// The same rate over one subject file. Over a term alone a small file can fail
+// every row it has and still be a rounding error, and the sections it dropped
+// then render as an honestly absent seat count. subjectResidueRefusal is what
+// keeps that from being a hair trigger: measured on 2026-08-21, 633 of the 680
+// subject files offered across the three searchable terms hold under 200 rows,
+// so one odd line is already over the rate.
+const MAX_SUBJECT_RESIDUE_RATE = 0.005;
+
+// Measured on 2026-08-21: Summer 2026 is the smallest term at 198 subjects and
+// 4866 sections, Autumn 2026 the largest at 241 and 17692. Both floors sit far
+// under the smallest because they only cover a first snapshot of a term, which
+// has no committed count to be held to.
 const MIN_SUBJECTS = 50;
+const MIN_SECTIONS = 500;
 
 // A chosen ceiling, not a measured failure rate. Under it a subject's sections
 // read as unknown for a day. Over it too much of the term is missing to ship.
@@ -269,6 +287,21 @@ async function mapLimit(items, limit, worker) {
   return out;
 }
 
+// The layout check, one subject file at a time. Kept apart from the fetch so it
+// can be run against parsed files without the network.
+function subjectRefusals(term, results) {
+  return results
+    .filter((r) => r.offered)
+    .map((r) =>
+      subjectResidueRefusal(
+        `term ${term} ${r.subject}`,
+        r.sections.length,
+        r.failures.length,
+        MAX_SUBJECT_RESIDUE_RATE
+      )
+    );
+}
+
 async function snapshotTerm(term, subjects) {
   const started = Date.now();
   // mapLimit runs on Promise.all, so a worker that throws rejects the whole
@@ -355,28 +388,50 @@ async function snapshotTerm(term, subjects) {
     failures,
     fetchErrors,
     parseErrors,
+    refusals: subjectRefusals(term, results),
   };
 }
 
-// The checks a term clears before its file is rewritten. Returned rather than
-// thrown so a bad term does not take the good ones with it.
-function termProblem(stats) {
-  if (stats.sectionsParsed === 0) return 'no sections parsed';
-  if (stats.subjectsOffered < MIN_SUBJECTS) return `only ${stats.subjectsOffered} subjects returned data`;
-  if (stats.subjectsFailed > MAX_SUBJECT_FAILURES) {
-    return `${stats.subjectsFailed} subject requests failed, more than the ${MAX_SUBJECT_FAILURES} allowed`;
-  }
-  // A file that arrived and would not parse is a layout change, not a flake, so
-  // one is enough to hold the term back. This is the threshold the loud throws
-  // in parseSubjectFile rely on, so it does not get a tolerance.
-  if (stats.subjectsUnparsed > 0) return `${stats.subjectsUnparsed} subject files did not parse`;
-  if (stats.residueRate > MAX_TERM_RESIDUE_RATE) {
-    return (
-      `residue rate ${(stats.residueRate * 100).toFixed(2)}% exceeds ` +
-      `${(MAX_TERM_RESIDUE_RATE * 100).toFixed(2)}%, the fixed-width layout probably changed`
-    );
-  }
-  return null;
+// Every reason this term's file is not rewritten, as one message or null.
+// Returned rather than thrown so a bad term does not take the good ones with it,
+// and built out of the shared refusal rules so FORCE_WRITE=1 clears a genuine
+// shrink in this term and nothing else. `refusals` is the per-subject layout
+// check from snapshotTerm, `previous` how many sections the committed file for
+// this term holds.
+function termProblem(stats, { refusals = [], previous = 0, force } = {}) {
+  const label = `term ${stats.term}`;
+  // Nothing parsed is the whole story, and it is what an unpublished term looks
+  // like, so it is said once instead of tripping every count below it.
+  if (stats.sectionsParsed === 0) return refusalMessage([fatal(`${label}: no sections parsed`)], force);
+
+  return refusalMessage(
+    [
+      ...refusals,
+      stats.subjectsOffered < MIN_SUBJECTS
+        ? fatal(`${label}: only ${stats.subjectsOffered} subjects returned data`)
+        : null,
+      stats.subjectsFailed > MAX_SUBJECT_FAILURES
+        ? fatal(
+            `${label}: ${stats.subjectsFailed} subject requests failed, ` +
+              `more than the ${MAX_SUBJECT_FAILURES} allowed`
+          )
+        : null,
+      // A file that arrived and would not parse is a layout change, not a flake,
+      // so one is enough to hold the term back. This is the threshold the loud
+      // throws in parseSubjectFile rely on, so it does not get a tolerance.
+      stats.subjectsUnparsed > 0 ? fatal(`${label}: ${stats.subjectsUnparsed} subject files did not parse`) : null,
+      stats.residueRate > MAX_TERM_RESIDUE_RATE
+        ? fatal(
+            `${label}: residue rate ${(stats.residueRate * 100).toFixed(2)}% exceeds ` +
+              `${(MAX_TERM_RESIDUE_RATE * 100).toFixed(2)}%, the fixed-width layout probably changed`
+          )
+        : null,
+      // A committed term file records sections and not subjects, so only the
+      // sections have a previous count to be held to.
+      countRefusal(`${label} sections`, stats.sectionsParsed, MIN_SECTIONS, previous),
+    ],
+    force
+  );
 }
 
 async function writeAtomic(path, contents) {
@@ -392,6 +447,17 @@ async function writeJson(path, value) {
   const json = `${JSON.stringify(value, null, 0)}\n`;
   await writeAtomic(path, json);
   return Buffer.byteLength(json);
+}
+
+// How many sections the last snapshot of this term committed. Missing means a
+// first snapshot of that term, not an error.
+async function previousSections(term) {
+  try {
+    const snapshot = JSON.parse(await readFile(join(OUT_DIR, `${TERM_PREFIX}${term}.json`), 'utf8'));
+    return Object.keys(snapshot.sections ?? {}).length;
+  } catch {
+    return 0;
+  }
 }
 
 async function readIndex() {
@@ -417,6 +483,17 @@ async function main() {
   const terms = requested.length ? searchable.filter((t) => requested.includes(t)) : searchable;
   if (!terms.length) throw new Error(`none of ${requested.join(', ')} is searchable`);
 
+  const committed = await readIndex();
+
+  // searchableTermsV2 is one uncached call to an API that pages
+  // non-deterministically, and a term missing from that answer has its file
+  // deleted at the end of this run. A named run is held to the same check,
+  // because it decides what to keep from the same list.
+  const termRefusal = refusalMessage([
+    countRefusal('searchable terms', searchable.length, 1, committed?.terms?.length),
+  ]);
+  if (termRefusal) throw new Error(`Refusing to write ${OUT_DIR}.\n${termRefusal}`);
+
   // One subject index covers every term. It lists every code Barrett knows, and
   // a subject not offered in a term 404s, which is normal and not an error.
   const subjects = await fetchSubjects();
@@ -426,7 +503,7 @@ async function main() {
   const skipped = [];
 
   for (const term of terms) {
-    const { snapshot, stats, failures, fetchErrors, parseErrors } = await snapshotTerm(term, subjects);
+    const { snapshot, stats, failures, fetchErrors, parseErrors, refusals } = await snapshotTerm(term, subjects);
 
     console.log(
       `term ${term}: ${stats.subjectsOffered} subjects offered, ` +
@@ -438,11 +515,13 @@ async function main() {
     for (const f of failures.slice(0, 20)) console.log(`  residue ${f}`);
     for (const e of [...fetchErrors, ...parseErrors].slice(0, 20)) console.error(`  ${e}`);
 
-    const problem = termProblem(stats);
+    const problem = termProblem(stats, { refusals, previous: await previousSections(term) });
     if (problem) {
       skipped.push(term);
       const had = await exists(join(OUT_DIR, `${TERM_PREFIX}${term}.json`));
-      console.error(`term ${term}: ${problem}, ${had ? 'keeping the file it already has' : 'no file to keep'}`);
+      // The refusals are one per line, so the note about the old file gets its
+      // own rather than trailing whatever the last reason happened to be.
+      console.error(`${problem}\nterm ${term}: ${had ? 'keeping the file it already has' : 'no file to keep'}`);
       continue;
     }
     // Actions shows this on the run summary, so a term that shipped with
@@ -477,8 +556,7 @@ async function main() {
   // A run for named terms leaves the rest alone, so their index entries carry
   // over. A term that is no longer searchable does not, which is what drops it
   // from the index and then from disk.
-  const previous = await readIndex();
-  for (const entry of previous?.terms ?? []) {
+  for (const entry of committed?.terms ?? []) {
     const term = String(entry?.term ?? '');
     if (!searchable.includes(term)) continue;
     if (entries.some((e) => e.term === term)) continue;
@@ -511,9 +589,17 @@ async function main() {
 }
 
 // Exported so a checker can reuse the parser without refetching, so the retry
-// policy can be exercised without a network, and so the tests can run a term
-// without the writing half.
-export { MAX_SUBJECT_FAILURES, fetchText, parseSubjectFile, snapshotTerm, termProblem };
+// policy can be exercised without a network, and so the tests can run a term,
+// and its write gate, without the writing half.
+export {
+  MAX_SUBJECT_FAILURES,
+  fetchText,
+  parseSubjectFile,
+  previousSections,
+  snapshotTerm,
+  subjectRefusals,
+  termProblem,
+};
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
   main().catch((err) => {

--- a/scripts/guards.mjs
+++ b/scripts/guards.mjs
@@ -1,0 +1,78 @@
+// The refusal rules the three snapshotters share.
+//
+// An absolute floor only catches a total collapse. What actually goes wrong is a
+// partial one: upstream rate limits half a run, the count still clears the floor,
+// and the site quietly loses a third of its rows. So a run is measured against
+// what is already committed, and the floor covers the first run with nothing to
+// compare against.
+
+// The committed history is flat: three ratings snapshots in a row at 7367, and
+// term 1268 went 17680 to 17688 to 17692 sections over the same nights. Nothing
+// has moved down yet, so a tenth is a deliberate guess rather than a tuned
+// number, loose enough that real churn cannot trip it. Only the last committed
+// run is compared against, so a slow bleed of a few percent a night still gets
+// through.
+const MAX_DROP = 0.1;
+
+// FORCE_WRITE=1 is there so a real upstream shrink can be shipped, not so a
+// collapse or a broken parse can be, so only the drop yields to it. `fatal` is
+// exported because a script has checks of its own that belong in the same
+// message and must not yield either.
+const forceable = (reason) => ({ reason, forceable: true });
+export const fatal = (reason) => ({ reason, forceable: false });
+
+// A count against its floor and against the last committed run. `previous` is 0
+// or null on a first run, which leaves only the floor.
+export function countRefusal(label, count, floor, previous) {
+  if (count < floor) {
+    // Naming the committed count matters most here: a term that went to zero
+    // trips the floor, and the floor alone does not say what was lost.
+    const held = previous ? `, and ${previous} is already committed` : '';
+    return fatal(`${label}: got ${count}, the floor is ${floor}${held}`);
+  }
+  if (!previous) return null;
+
+  const allowed = Math.ceil(previous * (1 - MAX_DROP));
+  if (count < allowed) {
+    const drop = ((1 - count / previous) * 100).toFixed(1);
+    return forceable(`${label}: got ${count}, down ${drop}% from the ${previous} already committed, anything under ${allowed} is a collapse`);
+  }
+  return null;
+}
+
+// The share of rows a parser could not read, over a whole run.
+export function residueRefusal(label, parsed, failed, maxRate) {
+  const seen = parsed + failed;
+  if (!seen) return null;
+
+  const rate = failed / seen;
+  if (rate <= maxRate) return null;
+  return fatal(`${label}: ${failed} of ${seen} rows did not parse (${(rate * 100).toFixed(2)}%), over ${(maxRate * 100).toFixed(2)}%`);
+}
+
+// The same for one file rather than the run. A file that read nothing at all has
+// broken. Past that it takes more than one bad row, because most of Barrett's
+// subject files are short enough that one odd line is over any useful rate.
+export function subjectResidueRefusal(label, parsed, failed, maxRate) {
+  if (!failed) return null;
+  if (!parsed) return fatal(`${label}: nothing parsed, all ${failed} rows failed`);
+  if (failed < 2) return null;
+  return residueRefusal(label, parsed, failed, maxRate);
+}
+
+// What to abort with, or null when the run may write.
+export function refusalMessage(refusals, force = process.env.FORCE_WRITE === '1') {
+  const reasons = refusals.filter(Boolean);
+  if (!reasons.length) return null;
+
+  if (force) {
+    for (const r of reasons) if (r.forceable) console.warn(`FORCE_WRITE=1, writing anyway: ${r.reason}`);
+  }
+  const left = force ? reasons.filter((r) => !r.forceable) : reasons;
+  if (!left.length) return null;
+
+  const lines = left.map((r) => r.reason);
+  // Only worth suggesting when it would actually get past everything listed.
+  if (!force && left.every((r) => r.forceable)) lines.push('Set FORCE_WRITE=1 to write this anyway.');
+  return lines.join('\n');
+}

--- a/tests/barrett-mock.mjs
+++ b/tests/barrett-mock.mjs
@@ -34,14 +34,17 @@ const bad = (status, statusText) => ({ ok: false, status, statusText, headers, t
  * Stub globalThis.fetch for one scenario and return a restore function.
  *
  * `published` names the terms Barrett actually serves; the rest 404 the way an
- * unpublished term does. A subject in `failing` 403s, which fetchText treats as
- * fatal, one in `mislabelled` returns a file stamped with the wrong term, and
- * one in `layoutBroken` returns a file with no column header.
+ * unpublished term does, and one in `draft` is served with the pre-publication
+ * banner every subject file of an unpublished term carries. A subject in
+ * `failing` 403s, which fetchText treats as fatal, one in `mislabelled` returns
+ * a file stamped with the wrong term, and one in `layoutBroken` returns a file
+ * with no column header.
  */
 export function install({
   subjects = [],
   searchable = [],
   published = [],
+  draft = [],
   failing = [],
   mislabelled = [],
   layoutBroken = [],
@@ -61,7 +64,7 @@ export function install({
       subject,
       mislabelled.includes(subject) ? "1264" : term,
       rows(subject, sections),
-      layoutBroken.includes(subject) ? { columns: null } : {}
+      { draft: draft.includes(term), ...(layoutBroken.includes(subject) ? { columns: null } : {}) }
     ));
   });
 }

--- a/tests/contract.test.js
+++ b/tests/contract.test.js
@@ -1,0 +1,296 @@
+// What the nightly pipelines are allowed to write, and what the committed files
+// have to look like.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { BARRETT_SUBJECT } from "./fixtures.js";
+import { countRefusal, refusalMessage, residueRefusal, subjectResidueRefusal } from "../scripts/guards.mjs";
+import { previousCount, writeRefusals as ratingsRefusals } from "../scripts/fetch-ratings.mjs";
+import { previousCounts, previousIndex, writeRefusals as coursesRefusals } from "../scripts/fetch-courses.mjs";
+import { parseSubjectFile, previousSections, subjectRefusals, termProblem } from "../scripts/fetch-seats.mjs";
+
+const DATA = join(dirname(dirname(fileURLToPath(import.meta.url))), "data");
+const read = async (name) => JSON.parse(await readFile(join(DATA, name), "utf8"));
+const MISSING = join(DATA, "no-such-file.json");
+
+// force is passed explicitly so a FORCE_WRITE=1 left in a shell cannot change
+// what any of these see.
+const say = (refusals) => refusalMessage(refusals, false);
+
+// One subject file as snapshotTerm sees it once it is parsed.
+const parsed = (subject, sections, failures) => ({
+  subject,
+  offered: true,
+  sections: Array(sections).fill(null),
+  failures: Array(failures).fill("unreadable row"),
+});
+
+// One term as snapshotTerm reports it, healthy unless a field here says
+// otherwise.
+const termStats = (term, extra) => ({
+  term,
+  subjectsOffered: 200,
+  subjectsFailed: 0,
+  subjectsUnparsed: 0,
+  sectionsParsed: 17692,
+  residueRate: 0,
+  ...extra,
+});
+
+// Key order is part of the deal, not just the key set: the scripts rely on
+// insertion order to come out byte-identical when nothing upstream changed. A
+// field one of the pipelines has learned to write since the snapshots were last
+// committed goes in `optional`, so teaching it one is a line here rather than a
+// red main the night after.
+function assertKeys(value, required, optional, what) {
+  const keys = Object.keys(value);
+  assert.deepEqual(keys.filter((k) => required.includes(k)), required, `${what} is missing a key or reordered one`);
+  const known = new Set([...required, ...optional]);
+  assert.deepEqual(keys.filter((k) => !known.has(k)), [], `${what} has a key nothing expects`);
+}
+
+const PROFESSOR_KEYS = [
+  "legacyId",
+  "firstName",
+  "lastName",
+  "department",
+  "avgRating",
+  "numRatings",
+  "avgDifficulty",
+  "wouldTakeAgainPercent",
+];
+// Allowed ahead of #69, which writes the rating distribution as a ninth key.
+const PROFESSOR_OPTIONAL = ["distribution"];
+
+const SNAPSHOT_KEYS = ["term", "termName", "sourceUpdated", "sections"];
+// Allowed ahead of #67, which writes the auto-enroll link groups as a fifth.
+const SNAPSHOT_OPTIONAL = ["groups"];
+
+test("ratings.json keeps its shape", async () => {
+  const ratings = await read("ratings.json");
+  assert.deepEqual(Object.keys(ratings), ["school", "count", "professors"]);
+  assert.deepEqual(Object.keys(ratings.school), ["id", "legacyId", "name"]);
+  assert.ok(ratings.professors.length > 0);
+  assert.equal(ratings.count, ratings.professors.length);
+
+  for (const p of ratings.professors) {
+    assertKeys(p, PROFESSOR_KEYS, PROFESSOR_OPTIONAL, `professor ${p.legacyId}`);
+    assert.equal(typeof p.legacyId, "number");
+    assert.ok(p.numRatings > 0, `${p.legacyId} is unrated and should have been dropped`);
+    // Upstream says -1 for "no data" on these three, which would render as a score.
+    for (const key of ["avgRating", "avgDifficulty", "wouldTakeAgainPercent"]) {
+      const value = p[key];
+      assert.ok(value === null || value >= 0, `${p.legacyId} has ${key} ${value}`);
+    }
+  }
+});
+
+test("courses.json keeps its shape", async () => {
+  const courses = await read("courses.json");
+  assert.deepEqual(Object.keys(courses), ["source", "fields", "note", "terms"]);
+  assert.deepEqual(courses.fields, ["catalogNumber", "title", "minUnits", "maxUnits"]);
+  assert.ok(Object.keys(courses.terms).length > 0);
+
+  for (const [strm, term] of Object.entries(courses.terms)) {
+    assert.match(strm, /^\d{4}$/);
+    assert.deepEqual(Object.keys(term), ["term", "name", "subjects"]);
+    assert.equal(term.term, strm);
+    assert.ok(term.subjects.length > 0);
+
+    for (const subject of term.subjects) {
+      assert.deepEqual(Object.keys(subject), ["code", "name", "courses"]);
+      assert.ok(subject.courses.length > 0, `${strm} ${subject.code} is in the index with no courses`);
+      for (const [catalog, title, minUnits, maxUnits] of subject.courses) {
+        assert.ok(catalog, `${strm} ${subject.code} has a course with no catalog number`);
+        assert.equal(typeof title, "string");
+        assert.equal(typeof minUnits, "number");
+        assert.equal(typeof maxUnits, "number");
+      }
+    }
+  }
+});
+
+test("seats.json and the term files it lists agree", async () => {
+  const index = await read("seats.json");
+  assert.deepEqual(Object.keys(index), ["source", "fields", "note", "terms"]);
+  assert.deepEqual(index.fields, ["enrolled", "limit", "waitlist"]);
+  assert.ok(index.terms.length > 0);
+
+  for (const entry of index.terms) {
+    assert.deepEqual(Object.keys(entry), ["term", "termName", "sourceUpdated", "sections", "file"]);
+    assert.equal(entry.file, `seats-${entry.term}.json`);
+    assert.match(entry.sourceUpdated, /^\d{4}-\d{2}-\d{2}$/);
+
+    const snapshot = await read(entry.file);
+    assertKeys(snapshot, SNAPSHOT_KEYS, SNAPSHOT_OPTIONAL, entry.file);
+    assert.equal(snapshot.term, entry.term);
+
+    const rows = Object.entries(snapshot.sections);
+    assert.equal(rows.length, entry.sections, `${entry.file} does not hold what the index says`);
+    for (const [classNumber, row] of rows) {
+      assert.match(classNumber, /^\d+$/);
+      assert.equal(row.length, 3, `${entry.file} ${classNumber} is not enrolled/limit/waitlist`);
+      for (const value of row) assert.equal(typeof value, "number");
+    }
+  }
+});
+
+test("a first run has only the floor to clear", () => {
+  assert.equal(countRefusal("rated professors", 5001, 5000, 0), null);
+  assert.ok(countRefusal("rated professors", 4999, 5000, 0));
+});
+
+// Regression, #59. The floors were the whole check, so a run that lost a third
+// of the roster or four fifths of a term wrote itself over the good file.
+test("regression #59: a collapse against the committed file is refused", () => {
+  const roster = countRefusal("rated professors", 5001, 5000, 7367);
+  assert.match(roster.reason, /5001/);
+  assert.match(roster.reason, /7367/);
+  assert.ok(countRefusal("term 1268 courses", 1201, 1200, 6072));
+  assert.ok(countRefusal("term 1268 subjects", 100, 100, 243));
+});
+
+test("ordinary drift and growth still write", () => {
+  assert.equal(countRefusal("term 1268 courses", 6000, 1200, 6072), null);
+  assert.equal(countRefusal("term 1268 courses", 6500, 1200, 6072), null);
+  // The line itself: a tenth under the last run writes, a hair further does not.
+  assert.equal(countRefusal("sections", 900, 500, 1000), null);
+  assert.ok(countRefusal("sections", 899, 500, 1000));
+});
+
+// Regression, #59. The rate used to be measured once over every subject of every
+// term, so a small file could fail wholesale and vanish under the total. Those
+// sections then render as "No seat data for this section.", the sentence Finder
+// uses for a section Barrett genuinely does not carry.
+test("regression #59: a subject file that fails wholesale is refused", () => {
+  const published = parseSubjectFile("AVIATN", "1268", BARRETT_SUBJECT);
+  assert.equal(published.sections.length, 3);
+  assert.equal(published.failures.length, 0);
+  assert.equal(subjectResidueRefusal("term 1268 AVIATN", 3, 0, 0.005), null);
+
+  // What a fixed-width layout change looks like: every field one column over.
+  const shifted = BARRETT_SUBJECT.split("\n")
+    .map((line, i) => (i > 3 && line.trim() ? ` ${line}` : line))
+    .join("\n");
+  const broken = parseSubjectFile("AVIATN", "1268", shifted);
+  assert.equal(broken.sections.length, 0);
+  assert.equal(broken.failures.length, 3);
+
+  assert.ok(subjectResidueRefusal("term 1268 AVIATN", 0, 3, 0.005));
+  // The same three failures against the term they sit in, which is all the old
+  // rule ever measured.
+  assert.equal(residueRefusal("term 1268", 17692, 3, 0.005), null);
+});
+
+// 633 of the 680 subject files Barrett offered on 2026-08-21 hold under 200
+// rows, so a plain rate per file would fail the whole night on one odd line.
+test("one unreadable line in a short subject file is not a layout change", () => {
+  assert.equal(subjectResidueRefusal("term 1268 AEROENG", 73, 1, 0.005), null);
+  assert.ok(subjectResidueRefusal("term 1268 AEROENG", 72, 2, 0.005));
+  assert.ok(subjectResidueRefusal("term 1268 ENVSCI", 0, 1, 0.005));
+});
+
+// Regression, #59. The rules only matter if the scripts hold a run to the file
+// that is really committed, so these three drive each script's own gate.
+test("regression #59: the ratings gate reads the committed roster", async () => {
+  const committed = (await read("ratings.json")).professors.length;
+  assert.equal(await previousCount(), committed);
+  assert.equal(await previousCount(MISSING), 0);
+
+  const refusal = say(await ratingsRefusals(Math.floor(committed * 0.7)));
+  assert.match(refusal, new RegExp(String(committed)));
+  assert.match(refusal, /FORCE_WRITE=1/);
+  assert.equal(say(await ratingsRefusals(committed)), null);
+});
+
+test("regression #59: the courses gate reads the committed index", async () => {
+  const committed = await read("courses.json");
+  const counts = previousCounts(await previousIndex());
+  for (const [strm, term] of Object.entries(committed.terms)) {
+    assert.deepEqual(counts[strm], {
+      subjects: term.subjects.length,
+      courses: term.subjects.reduce((n, s) => n + s.courses.length, 0),
+    });
+  }
+  assert.deepEqual(previousCounts(await previousIndex(MISSING)), {});
+
+  const [strm, before] = Object.entries(counts)[0];
+  const refusal = say(coursesRefusals(strm, before.subjects, Math.floor(before.courses * 0.5), before));
+  assert.match(refusal, new RegExp(String(before.courses)));
+  assert.equal(say(coursesRefusals(strm, before.subjects, before.courses, before)), null);
+});
+
+test("regression #59: the seats gate reads the committed term file", async () => {
+  const entry = (await read("seats.json")).terms[0];
+  assert.equal(await previousSections(entry.term), entry.sections);
+  assert.equal(await previousSections("9999"), 0);
+
+  const previous = entry.sections;
+  const stats = termStats(entry.term, { sectionsParsed: previous });
+  assert.equal(termProblem(stats, { previous, force: false }), null);
+
+  const short = termStats(entry.term, { sectionsParsed: Math.floor(previous * 0.7) });
+  assert.match(termProblem(short, { previous, force: false }), new RegExp(String(previous)));
+  // FORCE_WRITE=1 clears this term's shrink and says nothing about any other
+  // term, since each one is now held to its own committed count.
+  assert.equal(termProblem(short, { previous, force: true }), null);
+});
+
+// Regression, #59. The per-subject check has to reach the term gate, or a file
+// that failed wholesale is still only a rounding error against its term.
+test("regression #59: one broken subject file refuses its whole term", async () => {
+  const entry = (await read("seats.json")).terms[0];
+  const clean = [parsed("AEROENG", 120, 0), { subject: "ZOOLOGY", offered: false }];
+  assert.deepEqual(subjectRefusals(entry.term, clean).filter(Boolean), []);
+
+  const refusals = subjectRefusals(entry.term, [...clean, parsed("AVIATN", 0, 3)]).filter(Boolean);
+  assert.equal(refusals.length, 1);
+  assert.match(refusals[0].reason, /AVIATN/);
+
+  // The same three failures against the term they sit in, which is all the term
+  // gate on its own ever measured.
+  const previous = entry.sections;
+  const stats = termStats(entry.term, { sectionsParsed: previous, residueRate: 3 / (previous + 3) });
+  assert.equal(termProblem(stats, { previous, force: false }), null);
+  assert.match(termProblem(stats, { refusals, previous, force: false }), /AVIATN/);
+});
+
+test("nothing to refuse means nothing to say", () => {
+  assert.equal(say([]), null);
+  assert.equal(say([null, null]), null);
+});
+
+test("a refusal names every reason and the way past it", () => {
+  const message = say([null, countRefusal("sections", 800, 500, 1000), countRefusal("courses", 1000, 500, 1200)]);
+  assert.match(message, /sections/);
+  assert.match(message, /courses/);
+  assert.match(message, /FORCE_WRITE=1/);
+});
+
+test("a floor refusal says what is committed and offers no way past", () => {
+  const message = say([countRefusal("term 1268 sections", 0, 500, 17692)]);
+  assert.match(message, /17692/);
+  assert.doesNotMatch(message, /FORCE_WRITE/);
+});
+
+test("FORCE_WRITE=1 clears a shrink but not a broken parse", () => {
+  const shrink = countRefusal("rated professors", 5001, 5000, 7367);
+  const layout = subjectResidueRefusal("term 1268 AVIATN", 0, 3, 0.005);
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (line) => warnings.push(line);
+  try {
+    assert.equal(refusalMessage([shrink], true), null);
+    const left = refusalMessage([shrink, layout], true);
+    assert.match(left, /AVIATN/);
+    assert.doesNotMatch(left, /rated professors/);
+  } finally {
+    console.warn = original;
+  }
+  assert.equal(warnings.length, 2);
+  for (const line of warnings) assert.match(line, /FORCE_WRITE=1/);
+});

--- a/tests/fetch-seats-run.test.js
+++ b/tests/fetch-seats-run.test.js
@@ -10,8 +10,10 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const SCRIPT = join(ROOT, "scripts", "fetch-seats.mjs");
 const MOCK = pathToFileURL(join(ROOT, "tests", "barrett-mock.mjs")).href;
 
-// MIN_SUBJECTS is 50, so a term needs at least that many to clear its checks.
+// MIN_SUBJECTS is 50 and MIN_SECTIONS is 500, so a term needs at least that
+// many subjects, and enough sections between them, to clear its checks.
 const SUBJECTS = Array.from({ length: 50 }, (_, i) => `SUBJ${String(i).padStart(2, "0")}`);
+const SECTIONS_PER_SUBJECT = 12;
 
 function run(outDir, scenario) {
   return spawnSync(process.execPath, ["--import", MOCK, SCRIPT], {
@@ -40,12 +42,23 @@ test("regression #93: a skipped term keeps its file while the rest are written",
     });
     const before = read(dir, "seats-1272.json");
 
-    const r = run(dir, { subjects: SUBJECTS, searchable: ["1268", "1272"], published: ["1268"] });
+    const r = run(dir, {
+      subjects: SUBJECTS,
+      searchable: ["1268", "1272"],
+      published: ["1268"],
+      sections: SECTIONS_PER_SUBJECT,
+    });
 
     assert.equal(r.status, 1, `the run still goes red\n${r.stderr}`);
-    assert.match(r.stderr, /term 1272: no sections parsed, keeping the file it already has/);
+    // A term can be held back for several reasons at once, so the reasons and
+    // the note about its old file are separate lines.
+    assert.match(r.stderr, /term 1272: no sections parsed/);
+    assert.match(r.stderr, /term 1272: keeping the file it already has/);
     assert.equal(read(dir, "seats-1272.json"), before, "the skipped term's file is untouched");
-    assert.equal(Object.keys(JSON.parse(read(dir, "seats-1268.json")).sections).length, 200);
+    assert.equal(
+      Object.keys(JSON.parse(read(dir, "seats-1268.json")).sections).length,
+      SUBJECTS.length * SECTIONS_PER_SUBJECT
+    );
 
     const index = JSON.parse(read(dir, "seats.json"));
     assert.deepEqual(index.terms.map((t) => t.term), ["1268", "1272"]);

--- a/tests/fetch-seats.test.js
+++ b/tests/fetch-seats.test.js
@@ -101,6 +101,7 @@ describe("what holds a term back", () => {
   const SUBJECTS = Array.from({ length: 12 }, (_, i) => `SUBJ${String(i).padStart(2, "0")}`);
 
   const termStats = (extra) => ({
+    term: "1268",
     subjectsOffered: 241,
     subjectsFailed: 0,
     subjectsUnparsed: 0,
@@ -165,7 +166,7 @@ describe("what holds a term back", () => {
   });
 
   test("regression #93: a term that parsed nothing is reported, not thrown", () => {
-    assert.equal(termProblem(termStats({ subjectsOffered: 0, sectionsParsed: 0 })), "no sections parsed");
+    assert.equal(termProblem(termStats({ subjectsOffered: 0, sectionsParsed: 0 })), "term 1268: no sections parsed");
     assert.equal(termProblem(termStats({})), null, "a healthy term has no problem to report");
   });
 
@@ -175,6 +176,26 @@ describe("what holds a term back", () => {
       termProblem(termStats({ subjectsFailed: MAX_SUBJECT_FAILURES + 1 })),
       /subject requests failed/
     );
+  });
+
+  // Regression, #59 with #91. Every subject file of a term Barrett has not
+  // published yet carries the DRAFT banner. While that banner counted as a row
+  // the parser could not read it was one failure in every file, and #59 holds a
+  // term back on its residue, so the term refused the day it became searchable.
+  test("regression #59: a DRAFT term leaves nothing for the residue gate", async () => {
+    const restore = install({ subjects: SUBJECTS, published: ["1272"], draft: ["1272"] });
+    try {
+      const { stats, refusals } = await snapshotTerm("1272", SUBJECTS);
+      assert.equal(stats.residueFailures, 0, "the banner is not a row that failed to parse");
+      assert.deepEqual(refusals.filter(Boolean), [], "and no subject file is over the per-file rate");
+      assert.equal(termProblem(termStats({ term: "1272", residueRate: stats.residueRate })), null);
+
+      // One banner line per subject file is what the term gate used to be shown.
+      const noise = SUBJECTS.length / (stats.sectionsParsed + SUBJECTS.length);
+      assert.match(termProblem(termStats({ term: "1272", residueRate: noise })), /residue rate/);
+    } finally {
+      restore();
+    }
   });
 
   test("the subject floor and the layout check still stop a term", () => {

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -131,6 +131,21 @@ export const BARRETT_COLUMNS =
 export const BARRETT_BANNER =
   "#####  DRAFT: pre-publication information; classes shown here are subject to change #####";
 
+// One Barrett subject file, three real AVIATN section lines from term 1268 as
+// published on 2026-08-20. The columns are load bearing, so this is verbatim.
+export const BARRETT_SUBJECT = [
+  "AVIATN         1268 (Autumn 2026)         updated: 20-Aug-2026",
+  "",
+  "                       class#    (autoenrolls)                                enrld/limit/+wait",
+  "",
+  "  AVIATN 1000.01         10132 B                                      ONLINE      36/99       {7W2} C.Roby, S.Pritchard",
+  "",
+  "  AVIATN 1000.02         10133 B                                      ONLINE      20/99       {7W2} C.Roby, S.Pritchard (SI)",
+  "",
+  "  AVIATN 1000.03         10134 B                                      ONLINE      11/99       {7W2} C.Roby, S.Pritchard (SI)",
+  "",
+].join("\n");
+
 const BARRETT_DAY_COLUMNS = { M: 49, T: 50, W: 51, R: 52, F: 53, S: 54, s: 55 };
 
 /** One section line. Anything left out stays blank, as it does in a real file. */


### PR DESCRIPTION
Closes #59

Two things were wrong. The floors in the three snapshotters were absolute and nothing ever read what was already committed, so any count between the floor and reality overwrote a good file. And the seats residue rate was one number taken over every subject of every term, so a small subject file could fail every row it has, disappear under the total, and leave its sections rendering as an honestly absent seat count.

Runs below are the real scripts against the real sources, driven on a copy of `scripts/` and `data/` outside the worktree so nothing here wrote to `data/`. `stub-seats.mjs` is a preload that passes every Barrett request through untouched except one subject file, whose columns it shifts one place right. `stub-ratings.mjs` stands in for RateMyProfessors so a short roster can be asked for on purpose.

## The silent case

SWAHILI has 3 sections in term 1268. Shifting its file one column, which is what a fixed-width layout change looks like, fails all 3 rows. That is 0.02% of the term, so the old rate let it through:

```
$ STUB_SUBJECT=SWAHILI node --import ./stub-seats.mjs scripts/fetch-seats.mjs 1268   # on main
term 1268: 241 subjects offered, 17689 sections, 3 residue failures, 1076 continuation rows, 0 collisions, 12.3s
wrote data/seats-1268.json (305200 bytes, 298.0 KiB)
wrote data/seats.json (639 bytes)

committed 17692 -> written 17689
  lost class 20981 [6,24,0]
  lost class 21445 [4,24,0]
  lost class 23344 [14,20,0]
```

Those three class numbers then hit `js/detail.js:129` and print "No seat data for this section.", the same sentence Finder shows for a section Barrett genuinely does not carry. On this branch:

```
$ STUB_SUBJECT=SWAHILI node --import ./stub-seats.mjs scripts/fetch-seats.mjs 1268   # this branch
term 1268: 241 subjects offered, 17689 sections, 3 residue failures, 1076 continuation rows, 0 collisions, 12.7s
Refusing to write data.
term 1268 SWAHILI: nothing parsed, all 3 rows failed
exit 1
data/seats-1268.json still holds 17692
```

The rate is now checked per subject file as well as per term. It takes two bad lines rather than one, because 633 of the 680 subject files Barrett offered across the three searchable terms on 2026-08-21 hold under 200 rows, so a plain rate per file would fail the whole night on a single odd line. A file that parsed nothing at all is refused however few rows it had.

An ordinary run is unaffected. Term 1268 on this branch: 241 subjects, 17692 sections, 0 residue failures, and the file it writes matches the committed one class number for class number and seat row for seat row.

## A run that comes back a third short

The issue's headline number, 5001 rated professors against the 7367 committed:

```
$ node --import ./stub-ratings.mjs scripts/fetch-ratings.mjs   # on main
fetched 5001 of 7500, 5001 of them rated
Wrote 5001 professors to data\ratings.json (1118155 bytes)
data/ratings.json now holds 5001

$ node --import ./stub-ratings.mjs scripts/fetch-ratings.mjs   # this branch
fetched 5001 of 7500, 5001 of them rated
Refusing to write data\ratings.json. Upstream reported resultCount 7500.
rated professors: got 5001, down 32.1% from the 7367 already committed, anything under 6631 is a collapse
Set FORCE_WRITE=1 to write this anyway.
exit 1
data/ratings.json still holds 7367
```

Every count now goes through `scripts/guards.mjs`, which holds a run to the count committed for that term and refuses a drop of more than a tenth. The old absolute floors stay as the backstop for a first run, which has nothing to compare against. The committed history is what sized the tenth: three ratings snapshots in a row at 7367, and term 1268 going 17680 to 17688 to 17692 sections over the same nights. Nothing has moved down yet, so a tenth is deliberately loose rather than tuned.

## The term list

Every guard above is per term, which left the largest way to gut the file alone. The term list is one uncached call to `searchableTermsV2`, on the same API `docs/osu-api.md` documents as non-deterministic. An answer naming one of the three terms made `fetch-courses` write a `courses.json` holding only 1264, dropping 12235 committed courses, and made `fetch-seats` delete `seats-1262.json` and `seats-1264.json`. Both exited 0. Now:

```
$ node --import ./stub-terms.mjs scripts/fetch-seats.mjs
Refusing to write data.
searchable terms: got 1, down 66.7% from the 3 already committed, anything under 3 is a collapse
Set FORCE_WRITE=1 to write this anyway.
exit 1
data/seats-1262.json data/seats-1264.json data/seats-1268.json

$ node --import ./stub-terms.mjs scripts/fetch-courses.mjs
Refusing to write data\courses.json.
searchable terms: got 1, down 66.7% from the 3 already committed, anything under 3 is a collapse
exit 1
```

A named run of `fetch-courses` stays exempt, because rewriting the file around the terms you named is what that mode is for. A named run of `fetch-seats` is not exempt, because that mode is documented to leave the other terms alone and it decides what to keep from the same list.

## The escape hatch

`FORCE_WRITE=1` clears a count that came back short, and nothing else:

```
$ FORCE_WRITE=1 node --import ./stub-ratings.mjs scripts/fetch-ratings.mjs
FORCE_WRITE=1, writing anyway: rated professors: got 5001, down 32.1% from the 7367 already committed, anything under 6631 is a collapse
Wrote 5001 professors to data\ratings.json (1118155 bytes)

$ FORCE_WRITE=1 STUB_SUBJECT=SWAHILI node --import ./stub-seats.mjs scripts/fetch-seats.mjs 1268
term 1268 SWAHILI: nothing parsed, all 3 rows failed
exit 1
data/seats-1268.json still holds 17692
```

A shrink is something a human can decide is real. A file that would not parse is not, and neither is a floor, so those refuse either way and the message does not offer the hatch when it would not help. The three workflows get a `force` dispatch input, otherwise the hatch is unreachable from the Actions UI and a real shrink means editing a workflow on main.

## Tests

154 pass, 138 of which were already on main. `tests/contract.test.js` is the new file. It pins the shape and key order of every committed data file, and drives each script's own gate against those same files rather than only the rules in isolation.

Confirmed to fail without the fix, each knockout applied to a copy outside the worktree:

```
reverted                                     node --test tests/contract.test.js
------------------------------------------   ---------------------------------
all three scripts back to main               contract.test.js will not load
only the wiring, guards and exports kept     not ok 9, 10, 11, 12
the drop rule, leaving the floors            not ok 5, 6, 9, 10, 11, 14, 16
the per-file residue rule                    not ok 8
the FORCE_WRITE split                        not ok 16
```

The second row is the one worth pointing at. Reverting the three call sites to floors, while leaving `guards.mjs` and every export in place, is the whole fix removed with nothing else disturbed.

## Deliberately not done

- The comparison is against the last committed run only, so a sustained partial failure of a few percent a night still ratchets down. `scripts/guards.mjs` says so rather than implying a collapse cannot get through. Raising the floors near the counts they already record would close it and is a bigger call than this issue.
- `MIN_SECTIONS = 500` in `fetch-seats.mjs` replaces a bare "zero sections parsed" throw, so a first snapshot of a term with fewer than 500 sections would now refuse and could not be forced. Every searchable term measured today is 4866 or larger, and the existing `MIN_SUBJECTS = 50` already refuses that shape.
- No `data/*.json` and no `js/` file is touched, so nothing changed for the browser.
